### PR TITLE
WIP: Port std.lang to bb.lang for Babashka compatibility

### DIFF
--- a/TODO_BBLANG.md
+++ b/TODO_BBLANG.md
@@ -1,0 +1,24 @@
+# Babashka Port for std.lang
+
+## Overview
+The goal is to provide a `bb.lang` namespace that contains the core logic of `std.lang` without the heavy Java interop and `std.lib` custom metaprogramming, allowing it to run within Babashka. We have started duplicating `std.lang` logic into `src/bb/lang/` and its required helper namespaces into `src/bb/lib/` and `src/bb/string/`.
+
+## Remaining Work
+
+1. **Untangle `definvoke` usage**
+   `std.lib.invoke` heavily utilizes macros and Java interoperability (e.g. creating records that implement `clojure.lang.IFn`). Babashka does not support this.
+   - We must go through all `bb.*` files and replace `(definvoke my-func ...)` with standard `(defn ...)` or native `(clojure.core/memoize ...)`.
+   - `path-separator` in `bb.string.coerce` has already been converted. Look out for others across `bb.lang.base.*`.
+
+2. **Clean up `bb.lib` and `bb.string`**
+   - Several `bb.lib.*` files (like `bb.lib.memoize` and `bb.lib.impl`) still contain code intended to compile JVM byte-code or interact with deeply embedded `std.lib` concepts. These need to be rewritten to their simplest possible Babashka-compatible Clojure forms.
+   - Replace complex record-based implementations (like `Memoize`) with simpler atoms or native functions.
+   - Fix unresolved symbols and missing methods that stem from stripping Java imports out (like missing `StringBuffer` which needs to be replaced with `StringBuilder`).
+
+3. **Get `bb.lang.base.emit` compiling**
+   - Run `bb -cp src -e "(require 'bb.lang)"` iteratively. This will surface `definvoke` or `defrecord` errors one-by-one.
+   - Once `bb.lang` loads cleanly in Babashka, test its fundamental execution capabilities.
+
+4. **Tests**
+   - We have not copied `test/std/lang` to `test/bb/lang` yet. Once the source compiles in Babashka, copy the test directories.
+   - Refactor tests to utilize `clojure.test` since the custom `code.test` framework (`fact`, `=>`) relies on the full `std.lib` stack and macro ecosystem which will likely not compile in Babashka.

--- a/bb_compat.clj
+++ b/bb_compat.clj
@@ -1,0 +1,12 @@
+(ns bb-compat)
+
+(defmacro if-bb
+  [then else]
+  (if (System/getProperty "babashka.version")
+    then
+    else))
+
+(defmacro if-clj
+  [form]
+  (if-not (System/getProperty "babashka.version")
+    form))

--- a/src/bb/lang.clj
+++ b/src/bb/lang.clj
@@ -1,0 +1,243 @@
+(ns bb.lang
+  (:require [bb.lang.base.pointer :as ptr]
+            [bb.lang.base.compile :as compile]
+            [bb.lang.base.impl-lifecycle :as lifecycle]
+            [bb.lang.base.impl-entry :as entry]
+            [bb.lang.base.impl :as impl]
+            [bb.lang.base.library :as lib]
+            [bb.lang.base.manage :as manage]
+            [bb.lang.base.registry :as registry]
+            [bb.lang.base.runtime :as runtime]
+            [bb.lang.base.emit :as emit]
+            [bb.lang.base.emit-preprocess :as preprocess]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.emit-helper :as helper]
+            [bb.lang.base.util :as ut]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.script-def :as script-def]
+            [bb.lang.base.script-control :as script-control]
+            [bb.lang.base.script-lint :as lint]
+            [bb.lang.base.script-annex :as annex]
+            [bb.lang.base.script-macro :as macro]
+            [bb.lang.base.script :as script]
+            [bb.lang.base.workspace :as workspace]
+            [bb.lang.interface.type-notify :as notify]
+            [bb.lang.model.spec-c]
+            [bb.lang.model.spec-bash]
+            [bb.lang.model.spec-glsl]
+            [bb.lang.model.spec-js]
+            [bb.lang.model.spec-lua]
+            [bb.lang.model.spec-python]
+            [bb.lang.model.spec-perl]
+            [bb.lang.model.spec-php]
+            [bb.lang.model.spec-r]
+            [bb.lang.model.spec-ruby]
+            [bb.lang.model.spec-rust]
+            [bb.lang.model.spec-xtalk]
+            [bb.lang.interface.type-shared :as shared]
+            [std.lib :as h])
+  (:refer-clojure :exclude [test]))
+
+(h/intern-in
+ ut/sym-full
+ ut/sym-id
+ ut/sym-module
+ ut/sym-pair
+ ut/sym-default-str
+ [ptr ut/lang-pointer]
+
+ common/with:explode
+ common/with-trace
+ emit/with:emit
+ [emit* emit/emit-main]
+ helper/basic-typed-args
+ helper/emit-type-record
+
+ preprocess/macro-form
+ preprocess/macro-opts
+ preprocess/macro-grammar
+ preprocess/with:macro-opts
+
+ impl/emit-script
+ impl/emit-str
+ impl/emit-as
+ impl/emit-symbol
+ entry/emit-entry
+ impl/emit-entry-deps
+
+ impl/default-library
+ impl/default-library:reset
+ impl/runtime-library
+ impl/with:library
+ impl/grammar
+
+ notify/default-notify
+ notify/default-notify:reset
+ [notify-get   notify/get-sink]
+ [notify-clear notify/clear-sink]
+ [notify-add-listener    notify/add-listener]
+ [notify-remove-listener notify/remove-listener]
+
+ ptr/with:print
+ ptr/with:print-all
+ ptr/with:clip
+ ptr/with:input
+ ptr/with:raw
+ ptr/with:rt
+ ptr/with:rt-wrap
+ [rt:macro-opts ptr/rt-macro-opts]
+
+ entry/with:cache-none
+ entry/with:cache-force
+
+ script/script
+ script/script-
+ script/script+
+
+ script/!
+ #_#_
+ script/!.async
+ script/!.run
+ macro/defmacro.!
+
+ annex/annex-current
+ annex/annex-reset
+ script/annex:get
+ script/annex:start
+ script/annex:stop
+ script/annex:restart-all
+ script/annex:start-all
+ script/annex:stop-all
+ script/annex:list
+ script-def/tmpl-entry
+ script-def/tmpl-macro
+
+ lib/get-book-raw
+ lib/get-book
+ lib/get-module
+ lib/get-snapshot
+ lib/delete-module!
+ lib/delete-modules!
+ lib/delete-entry!
+ lib/purge-book!
+
+ lint/lint-set
+ lint/lint-clear
+
+ [rt ut/lang-rt]
+ [rt:list ut/lang-rt-list]
+ [rt:default ut/lang-rt-default]
+ [rt:restart script-control/script-rt-restart]
+ [rt:stop script-control/script-rt-stop]
+
+ workspace/sym-entry
+ workspace/module-entries
+ workspace/emit-ptr
+ workspace/emit-module
+ workspace/print-module
+
+ workspace/ptr-clip
+ workspace/ptr-display-str
+ workspace/ptr-print
+ workspace/ptr-setup
+ workspace/ptr-teardown
+ workspace/ptr-setup-deps
+ workspace/ptr-teardown-deps
+ workspace/rt:module
+ workspace/rt:module-meta
+ workspace/rt:module-purge
+ workspace/rt:inner
+ workspace/rt:restart
+ workspace/rt:setup
+ workspace/rt:setup-to
+ workspace/rt:setup-single
+ workspace/rt:scaffold
+ workspace/rt:scaffold-to
+ workspace/rt:scaffold-imports
+ workspace/rt:teardown
+ workspace/rt:teardown-at
+ workspace/rt:teardown-single
+ workspace/rt:teardown-to
+ workspace/intern-macros
+
+ [lib:overview manage/lib-overview]
+ [lib:module   manage/lib-module-overview]
+ [lib:entries  manage/lib-module-entries]
+ [lib:purge    manage/lib-module-purge]
+ [lib:unused   manage/lib-module-unused])
+
+(defn rt:space
+  "will return space if not found (no default space)"
+  {:added "4.0"}
+  [lang & [namespace]]
+  (std.lib.context.space/space:rt-get
+   (std.lib.context.space/space (or namespace *ns*))
+   (ut/lang-context lang)))
+
+(defn get-entry
+  "gets the entry if pointer"
+  {:added "4.0"}
+  [m]
+  (if (book/book-entry? m)
+    m
+    (ptr/get-entry m)))
+
+(defn as-lua
+  "change `[]` to `{}`"
+  {:added "4.0"}
+  [input]
+  (h/prewalk (fn [form]
+               (if (and (vector? form)
+                        (empty? form))
+                 {}
+                 form))
+             input))
+
+(defn rt:invoke
+  "invokes code in the given namespace"
+  {:added "4.0"}
+  [ns lang code]
+  (h/p:rt-invoke-ptr
+   (ut/lang-rt ns lang)
+   (ptr lang {:module ns})
+   code))
+
+(defn force-reload
+  "forces reloading of all dependent namespaces"
+  {:added "4.0"}
+  ([ns lang]
+   (doseq [ns (h/deps:ordered (get-book (default-library)
+                                        lang)
+                             [ns])]
+     (lib:purge ns)
+     (eval (list 'jvm.namespace/clear ns))
+     (require ns :reload)
+     (h/p :RELOADED ns))))
+
+
+(comment
+
+  (lib:module '[statsdb])
+  (lib:entries '[statsdb])
+  (lib:purge '[lua])
+  (./reset '[lua])
+  (do (./reset '[statsdb])
+      (delete-modules!
+       (default-library)
+       :postgres
+       (->> (:modules (get-book (default-library)
+                                  :postgres
+                                  ))
+            (keys)
+            (filter (fn [n]
+                      (std.string/starts-with? (str n) "stats")))))
+      (require ['statsdb.core.execute])
+      (std.make/build play.tui-counter-basic.main/PROJECT
+                      :statsdb))
+
+  (emit-as
+   :js '[(if (->> a b c)
+           a b)])
+
+  (get (:reserved (grammar :xtalk))
+       '->>))

--- a/src/bb/lang/base/book.clj
+++ b/src/bb/lang/base/book.clj
@@ -1,0 +1,403 @@
+(ns bb.lang.base.book
+  (:require [std.protocol.deps :as protocol.deps]
+            [bb.lang.base.book-module :as module]
+            [bb.lang.base.book-entry :as entry]
+            [bb.lang.base.book-meta :as meta]
+            [bb.lang.base.util :as ut]
+            [bb.lang.base.emit-preprocess :as preprocess]
+            [bb.string :as str]
+            [bb.lib.atom :as atom]
+            [bb.lib :as h :refer [defimpl]]))
+
+(h/intern-in module/book-module
+             module/book-module?
+             entry/book-entry
+             entry/book-entry?
+             meta/book-meta
+             meta/book-meta?)
+
+(def ^:dynamic *skip-check* false)
+
+(def ^:dynamic *dep-types* :code)
+
+(defn get-base-entry
+  "gets an entry in the book"
+  {:added "4.0"}
+  ([{:keys [modules] :as book} module-id id section]
+   (get-in modules [module-id section id])))
+
+(defn get-code-entry
+  "gets a code entry in the book"
+  {:added "4.0"}
+  ([{:keys [modules] :as book} id]
+   (let [[mid sid] (ut/sym-pair id)]
+     (or (get-base-entry book mid sid :code)
+         (get-base-entry book mid sid :header)
+         (h/error "ENTRY NOT FOUND"
+                  {:module mid
+                   :symbol sid})))))
+
+(defn get-fragment-entry
+  "gets a code entry in the book"
+  {:added "4.0"}
+  ([{:keys [modules] :as book} id]
+   (let [[mid sid] (ut/sym-pair id)]
+     (or (get-base-entry book mid sid :fragment)
+         (h/error "ENTRY NOT FOUND"
+                  {:module mid
+                   :symbol sid})))))
+
+(defn get-entry
+  "gets either the module or code entry"
+  {:added "4.0"}
+  ([{:keys [modules] :as book} id]
+   (if (namespace id)
+     (get-code-entry book id)
+     (get modules id))))
+
+(defn get-module
+  "gets the module"
+  {:added "4.0"}
+  ([{:keys [modules] :as book} id]
+   (get modules id)))
+
+(defn get-code-deps
+  "gets `:deps` or if a `:static/template` calculate dependencies"
+  {:added "4.0"}
+  ([{:keys [modules grammar lang] :as book} id]
+   (let [entry (get-code-entry book id)]
+     (if-not (:static/template entry)
+       (:deps entry)
+       (get-in (swap! (:static/template.cache entry)
+                      (fn [m]
+                        (if (get-in m [lang :deps])
+                          m
+                          (let [input (:form entry)
+                                mopts {:modules modules
+                                       :grammar grammar
+                                       :entry entry}
+
+                                [form deps] (preprocess/to-staging input grammar modules mopts)]
+                            (assoc-in m [lang :deps]  deps)))))
+               [lang :deps])))))
+
+(defn get-deps
+  "get dependencies for a given id"
+  {:added "4.0"}
+  ([{:keys [modules] :as book} id]
+   (if (namespace id)
+     (get-code-deps book id)
+     (module/module-deps-all (get modules id)))))
+
+(defn get-deps-native
+  "get dependencies for a given id"
+  {:added "4.0"}
+  ([{:keys [modules] :as book} id]
+   (if (namespace id)
+     (:deps-native (get-code-entry book id))
+     (module/module-deps-native (get modules id)))))
+
+(defn list-entries
+  "lists entries for a given symbol"
+  {:added "4.0"}
+  ([book]
+   (list-entries book *dep-types*))
+  ([{:keys [modules]} dep-types]
+   (case dep-types
+     :module  (keys modules)
+     :code    (mapcat (fn [[ns {:keys [code]}]]
+                        (map (partial ut/sym-full ns) (keys code)))
+                      modules))))
+
+(defn book-string
+  "shows the book string"
+  {:added "4.0"}
+  ([{:keys [lang
+            meta
+            grammar
+            modules
+            parent
+            scope]}]
+   (str "#book " [lang] " "
+        (h/map-vals (fn [module]
+                      (->> (select-keys module [:code :fragment])
+                           (h/map-vals count)))
+                    modules))))
+
+(defimpl Book [lang
+               meta
+               grammar
+               modules
+               parent
+               referenced]
+  :final true
+  :string book-string
+  :protocols [protocol.deps/IDeps])
+
+(defn book?
+  "checks that object is a book"
+  {:added "4.0"}
+  ([obj]
+   (instance? Book obj)))
+
+(defn book
+  "creates a book"
+  {:added "4.0"}
+  ([{:keys [lang
+            meta
+            grammar
+            modules
+            parent
+            merged] :as m}]
+   (assert (not-empty meta) "Meta required")
+   (assert (not-empty grammar) "Grammer required")
+   (map->Book (merge {:parent nil
+                      :modules {}}
+                     m
+                     {:merged (conj (set merged) lang)}))))
+
+(defn book-merge
+  "merges a book with it's parent"
+  {:added "4.0"}
+  [book parent]
+  (let [_  (or (= (:parent book)
+                  (:lang parent))
+               (h/error "Not mergable" {:book   (select-keys book   [:lang :parent :merged])
+                                        :parent (select-keys parent [:lang :parent :merged])}))]
+    (-> book
+        (update :merged  conj (:lang parent))
+        (update :modules (fn [m]
+                           (reduce-kv
+                            (fn [m k module]
+                              (let [native (get m k)
+                                    module (if native
+                                             (assoc native
+                                                    :code     (merge (:code module)
+                                                                     (:code native))
+                                                    :fragment (merge (:fragment module)
+                                                                     (:fragment native)))
+                                             module)]
+                                (assoc m k module)))
+                            m
+                            (:modules parent))))
+        (merge {:parent (:parent parent)}))))
+
+(defn book-from
+  "returns the merged book given snapshot"
+  {:added "4.0"}
+  [snapshot lang]
+  (loop [{:keys [parent] :as book} (get-in snapshot [lang :book])]
+    (if parent
+      (recur (book-merge book (get-in snapshot [parent :book])))
+      book)))
+
+(defn check-compatible-lang
+  "checks if the lang is compatible with the book"
+  {:added "4.0"}
+  [book lang]
+  (boolean (or (=  (:lang book) lang)
+               (get (:merged book) lang))))
+
+(defn assert-compatible-lang
+  "asserts that the lang is compatible"
+  {:added "4.0"}
+  [book lang]
+  (or (check-compatible-lang book lang)
+      (h/error "Not compatible" {:book (select-keys book   [:lang :parent :merged])
+                                 :lang lang})))
+
+(defn set-module
+  "adds an addional module to the book"
+  {:added "4.0"}
+  [book module]
+  (let [_ (assert-compatible-lang book (:lang module))
+        {:keys [id]} module]
+    (atom/atom-set-fn book [[[:modules id] module]])))
+
+(defn put-module
+  "adds or updates a module"
+  {:added "4.0"}
+  [book module]
+  (let [_ (assert-compatible-lang book (:lang module))
+        {:keys [id]} module]
+    (atom/atom-put-fn book [:modules id] (h/filter-vals identity module))))
+
+(defn delete-module
+  "deletes a module given a book"
+  {:added "4.0"}
+  [book module-id]
+  (atom/atom-delete-fn book [[:modules module-id]]))
+
+(defn delete-modules
+  "deletes all modules"
+  {:added "4.0"}
+  [book module-ids]
+  (atom/atom-batch-fn book (mapv (fn [module-id]
+                                   [:delete [:modules module-id]])
+                                 module-ids)))
+
+(defn has-module?
+  "checks that a books has a given module"
+  {:added "4.0"}
+  [book module-id]
+  (boolean (get-in book [:modules module-id])))
+
+(defn assert-module
+  "asserts that module exists"
+  {:added "4.0"}
+  [book module-id]
+  (or (has-module? book module-id)
+      (h/error "No module found." {:available (set (list-entries book :module))
+                                   :module module-id})))
+
+(defn set-entry
+  "sets entry in the book"
+  {:added "4.0"}
+  [book entry]
+  (let [_ (assert-compatible-lang book (:lang entry))
+        _ (assert-module book (:module entry))
+        {:keys [id module section]} entry]
+    (atom/atom-set-fn book [[[:modules module section id] entry]])))
+
+(defn put-entry
+  "updates entry value in the book"
+  {:added "4.0"}
+  [book entry]
+  (let [_ (assert-compatible-lang book (:lang entry))
+        _ (assert-module book (:module entry))
+        {:keys [id module section]} entry]
+    (atom/atom-put-fn book [:modules module section id] (h/filter-vals identity entry))))
+
+(defn has-entry?
+  "checks that book has an entry"
+  {:added "4.0"}
+  [book module-id section symbol-id]
+  (boolean (get-in book [:modules module-id  section symbol-id])))
+
+(defn assert-entry
+  "asserts that module exists"
+  {:added "4.0"}
+  [book module-id section symbol-id]
+  (or (has-entry? book module-id section symbol-id)
+      (and (assert-module book module-id)
+           (h/error "No entry found." {:available (set (keys (get (get-entry book module-id)
+                                                                  section)))
+                                       :section section
+                                       :module module-id}))))
+
+(defn delete-entry
+  "deletes an entry"
+  {:added "4.0"}
+  [book module-id section symbol-id]
+  (atom/atom-delete-fn book [[:modules module-id section symbol-id]]))
+
+
+(defn module-create-filename
+  "creates a filename for module"
+  {:added "4.0"}
+  [book module-id]
+  (let [suffix   (or (get-in book [:file :suffix])
+                     (name (get-in book [:grammar :tag])))]
+    (str (last (str/split (name module-id) #"\."))
+         "." suffix)))
+
+(defn module-create-check
+  "checks that bundles are available"
+  {:added "4.0"}
+  [{:keys [modules] :as book} module-id link]
+  (let [missing (h/difference (set (vals link))
+                              (set (conj (keys modules)
+                                         module-id)))]
+    (if (not-empty missing)
+      (h/error "Missing namespaces" {:ns missing
+                                     :link link
+                                     :all (keys modules)})
+      true)))
+
+(defn module-create-requires
+  "creates a map for the requires"
+  {:added "4.0"}
+  [require]
+  (h/map-juxt [first #(apply hash-map (cons :id %))] require))
+
+(defn module-create
+  "creates a module given book and options"
+  {:added "4.0"}
+  ([{:keys [lang] :as book} module-id options]
+   (let [_ (or book      (h/error "Book is required." {:lang lang
+                                                       :module module-id}))
+         _ (or module-id (h/error "Module id is required." {:lang lang
+                                                            :book book
+                                                            :module module-id}))
+         {:keys [require
+                 require-impl
+                 import alias
+                 export file
+                 static]} options
+         requires  (module-create-requires require)
+         internal (-> (h/map-entries (fn [[id {:keys [as]}]] [id (or as id)])
+                                     requires)
+                      (assoc module-id '-))
+         link     (-> (h/map-entries (fn [[id {:keys [as]}]]
+                                       [(if (vector? as)
+                                          (last as)
+                                          (or as id))
+                                        id])
+                                     requires)
+                      (assoc '- module-id))
+         internal   (h/transpose link)
+         native     (h/map-juxt [first (fn [[_ & args]]
+                                         (let [{:keys [bundle]
+                                                :as opts} (apply hash-map args)
+                                               bundle (if bundle
+                                                        (h/map-juxt [first #(apply hash-map (rest %))]
+                                                                    bundle))]
+                                           (cond-> opts
+                                             bundle (assoc :bundle bundle))))]
+                                import)
+         native-lu  (->> native
+                         (mapcat (fn [[import {:keys [as]}]]
+                                   (->> (disj (set (flatten (seq (h/seqify as)))) '*)
+                                        (filter symbol?)
+                                        (map (fn [sym] [sym import])))))
+                         (into {}))
+         alias    (merge (h/map-juxt [#(nth % 2) first] alias)
+                         (->> (vals native)
+                              (map :as)
+                              (keep (fn [x] (if (vector? x) (last x) x)))
+                              (h/map-juxt [identity identity])))
+         includes   (->> requires
+                         (keep (fn [[k v]] (if (:include v) k)))
+                         (set))
+         _          (if (not *skip-check*) (module-create-check book module-id link))]
+     (module/book-module {:lang lang
+                          :id module-id
+
+                          ;; link
+                          :alias      alias
+                          :link       link
+                          :internal   internal
+                          :native     native
+                          :native-lu  native-lu
+                          :require-impl require-impl
+                          :includes   includes
+
+                          :static static}))))
+
+
+
+
+(comment
+
+  (dissoc (bb.lang/get-module
+           (bb.lang/default-library)
+           :js
+           'js.lib.puck)
+          :fragment)
+
+  (dissoc (bb.lang/get-module
+           (bb.lang/default-library)
+           :js
+           'js.core)
+          #_:fragment
+          :code))

--- a/src/bb/lang/base/book_entry.clj
+++ b/src/bb/lang/base/book_entry.clj
@@ -1,0 +1,90 @@
+(ns bb.lang.base.book-entry
+  (:require [bb.lib :as h :refer [defimpl]]
+            [bb.lang.base.util :as ut]))
+
+(defn- book-entry-string
+  ([{:keys [id lang module section display] :as entry}]
+   (if (= display :symbol)
+     (str "E:"(ut/sym-full module id))
+     (str "#book.entry " [lang section (ut/sym-full module id)]
+          (if (= display :brief)
+            ""
+            (str " "
+                 (h/filter-vals identity
+                                (dissoc entry
+                                        :section
+                                        :id
+                                        :module
+                                        :declared
+                                        :form-input
+                                        :template
+                                        :standalone
+
+                                        :line
+                                        :time
+                                        :priority
+                                        :display))))))))
+
+(defimpl BookEntry [;; required
+                    lang
+                    id
+                    module
+                    section
+
+                    ;; stores if code has been declared (line number)
+                    declared
+
+                    ;; code
+                    form
+                    form-input
+
+                    ;; linking
+                    deps
+                    deps-fragment
+                    deps-native
+
+                    ;; required at runtime for dynamic eval to work
+                    namespace
+
+                    ;; supporting macros
+                    template
+                    standalone
+
+                    ;; ordering
+                    line
+                    time
+                    priority
+
+                    ;;
+                    display]
+  :final true
+  :string book-entry-string)
+
+(defn book-entry?
+  "checks if object is a book entry"
+  {:added "4.0"}
+  ([x]
+   (instance? BookEntry x)))
+
+(defn book-entry
+  "creates a book entry"
+  {:added "4.0"}
+  ([{:keys [lang
+            id
+            module
+
+            section
+
+            form
+            form-input
+            deps
+            deps-native
+
+            namespace
+
+            template
+            standalone
+
+            declared] :as m}]
+   (map->BookEntry (merge {:display :default}
+                          m))))

--- a/src/bb/lang/base/book_meta.clj
+++ b/src/bb/lang/base/book_meta.clj
@@ -1,0 +1,56 @@
+(ns bb.lang.base.book-meta
+  (:require [bb.lib :as h :refer [defimpl]]))
+
+(defn- book-meta-string
+  ([{:keys [lang] :as m}]
+   (str "#book.meta "
+        " "
+        (vec (sort (keys (h/filter-vals boolean m)))))))
+
+(defimpl BookMeta [bootstrap
+
+                   module-import
+                   module-export
+                   module-link
+
+                   has-module
+		   setup-module
+		   teardows-module
+
+                   has-ptr
+		   setup-ptr
+		   teardown-ptr]
+  :string book-meta-string)
+
+(defn book-meta?
+  "checks if object is a book meta"
+  {:added "4.0"}
+  ([x]
+   (instance? BookMeta x)))
+
+(defn book-meta
+  "creates a book meta
+
+   (book-meta {:module-export  (fn [{:keys [as]} opts]
+                                 (h/$ (return ~as)))
+               :module-import  (fn [name {:keys [as]} opts]
+                                 (h/$ (var ~as := (require ~(str name)))))
+               :has-ptr        (fn [ptr]
+                                 (list 'not= (ut/sym-full ptr) nil))
+               :teardown-ptr   (fn [ptr]
+                                 (list := (ut/sym-full ptr) nil))})
+  => book-meta?"
+  {:added "4.0"}
+  ([{:keys [bootstrap
+            module-import
+            module-export
+            module-link
+
+            has-module
+	    setup-module
+	    teardows-module
+
+            has-ptr
+	    setup-ptr
+	    teardown-ptr] :as m}]
+   (map->BookMeta m)))

--- a/src/bb/lang/base/book_module.clj
+++ b/src/bb/lang/base/book_module.clj
@@ -1,0 +1,162 @@
+(ns bb.lang.base.book-module
+  (:require [bb.lib :as h :refer [defimpl]]
+            [clojure.set :as set]))
+
+(defn- book-module-string
+  ([{:keys [lang id display] :as module}]
+   (let [meta (->> (dissoc module :id :lang :code :fragment :display)
+                   (h/filter-vals (fn [e]
+                                    (if (coll? e)
+                                      (not-empty e)
+                                      e))))
+         entries (->> (select-keys module [:code :fragment])
+                      (h/map-vals (comp sort keys)))]
+     (str "#book.module " [lang id]
+          (if (= :brief display)
+            ""
+            (str " "
+                 {:meta meta
+                  :entries entries}))))))
+
+;;
+;;
+;;
+
+(defimpl BookModule [;; required
+                     lang
+                     id
+
+                     ;; dependency management
+                     alias         ;; map of shortcuts to packages (both external and internal)
+                     link          ;; map of internal dependencies
+                     native        ;; packages that are native to the workspace runtime
+                     native-lu     ;; lookup for native imports
+                     internal      ;; set of required packages
+
+                     ;; actual code
+
+                     fragment   ;; macros
+                     code       ;; main code
+                     includes   ;; included modules
+
+                     ;; misc (for adding additional data not related to runtime)
+                     static]
+  :final true
+  :string book-module-string)
+
+(defn book-module?
+  "checks of object is a book module"
+  {:added "4.0"}
+  ([x]
+   (instance? BookModule x)))
+
+(defn book-module
+  "creates a book module"
+  {:added "4.0"}
+  ([{:keys [lang
+            id
+
+            alias
+            link
+            internal
+            native
+            native-lu
+            require-impl
+
+            fragment
+            code
+            includes
+
+            static
+            display] :as m}]
+   (assert (not= nil lang) "Module :lang required")
+   (assert (not= nil id)   "Module :id Required")
+   (map->BookModule (merge { ;; Link
+                            :alias {}
+                            :link {}
+                            :native {}
+                            :require-impl []
+
+                            ;; Code
+                            :fragment {}
+                            :code {}
+                            :includes #{}
+
+                            ;; Misc
+                            :static {}
+                            :display :default}
+                           m))))
+
+(defn module-deps-code
+  "gets dependencies for a given module"
+  {:added "4.0"}
+  ([module]
+   (let [entries (vals (:code module))]
+     (disj (apply set/union
+                  (map (fn [e]
+                         (set (map (comp symbol namespace) (:deps e))))
+                       entries))
+           (:id module)))))
+
+(defn module-deps-all
+  "gets dependencies for a given module (including explicit links)"
+  {:added "4.0"}
+  ([module]
+   (disj (h/union (module-deps-code module)
+                  (set (vals (:link module))))
+         (:id module))))
+
+(defn module-deps-native
+  "gets dependencies for a given module"
+  {:added "4.0"}
+  ([module]
+   (let [entries (vals (:code module))]
+     (apply merge-with
+            set/union
+            (keep (fn [e]
+                    (not-empty (:deps-native e)))
+                  entries)))))
+
+(defn module-deps-fragment
+  "gets dependencies for a given module"
+  {:added "4.0"}
+  ([module]
+   (let [entries (vals (:code module))]
+     (apply set/union
+            (map :deps-fragment entries)))))
+
+(defn module-entries
+  [module filter-keys]
+  (->> (:code module)
+       (vals)
+       (sort-by (juxt :priority :time :line))
+       (keep (fn [{:keys [id op-key]
+                   :as entry}]
+               (if (filter-keys op-key)
+                 [(list :% \" id \")
+                  (symbol (str (:id module))
+                          (name id))])))))
+
+
+
+(comment
+  h/atom:get
+  #_
+  (defn library-install-module
+    "installs a module into the library"
+    {:added "3.0"}
+    ([{:keys [lang store] :as lib} module-id conf]
+     (let [{:keys [link native alias code fragment]} conf
+           missing (h/difference (set (vals link))
+                                 (set (conj (keys @store)
+                                            module-id)))
+           _  (if (not-empty missing)
+                (h/error "Missing namespaces" {:ns missing}))
+           module     (library-module (assoc conf
+                                             :id   module-id
+                                             :lang lang
+                                             :alias     (or alias {})
+                                             :link      (or link {})
+                                             :native    (or native {})
+                                             :code      (or code {})
+                                             :fragment  (or fragment {})))]))))

--- a/src/bb/lang/base/compile.clj
+++ b/src/bb/lang/base/compile.clj
@@ -1,0 +1,226 @@
+(ns bb.lang.base.compile
+  (:require [std.make.compile :as compile]
+            [bb.lang.base.emit :as emit]
+            [bb.lang.base.util :as ut]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.pointer :as ptr]
+            [bb.lang.base.impl :as impl]
+            [bb.lang.base.impl-deps :as deps]
+            [bb.lang.base.impl-deps-imports :as deps-imports]
+            [bb.lang.base.impl-lifecycle :as lifecycle]
+            [bb.lang.base.library :as lib]
+            [bb.lang.base.library-snapshot :as snap]
+            [bb.lang.base.compile-links :as links]
+            [bb.lib :as h]
+            [bb.string :as str]
+            [std.fs :as fs]))
+
+
+;;
+;; SCRIPT
+;;
+
+(defn compile-script
+  "compiles a script"
+  {:added "4.0"}
+  [{:keys [header footer main root target name file] :as opts}]
+  (let [opts  (merge {:layout :flat
+                      :entry {:label true}}
+                     opts)
+        entry (compile/compile-resolve main)
+        _ (if (not (book/book-entry? entry))
+            (h/error "Not a library entry" {:main main}))
+        meta   (ptr/ptr-invoke-meta entry
+                                    (select-keys opts [:layout
+                                                       :emit]))
+        body   (impl/emit-script (:form entry) meta)
+        full   (compile/compile-fullbody body opts)
+        output (compile/compile-out-path opts)]
+    (compile/compile-write output full)))
+
+(def +install-script-fn+
+  (compile/types-add :script #'compile-script))
+
+
+;;
+;; SINGLE
+;;
+
+(defn compile-module-single
+  "compiles a single module"
+  {:added "4.0"}
+  ([{:keys [header lang footer main] :as opts}]
+   (let [mopts   (last (impl/emit-options opts))
+         {:keys [emit]} mopts
+         body    (lifecycle/emit-module-setup main
+                                              mopts)
+         full    (compile/compile-fullbody body opts)
+
+         ;; output transformations
+         full    (reduce (fn [full transform]
+                           (transform full (-> emit :static)))
+                         full
+                         (-> emit :code :transforms :full))
+         output  (compile/compile-out-path opts)]
+     (compile/compile-write output full))))
+
+(def +install-module-single-fn+
+  (compile/types-add :module.single #'compile-module-single))
+
+;;
+;; DIRECTORY
+;;
+
+(defn compile-module-create-links
+  [link-all link-root link-opts]
+  (->> link-all
+       (map (fn [ns]
+              [ns (links/link-attributes
+                   link-root
+                   ns
+                   link-opts)]))
+       (into {})))
+
+(defn compile-module-directory-selected
+  "compiles the directory based on sorted imports"
+  {:added "4.0"}
+  [type ns-all {:keys [lang main emit root target] :as opts}]
+  ;; for each file in the directory, find 'extra' deps
+  (let [lib         (impl/runtime-library)
+        snapshot    (lib/get-snapshot lib)
+        book        (snap/get-book snapshot lang)
+        ns-has?     (fn [ns]
+                      (.startsWith (str ns)
+                                   (str main)))
+        ns-selected (filter ns-has? ns-all)
+        ns-extras   (if (-> emit :code :extra-namespaces false?)
+                      []
+                      (->> (mapcat (fn [ns]
+                                     (:all (deps-imports/module-code-deps book [ns])))
+                                   ns-selected)
+                           (set)
+                           (filter (comp not ns-has?))))
+        links      (compile-module-create-links
+                    (concat ns-selected
+                            ns-extras)
+                    main
+                    (:link (:code emit)))
+        root-path  (if (empty? target)
+                     root
+                     (str root "/" target))
+
+        compile-fn (fn [ns]
+                     (let [emit-opts
+                           {:static  (:static (book/get-module book ns))
+                            :compile {:type type
+                                      :links links}}]
+                       (compile-module-single
+                        (-> opts
+                            (assoc :layout :module
+                                   :main ns
+                                   :snapshot snapshot
+                                   :output (str (fs/path (str root-path "/" (get-in links [ns :path])))))
+                            (update :emit merge emit-opts)))))
+
+        ns-compile (if compile/*compile-filter*
+                     (filter compile/*compile-filter* (concat ns-selected ns-extras))
+                     (concat ns-selected ns-extras))
+
+        ;; generate for all namespaces
+        files  (mapv compile-fn ns-compile)]
+    (compile/compile-summarise files)))
+
+(defn compile-module-directory
+  "compiles a directory"
+  {:added "4.0"}
+  ([{:keys [header footer lang main search root target emit] :as opts}]
+   (let [all-paths   (->> (or search ["src"])
+                          (map #(fs/path %))
+                          (mapcat #(fs/select % {:include [".clj$"]})))
+         ns-all      (pmap fs/file-namespace all-paths)]
+     (doseq [[path ns] (map vector all-paths ns-all)]
+       (if ns
+         (try (require ns)
+              (catch Throwable t
+                (println "WARN: Failed to load" ns "from" path (.getMessage t))))
+         (println "WARN: Could not determine namespace for file:" path)))
+     (compile-module-directory-selected :directory (filter identity ns-all) opts))))
+
+(def +install-module-directory-fn+
+  (compile/types-add :module.directory #'compile-module-directory))
+
+
+;;
+;; ROOT
+;;
+
+(defn compile-module-prep
+  "precs the single entry point setup"
+  {:added "4.0"}
+  [{:keys [lang main] :as opts}]
+  (let [lib         (impl/runtime-library)
+        snapshot    (lib/get-snapshot lib)
+        book        (snap/get-book snapshot lang)
+        parent (->> (str/split (str main) #"\.")
+                    (butlast)
+                    (str/join ".")
+                    (symbol))
+        selected  (->> (:all (deps-imports/module-code-deps book [main]))
+                       (filter (fn [ns]
+                                 (.startsWith (str ns)
+                                              (str parent)))))]
+    [selected (assoc opts :main parent)]))
+
+(defn compile-module-root
+  "compiles module.root"
+  {:added "4.0"}
+  ([{:keys [lang main] :as opts}]
+   (require main)
+   (let [[selected opts] (compile-module-prep opts)]
+     (compile-module-directory-selected :graph selected opts))))
+
+(def +install-module-root-fn+
+  (compile/types-add :module.root #'compile-module-root))
+
+;;
+;; GRAPH
+;;
+
+(defn compile-module-graph
+  "compiles a module graph"
+  {:added "4.0"}
+  ([{:keys [lang main] :as opts}]
+   (require main)
+   (let [[selected opts] (compile-module-prep opts)]
+     (compile-module-directory-selected :graph selected opts))))
+
+(def +install-module-graph-fn+
+  (compile/types-add :module.graph #'compile-module-graph)) ;
+
+
+
+;;
+;; SCHEMA
+;;
+
+(defn compile-module-schema
+  "compiles all namespaces into a single file (for sql)"
+  {:added "4.0"}
+  ([{:keys [header footer lang main root target] :as opts}]
+   (require main)
+   (let [mopts   (last (impl/emit-options opts))
+         lib         (impl/runtime-library)
+         snapshot    (lib/get-snapshot lib)
+         book        (snap/get-book snapshot lang)
+         deps        (h/deps:ordered book [main])
+         full-arr    (map (fn [module-id]
+                            (-> (lifecycle/emit-module-setup module-id
+                                                             mopts)
+                                (compile/compile-fullbody opts)))
+                          deps)
+         full        (str/join "\n\n" full-arr)
+         output (compile/compile-out-path opts)]
+     (compile/compile-write output full))))
+
+(def +install-module-schema-fn+
+  (compile/types-add :module.schema #'compile-module-schema))

--- a/src/bb/lang/base/compile_links.clj
+++ b/src/bb/lang/base/compile_links.clj
@@ -1,0 +1,98 @@
+(ns bb.lang.base.compile-links
+  (:require [bb.lib :as h]
+            [bb.string :as str]
+            [std.fs :as fs]))
+
+(def ^:dynamic
+  *link-defaults*
+  {:root-libs   "libs"
+   :root-prefix "."
+   :path-suffix ""
+   :path-separator "/"
+   :path-replace {}
+   :file-replace {}})
+
+(defn get-link-lookup
+  "gets a lookup value"
+  {:added "4.0"}
+  [link-ns ns-lookup]
+  (or (get ns-lookup link-ns)
+      (reduce (fn [_ [pattern v]]
+                (if (h/match-filter pattern link-ns)
+                  (reduced v)))
+              nil
+              ns-lookup)))
+
+(defn get-link-match
+  "gets a lookup match"
+  {:added "4.0"}
+  [link-ns ns-lookup]
+  (or (if-let [v (get ns-lookup link-ns)]
+        [link-ns v])
+      (reduce (fn [_ [pattern v]]
+                (if (h/match-filter pattern link-ns)
+                  (reduced [pattern v])))
+              nil
+              ns-lookup)))
+
+(defn link-attributes
+  "gets link attributes"
+  {:added "4.0"}
+  [root-ns link-ns link-options]
+  (let [{:keys [root-libs
+                root-prefix
+                path-separator
+                path-suffix
+                path-replace
+                ns-suffix
+                ns-label]}  (merge *link-defaults* link-options)
+
+        apply-replace (fn [s]
+                        (reduce (fn [s [pat sub]]
+                                  (str/replace s pat sub))
+                                s
+                                path-replace))
+
+        link-ns-str   (str link-ns)
+        link-ns-arr   (str/split link-ns-str #"\.")
+        root-ns-str   (str root-ns)
+        root-ns-arr   (str/split root-ns-str #"\.")
+
+        prefix-match  (if (map? root-prefix)
+                        (get-link-match link-ns (dissoc root-prefix :default)))
+
+        [prefix-key _] prefix-match
+
+        is-lib?       (or (nil? root-ns)
+                          (not (.startsWith ^String
+                                            link-ns-str
+                                            root-ns-str)))
+
+        rel-segments  (if (and prefix-key
+                               (or (string? prefix-key)
+                                   (symbol? prefix-key)))
+                        (let [p-arr (str/split (str prefix-key) #"\.")]
+                          (drop (count p-arr) (butlast link-ns-arr)))
+
+                        (if is-lib?
+                          (if (map? root-prefix)
+                            (butlast link-ns-arr)
+                            (cons root-libs (butlast link-ns-arr)))
+                          (drop (count root-ns-arr) (butlast link-ns-arr))))
+
+        link-rel      (str/join path-separator (map apply-replace rel-segments))
+
+        link-suffix (or (get-link-lookup link-ns ns-suffix)
+                        (if (map? path-suffix)
+                          (or (get-link-lookup link-ns (dissoc path-suffix :default))
+                              (:default path-suffix))
+                          path-suffix))
+
+        link-label  (apply-replace (or (get-link-lookup link-ns ns-label)
+                                       (last link-ns-arr)))
+        link-path   (apply-replace (str link-rel path-separator link-label link-suffix))]
+    {:is-lib? is-lib?
+     :rel    link-rel
+     :suffix link-suffix
+     :label  link-label
+     :path   link-path}))

--- a/src/bb/lang/base/emit.clj
+++ b/src/bb/lang/base/emit.clj
@@ -1,0 +1,135 @@
+(ns bb.lang.base.emit
+  (:require [bb.string :as str]
+            [bb.lib :as h]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.emit-helper :as helper]
+            [bb.lang.base.emit-block :as block]
+            [bb.lang.base.emit-top-level :as top]
+            [bb.lang.base.emit-preprocess :as preprocess]
+            [bb.lang.base.emit-fn :as fn]
+            [bb.lang.base.grammar :as grammar]
+            [bb.lang.base.util :as ut]))
+
+(defn default-grammar
+  "returns the default grammar
+
+   (emit/default-grammar)
+   => map?"
+  {:added "4.0"}
+  [& [m]]
+  (h/merge-nested helper/+default+ m))
+
+(def +option-keys+
+  [:lang
+   :entry
+   :module
+   :book
+   :snapshot
+   :layout
+   :emit])
+
+(defn emit-main-loop
+  "creates the raw emit
+
+   (emit/emit-main-loop '(not (+ 1 2 3))
+                       +grammar+
+                       {})
+   => \"!((+ 1 2 3))\""
+  {:added "4.0"}
+  ([form grammar mopts]
+   (common/emit-common-loop form
+                            grammar
+                            mopts
+                            top/+emit-lookup+
+                            top/emit-form)))
+
+(defn emit-main
+  "creates the raw emit with loop
+
+   (emit/emit-main '(not (+ 1 2 3))
+                   +grammar+
+                   {})
+   => \"!(1 + 2 + 3)\""
+  {:added "4.0"}
+  ([form grammar mopts]
+   (binding [common/*emit-fn* emit-main-loop]
+     (emit-main-loop form grammar mopts))))
+
+(defn emit
+  "emits form to output string"
+  {:added "4.0"}
+  ([form grammar namespace mopts]
+   (let [mopts (select-keys mopts +option-keys+)]
+     (binding [*ns* (or (if namespace
+                          (the-ns namespace))
+                        *ns*)]
+       (cond (:emit grammar)
+             ((:emit grammar) form mopts)
+
+             :else
+             (emit-main form grammar mopts))))))
+
+(defmacro with:emit
+  "binds the top-level emit function to common/*emit-fn*
+
+   (emit/with:emit
+    (common/*emit-fn* '(not (+ 1 2 3))
+                      +grammar+
+                      {}))
+   => \"!(1 + 2 + 3)\""
+  {:added "4.0"}
+  [& body]
+  `(binding [common/*emit-fn* emit-main-loop]
+     ~@body))
+
+;;
+;;
+;;
+;;
+
+(def +test-grammar+
+  (delay (grammar/grammar :test
+           (grammar/to-reserved (grammar/build))
+           helper/+default+)))
+
+(defn prep-options
+  "prepares the options for processing"
+  {:added "4.0"}
+  [meta]
+  (let [{:keys [lang grammar book namespace snapshot]
+         step :-} meta
+        step (or step
+                 (if (or (and lang snapshot)
+                         book)
+                   :staging
+                   :input))
+        namespace (or namespace
+                      (h/ns-sym))
+        book     (or (if (symbol? book)
+                       @(resolve book)
+                       book)
+                     (get-in snapshot [lang :book]))
+        grammar  (or (if (symbol? grammar)
+                       @(resolve grammar)
+                       grammar)
+                     (if book (:grammar book))
+                     @+test-grammar+)
+        mopts (select-keys meta +option-keys+)]
+    [step grammar book namespace mopts]))
+
+(def +steps+
+  [[:raw]
+   [:input]
+   [:staging]])
+
+(defn prep-form
+  "prepares the form"
+  {:added "4.0"}
+  [step form grammar book mopts]
+  (case step
+    :raw     [form]
+    :input   [(preprocess/to-input form)]
+    :staging (preprocess/to-staging (preprocess/to-input form)
+                                    grammar
+                                    (:modules book)
+                                    mopts)))

--- a/src/bb/lang/base/emit_assign.clj
+++ b/src/bb/lang/base/emit_assign.clj
@@ -1,0 +1,165 @@
+(ns bb.lang.base.emit-assign
+  (:require [bb.string :as str]
+            [bb.lib :as h]
+            [bb.lang.base.util :as ut]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.emit-preprocess :as preprocess]
+            [bb.lang.base.emit-helper :as helper]
+            [bb.lang.base.emit-data :as data]
+            [bb.lang.base.emit-block :as block]
+            [bb.lang.base.emit-fn :as fn]))
+
+(def +assign-types+
+  #{:assign/inline
+    :assign/template
+    :assign/fn})
+
+;;
+;; All will compile to a function :assign/fn that will then get executed on the symbol
+;;
+;; :assign/inline will work with functions
+;; - it will check if function is inlineable (one var declaration, one return statement, return statement is symbol)
+;; - it will do template substitution for the form
+;; - preprocessor will exclude the first element of the list from deps
+;; - it will always link to a code entry so if a macro in needed, tough.
+;;
+;; :assign/template works with macros, which will compile to a single form and have :assign out
+;; as the replacement
+;;
+;; :assign/fn works as well but it will bypass the dependency checker so be careful.
+;;
+
+(defn emit-def-assign-inline
+  "assigns an inline form directly"
+  {:added "4.0"}
+  [sym [link & input] grammar {:keys [lang book snapshot] :as mopts}]
+  (let [[link-module link-id] (ut/sym-pair link)
+        book     (or book (get-in snapshot [lang :book]))
+        entry    (or (get-in book [:modules link-module :code link-id])
+                     (h/error "Cannot find entry" {:lang  lang
+                                                   :input link}))
+        _        (or (empty? (:deps entry))
+                     (h/error "Inline cannot have additional dependencies." {:lang  lang
+                                                                             :input link}))
+        [_ _ args & body] (:form entry)
+        return-ref (volatile! nil)
+        body       (h/postwalk (fn [form]
+                                 (if (h/form? form)
+                                   (cond (= 'return (first form))
+                                         (if @return-ref
+                                           (h/error "Inline cannot have multiple returns." {:input @return-ref})
+                                           (do (vreset! return-ref (second form))
+                                               '<RETURN>))
+
+                                         :else
+                                         (remove (fn [x]
+                                                   (= x '<RETURN>))
+                                                 form))
+                                   form))
+                               body)
+        _          (or (not (coll? @return-ref))
+                       (h/error "Return should be a token." {:input @return-ref}))
+        assign-ref (volatile! nil)
+        -          (h/postwalk (fn [form]
+                                 (do (when (and (h/form? form)
+                                                (= 'var (first form)))
+                                       (let [asym (first (filter symbol? (rest form)))]
+                                         (or (= @return-ref asym)
+                                             (h/error "Inlined with unaccounted for declarations"
+                                                      {:link link
+                                                       :form body}))
+                                         (vreset! assign-ref asym)))
+                                     form))
+                               body)
+        asym?      @assign-ref
+        rsym?      (symbol? @return-ref)
+        smap       (cond-> (zipmap args input)
+                     (and rsym? asym?) (assoc @return-ref sym))
+        body       (h/prewalk-replace smap body)
+        #_#_
+        _          (h/prn smap @assign-ref @return-ref
+                          body)]
+    (if (and rsym? asym?)
+      (apply list 'do* body)
+      (apply list 'do* (concat body [(list 'var sym := (if rsym?
+                                                         (get smap @return-ref)
+                                                         @return-ref))])))))
+
+(defn emit-def-assign
+  "emits a declare expression"
+  {:added "3.0"}
+  ([_ {:keys [raw] :as props} [_ & args] grammar mopts]
+   (let [{:keys [sep space assign]} (helper/get-options grammar [:default :define])
+         args     (helper/emit-typed-args args grammar)
+
+         argstrs  (map (fn [{:keys [value symbol] :as arg}]
+                         (let [{:assign/keys [inline template] :as aopts} (meta value)
+                               custom (cond (:assign/fn aopts) [:raw  ((:assign/fn aopts) symbol)]
+                                            template [:template (h/prewalk-replace {template symbol} value)]
+                                            inline   [:inline   (emit-def-assign-inline symbol
+                                                                                        value
+                                                                                        grammar
+                                                                                        mopts)])]
+                           (if custom
+                             (common/*emit-fn* (second custom) grammar mopts)
+                             (fn/emit-input-default arg assign grammar mopts))))
+                       args)
+         vstr    (str/join (str sep space) argstrs)
+         rawstr  (if (not-empty raw) (str raw space))]
+     (str rawstr vstr))))
+
+;;
+;;
+;;
+
+(defn test-assign-loop
+  "emit do"
+  {:added "4.0" :adopt true}
+  [form grammar mopts]
+  (common/emit-common-loop form
+                           grammar
+                           mopts
+                           (assoc common/+emit-lookup+
+                                  :data data/emit-data
+                                  :block block/emit-block)
+                           (fn [key form grammar mopts]
+                             (case key
+                               :fn (fn/emit-fn :function form grammar mopts)
+                               (common/emit-op key form grammar mopts
+                                               {:def-assign emit-def-assign
+                                                :quote data/emit-quote
+                                                :table data/emit-table})))))
+
+(defn test-assign-emit
+  "emit assign forms
+
+   (assign/test-assign-loop (list 'var 'a := (with-meta ()
+                                               {:assign/fn (fn [sym]
+                                                             (list sym :as [1 2 3]))}))
+                            +grammar+
+                            {})
+   => \"(a :as [1 2 3])\"
+
+   (assign/test-assign-loop (list 'var 'a := (with-meta '(sym :as [1 2 3])
+                                               {:assign/template 'sym}))
+                            +grammar+
+                            {})
+   => \"(a :as [1 2 3])\"
+
+   (assign/test-assign-loop (list 'var 'a := (with-meta '(x.core/identity-fn 1)
+                                               {:assign/inline 'x.core/identity-fn}))
+                            +grammar+
+                            {:lang :x
+                             :snapshot +snap+})
+   => \"(do* (var a := 1))\"
+
+   (assign/test-assign-loop (list 'var 'a := (with-meta '(x.core/complex-fn 1)
+                                               {:assign/inline 'x.core/complex-fn}))
+                            +grammar+
+                            {:lang :x
+                             :snapshot +snap+})
+   => \"(do* (var a := 1) (:= a (+ a 1)))\""
+  {:added "4.0"}
+  [form grammar mopts]
+  (binding [common/*emit-fn* test-assign-loop]
+    (test-assign-loop form grammar mopts)))

--- a/src/bb/lang/base/emit_block.clj
+++ b/src/bb/lang/base/emit_block.clj
@@ -1,0 +1,258 @@
+(ns bb.lang.base.emit-block
+  (:require [bb.string :as str]
+            [bb.lib :as h]
+            [bb.lang.base.emit-common :as common]))
+
+;;
+;; BLOCK BODY
+;;
+
+(defn emit-statement
+  "emits a statement given grammar"
+  {:added "3.0"}
+  ([form grammar mopts]
+   (let [[_ type] (common/form-key form grammar)
+         {:keys [statement]} (get-in grammar [:default :common])
+         body (common/*emit-fn*  form grammar mopts)]
+     (if (#{:block :free :fn :def} type)
+       body
+       (str body statement)))))
+
+(defn emit-do
+  "emits a do block"
+  {:added "3.0"}
+  ([args grammar mopts]
+   (let [spacing (or (get-in grammar [:default :common :line-spacing]) 1)
+         cols    (repeat spacing (common/newline-indent))
+         lines   (apply str cols)]
+     (str/join lines
+               (filter (comp not empty?)
+                       (map (fn [form] (emit-statement form grammar mopts))
+                            args))))))
+
+(defn emit-do*
+  "like do but removes the statment at the end, useful for macros"
+  {:added "3.0"}
+  ([args grammar mopts]
+   (let [out (emit-do args grammar mopts)
+         statement (get-in grammar [:default :common :statement])]
+     (if (str/ends-with? out statement)
+       (h/lsubs out (count statement))
+       out))))
+
+(defn block-options
+  "gets the block options"
+  {:added "3.0"}
+  ([key block segment grammar]
+   (merge (get-in grammar [:default :common])
+          (get-in grammar [:default :block segment])
+          (get-in grammar [:block key segment])
+          (get-in block   [segment]))))
+
+(defn emit-block-body
+  "helper to emit a block body"
+  {:added "3.0"}
+  ([key block args grammar mopts]
+   (let [{:keys [start end append]} (block-options key block :body grammar)]
+     (str start
+          (common/with-indent [(get-in grammar [:default :common :indent])]
+            (str (common/newline-indent)
+                 (emit-do args grammar mopts)))
+          (if (not append)
+            (common/newline-indent))
+          end))))
+
+;;
+;; BLOCK PARAMS
+;;
+
+(defn parse-params
+  "parses params for a block"
+  {:added "3.0"}
+  ([params]
+   (cond (vector? params)
+         (if (some vector? params)
+           (mapv (fn [x] [:statement (if (vector? x) x [x])]) params)
+           [:statement params])
+
+         :else
+         [:raw params])))
+
+(defn emit-params-statement
+  "emits the params for statement"
+  {:added "3.0"}
+  ([key block args grammar mopts]
+   (let [acc (loop [acc  []
+                    curr []
+                    [x & more :as args] args]
+               (cond (empty? args) (conj acc curr)
+                     (keyword? x) (recur (conj acc curr) [x] more)
+                     :else (recur acc (conj curr x) more)))
+         acc (remove empty? acc)
+         {:keys [sep space]} (block-options key block :parameter grammar)]
+     (str/join space (map (fn [[k & more]]
+                            (let [[k args] (if (keyword? k)
+                                             [(.replaceAll (h/strn k) "-" " ") more]
+                                             [nil (cons k more)])]
+                              (cond->> (common/emit-array args grammar mopts)
+                                :then (map str/trim-right)
+                                :then (str/join (str sep space))
+                                k  (str k space))))
+                          acc)))))
+
+(defn emit-params
+  "constructs string to for loop args"
+  {:added "3.0"}
+  ([key block params grammar mopts]
+   (let [parsed (parse-params params)
+         {:keys [statement space start end]} (block-options key block :parameter grammar)
+         pstr (case (first parsed)
+                :raw (common/*emit-fn*  (second parsed) grammar mopts)
+                :statement (emit-params-statement key block (second parsed) grammar mopts)
+                (str/join (str statement space)
+                          (map #(emit-params-statement key block % grammar mopts)
+                               (map second parsed))))]
+     (str start pstr end))))
+
+;;
+;; BLOCK CONTROLS
+;;
+
+(defn emit-block-control
+  "emits a control form code"
+  {:added "3.0"}
+  ([ck {:keys [main] :as cblock} opts [tag & args] grammar mopts]
+   (let [main (or main #{:parameter :body})
+         [params body] (if (:parameter main)
+                         [(first args) (rest args)]
+                         [nil args])
+         cblock (h/merge-nested cblock opts)]
+     (str (or (:raw opts) tag)
+          (if (:parameter main)
+            (emit-params ck cblock params grammar mopts))
+          (if (:body main)
+            (emit-block-body ck cblock body grammar mopts))))))
+
+(defn emit-block-controls
+  "emits control blocks for a form"
+  {:added "3.0"}
+  ([key block control ctl-args grammar mopts]
+   (let [{:keys [begin append main]} (merge (get-in grammar [:default :block])
+                                            block)
+         sep (cond append " "
+                   :else (common/newline-indent))]
+     (->> (mapcat (fn [[ck {:keys [required] :as cblock}]]
+                    (let [margs (get ctl-args ck)
+                          _     (if (and required (empty? margs))
+                                  (h/error "Form is required in body" {:main key :control ck}))
+                          opts  (merge (get-in grammar [:default :block])
+                                       (get-in grammar [:block key :control :default])
+                                       (get-in grammar [:block key :control ck]))]
+                      (map (fn [args]
+                             (emit-block-control ck cblock opts args grammar mopts))
+                           margs)))
+                  control)
+          (str/join sep)
+          (str (if (empty? main) "" sep))))))
+
+;;
+;; BLOCK
+;;
+
+(defn emit-block-setup
+  "parses main and control blocks"
+  {:added "4.0"}
+  ([key {:keys [raw main control] :as block} [tag & args] grammar mopts]
+   (let [main (or main #{:parameter :body})
+         [params args] (if (:parameter main)
+                         [(first args) (rest args)]
+                         [nil args])
+         ctl       (h/map-juxt [(comp symbol name) identity] (map first control))
+         ctl-fn    (fn [form] (and (h/form? form) (ctl (first form))))
+         ctl-args  (->> (filter ctl-fn args)
+                        (group-by (comp ctl first)))
+         args      (remove ctl-fn args)
+         raw   (or (get-in grammar [:block key :raw])
+                   raw
+                   tag)
+         {:keys [start end append] :as wrap} (get-in grammar [:block key :wrap])]
+     [raw params args ctl-args wrap])))
+
+(defn emit-block-inner
+  "returns the inner block"
+  {:added "4.0"}
+  ([key {:keys [main control] :as block} form grammar mopts]
+   (let [[raw params args ctl-args wrap] (emit-block-setup key block form grammar mopts)
+         {:keys [start end append]} (block-options key block :body grammar)]
+     (str (:start wrap)
+          raw
+          (if (:parameter main)
+            (emit-params key block params grammar mopts))
+          start
+          (str/trim-right
+           (common/with-indent [(get-in grammar [:default :common :indent])]
+             (emit-block-controls key block control ctl-args grammar mopts)))
+          (common/newline-indent)
+          end
+          (if (and wrap (not (:append wrap)))
+            (common/newline-indent))
+
+          (:end wrap)))))
+
+(defn emit-block-standard
+  "emits a generic block"
+  {:added "3.0"}
+  ([key {:keys [main control] :as block} form grammar mopts]
+   (let [[raw params args ctl-args wrap] (emit-block-setup key block form grammar mopts)
+         {:keys [start end append]} wrap]
+     (str start
+          raw
+          (if (:parameter main)
+            (emit-params key block params grammar mopts))
+          (if (:body main)
+            (emit-block-body key block args grammar mopts))
+          (if control
+            (emit-block-controls key block control ctl-args grammar mopts))
+          (if (and wrap (not append)) (common/newline-indent))
+          end))))
+
+(defn emit-block
+  "emits a minimal block expression"
+  {:added "3.0"}
+  ([key [sym & args :as form] {:keys [reserved] :as grammar} mopts]
+   (let [{:keys [emit block macro] :as op} (get reserved sym)]
+     (case emit
+       :do    (emit-do  args grammar mopts)
+       :do*   (emit-do* args grammar mopts)
+       :macro (common/emit-macro key form grammar mopts)
+       :inner (emit-block-inner key block form grammar mopts)
+       (if (or (fn? emit) (var? emit))
+         (emit form grammar mopts)
+         (emit-block-standard key block form grammar mopts))))))
+
+
+;;
+;; TESTING
+;;
+
+(defn test-block-loop
+  "emits with blocks"
+  {:added "4.0"}
+  [form grammar mopts]
+  (common/emit-common-loop form
+                           grammar
+                           mopts
+                           (assoc common/+emit-lookup+ :block emit-block)
+                           common/emit-op))
+
+(defn test-block-emit
+  "emit with blocks"
+  {:added "4.0"}
+  [form grammar mopts]
+  (binding [common/*emit-fn* test-block-loop]
+    (test-block-loop form grammar mopts)))
+
+
+(comment
+  (./create-tests)
+  )

--- a/src/bb/lang/base/emit_common.clj
+++ b/src/bb/lang/base/emit_common.clj
@@ -1,0 +1,907 @@
+(ns bb.lang.base.emit-common
+  (:require [bb.string :as str]
+            [bb.lib :as h]
+            [bb.lang.base.util :as ut]
+            [bb.lang.base.emit-preprocess :as preprocess]
+            [bb.lang.base.emit-helper :as helper]))
+
+;; controls whether to fail with a stacktrace
+(def ^:dynamic *explode* nil)
+
+(def ^:dynamic *trace* nil)
+
+(def ^:dynamic *indent* 0)
+
+(def ^:dynamic *compressed* false)
+
+(def ^:dynamic *multiline* false)
+
+(def ^:dynamic *max-len* 60)
+
+(def ^:dynamic *emit-internal* false)
+
+(def ^:dynamic *emit-fn* helper/default-emit-fn)
+
+(defmacro with:explode
+  "form to control `explode` option"
+  {:added "4.0"}
+  ([& body]
+   `(binding [*explode* true]
+      ~@body)))
+
+(defmacro with-trace
+  "form to control `trace` option"
+  {:added "4.0"}
+  ([& body]
+   `(binding [*trace* true]
+      ~@body)))
+
+(defmacro with-compressed
+  "formats without newlines and indents"
+  {:added "3.0"}
+  ([& body]
+   `(binding [*compressed* true]
+      ~@body)))
+
+(defmacro with-indent
+  "adds indentation levels"
+  {:added "3.0"}
+  ([[& increment] & body]
+   `(binding [*indent* (+ *indent* (or ~@increment 2))]
+      ~@body)))
+
+(defn newline-indent
+  "returns a newline with indent"
+  {:added "3.0"}
+  []
+  (if-not *compressed*
+    (str "\n"
+         (apply str (repeat *indent* " ")))
+    " "))
+
+(defn emit-reserved-value
+  "emits a reserved value"
+  {:added "4.0"}
+  [form {:keys [reserved] :as grammar} mopts]
+  (if-let [{:keys [emit value free raw] :as props} (get reserved form)]
+    (or (and value
+             (or free
+                 raw
+                 (h/error "No raw value found" props)))
+
+        (h/error "Cannot use reserved token in body" props))))
+
+(defn emit-free-raw
+  "emits free value"
+  {:added "4.0"}
+  ([sep args grammar mopts]
+   (let [str-array (binding [*indent* 0]
+                     (mapv (fn [e]
+                             [e (or (and (string? e) e)
+                                    (and (keyword? e)
+                                         (or (emit-reserved-value e grammar mopts)
+                                             (h/strn e)))
+                                    (*emit-fn* e grammar mopts))])
+                           args))]
+     (loop [[prev out]   (first str-array)
+            [[curr s] :as input] (rest str-array)]
+       (cond (empty? input)
+             out
+
+             (or (char? curr)
+                 (char? prev))
+             (recur [curr (str out s)]
+                    (rest input))
+
+             :else
+             (recur [curr (str out (or sep " ") s)]
+                    (rest input)))))))
+
+(defn emit-free
+  "emits string with multiline support"
+  {:added "4.0"}
+  ([{:keys [sep]} [tag & more :as form] grammar mopts]
+   (let [{:keys [indent prefix full-body]} (meta form)
+         prev    *indent*
+         output  (emit-free-raw sep more grammar mopts)]
+     (if (str/multi-line? output)
+       (let [indent-fn (if full-body
+                         str/indent
+                         str/indent-rest)]
+         (indent-fn output
+                    (+ (or prev 0)
+                       (or indent 0))))
+       output))))
+
+;;
+;; COMMENT
+;;
+
+(defn emit-comment
+  "emits a comment"
+  {:added "4.0"}
+  ([_ [tag & more :as form] grammar mopts]
+   (let [{:keys [indent prefix full-body]} (meta form)
+         prefix  (or prefix (-> grammar :default :comment :prefix))
+         prev    *indent*
+         output  (emit-free-raw " " more grammar mopts)]
+     (if (str/multi-line? output)
+       (let [indent-fn (if full-body
+                         str/indent
+                         str/indent-rest)]
+         (str prefix " "
+              (indent-fn output
+                         0
+                         {:custom (str (str/spaces (+ (or prev 0)
+                                                      (or indent 0)))
+                                       prefix
+                                       " ")})))
+       (str prefix " " output)))))
+
+(defn emit-indent
+  "emits an indented form"
+  {:added "4.0"}
+  ([_ [tag & more :as form] grammar mopts]
+   (let [{:keys [indent prefix full-body]} (meta form)]
+     (emit-comment nil
+                   (with-meta form
+                     (merge {:prefix " "}
+                            (meta form)))
+                   grammar mopts))))
+
+;;
+;; MACRO
+;;
+
+(defn emit-macro
+  "emits form"
+  {:added "4.0"}
+  ([_ [tag & more :as form] grammar mopts]
+   (let [{:keys [macro] :as m} (get-in grammar [:reserved tag])]
+     (if m
+       (binding [preprocess/*macro-opts* mopts
+                 preprocess/*macro-grammar* grammar]
+         (*emit-fn* (macro form) grammar mopts))
+       (h/error "Not found: " {:input form})))))
+
+;;
+;; HELPERS
+;;
+
+(defn emit-array
+  "returns an array of emitted strings"
+  {:added "4.0"}
+  ([array grammar mopts]
+   (emit-array array grammar mopts *emit-fn*))
+  ([array grammar mopts emit-fn]
+   (map #(emit-fn % grammar mopts) array)))
+
+(defn emit-wrappable?
+  "checks if form if wrappable"
+  {:added "4.0"}
+  ([form grammar]
+   (if (h/form? form)
+     (let [infix? #{:infix :infix* :infix- :infix-if
+                    :assign :bi
+                    :prefix :postfix}
+           {:keys [macro emit wrappable]} (get-in grammar [:reserved (first form)])]
+       (boolean (or wrappable
+                    (infix? emit)
+                    ('#{fn fn.inner} (first form))
+                    (and (= :macro emit)
+                         (emit-wrappable? (macro form) grammar)))))
+     false)))
+
+(defn emit-squash
+  "emits a squashed representation"
+  {:added "4.0"}
+  [_ [tag & more] grammar mopts]
+  (str/join (emit-array more grammar mopts)))
+
+(defn emit-wrapping
+  "emits a potentially wrapped form"
+  {:added "4.0"}
+  ([form grammar mopts]
+   (let [result (*emit-fn* form grammar mopts)
+         {:keys [start end]} (get-in grammar [:default :common])
+         wrap? (emit-wrappable? form grammar)]
+     (if wrap?
+       (str start result end)
+       result))))
+
+(defn wrapped-str
+  "wrapped string using `:start` and `:end` keys of grammar"
+  {:added "3.0"}
+  ([inner path grammar]
+   (let [{:keys [start end]} (helper/get-options grammar path)]
+     (str start inner end))))
+
+;;
+;; OP
+;;
+
+(defn emit-unit
+  "emits a unit"
+  {:added "4.0"}
+  ([{:keys [raw default transform] :as props} [_ value] grammar mopts]
+   (*emit-fn* (cond-> (or value default)
+                transform (transform raw))
+              grammar mopts)))
+
+(defn emit-internal
+  "emits string within the form"
+  {:added "4.0"}
+  ([[_ value] grammar mopts]
+   (*emit-fn* value grammar mopts)))
+
+(defn emit-internal-str
+  "emits internal string"
+  {:added "4.0"}
+  ([[_ value] grammar mopts]
+   (binding [*emit-internal* true]
+     (cond (vector? value)
+           (str/join "\n"
+                     (mapv #(*emit-fn* % grammar mopts)
+                           value))
+
+           :else
+           (*emit-fn* value grammar mopts)))))
+
+(defn emit-pre
+  "emits string before the arg"
+  {:added "3.0"}
+  ([raw args grammar mopts]
+   (assert (= 1 (count args)) (str "Single argument for " raw))
+   (str raw (emit-wrapping (first args) grammar mopts))))
+
+(defn emit-post
+  "emits string after the arg"
+  {:added "3.0"}
+  ([raw args grammar mopts]
+   (assert (= 1 (count args)) (str "Single argument " raw))
+   (str (emit-wrapping (first args) grammar mopts) raw)))
+
+
+(defn emit-prefix
+  "emits operator before the arg"
+  {:added "4.0"}
+  ([raw args grammar mopts]
+   (assert (= 1 (count args)) (str "Single argument for " raw))
+   (let [{:keys [space]} (get-in grammar [:default :common])]
+     (str raw space (emit-wrapping (first args) grammar mopts)))))
+
+(defn emit-postfix
+  "emits operator before the arg"
+  {:added "4.0"}
+  ([raw args grammar mopts]
+   (assert (= 1 (count args)) (str "Single argument " raw))
+   (let [{:keys [space]} (get-in grammar [:default :common])]
+     (str (emit-wrapping (first args) grammar mopts) space raw))))
+
+(defn emit-infix
+  "emits infix ops"
+  {:added "3.0"}
+  ([raw args grammar mopts]
+   (assert (pos? (count args)) (str "One or more arguments " raw))
+   (let [{:keys [start end space]} (get-in grammar [:default :common])]
+     (str/join (str space raw space)
+               (emit-array args grammar mopts emit-wrapping)))))
+
+(defn emit-infix-default
+  "emits infix with a default value"
+  {:added "3.0"}
+  ([raw args default grammar mopts]
+   (assert (pos? (count args)) (str "One or more arguments " raw))
+   (let [args (case (count args)
+                1 (cons default args)
+                args)]
+     (emit-infix raw args grammar mopts))))
+
+(defn emit-infix-pre
+  "emits infix with a default value"
+  {:added "3.0"}
+  ([raw args grammar mopts]
+   (assert (pos? (count args)) (str "One or more arguments " raw))
+   (case (count args)
+     1 (emit-pre raw args grammar mopts)
+     (emit-infix raw args grammar mopts))))
+
+(defn emit-infix-if-single
+  "checks for infix in single
+
+   (emit-infix-if '(:? true x y)
+                  helper/+default+
+                  {})
+   => \"true ? x : y\""
+  {:added "4.0"}
+  ([[_ check then else] grammar mopts]
+   (let [{:keys [start end space]} (get-in grammar [:default :common])
+         inif (get-in grammar [:default :infix :if])]
+     (h/-> (emit-array [check then else] grammar mopts emit-wrapping)
+           (interleave [(str space (or (:check inif) "?") space)
+                        (str space (or (:then inif) ":") space) ""])
+           (str/join)))))
+
+(defn emit-infix-if
+  "emits an infix if string"
+  {:added "3.0"}
+  ([[_ & forms] grammar mopts]
+   (let [[check & args] forms]
+     (cond (>= 2 (count args))
+           (emit-infix-if-single (apply list :? check args) grammar mopts)
+
+           :else
+           (let [pairs (map vec (partition 2 forms))
+                 _ (if (not= :else (first (last pairs)))
+                     (h/error "ternary cond has to end with :else" {:form (last pairs)}))]
+             (emit-infix-if-single
+              (reduce (fn [acc [q alt]]
+                        (list :? q alt acc))
+                      (last (last pairs))
+                      (reverse (butlast pairs)))
+              grammar mopts))))))
+
+(defn emit-between
+  "emits the raw symbol between two elems"
+  {:added "3.0"}
+  ([raw args grammar mopts]
+   (str/join raw (emit-array args grammar mopts emit-wrapping))))
+
+(defn emit-bi
+  "emits infix with two args"
+  {:added "3.0"}
+  ([raw args grammar mopts]
+   (assert (= 2 (count args)) (str "Two arguments for " raw))
+   (emit-infix raw args grammar mopts)))
+
+(defn emit-assign
+  "emits a setter expression"
+  {:added "3.0"}
+  ([raw args grammar mopts]
+   (assert (= 2 (count args)) (str "Two arguments for assign"))
+   (let [{:keys [space assign]} (get-in grammar [:default :common])]
+     (str/join (str space (or raw assign) space)
+               (emit-array args grammar mopts emit-wrapping)))))
+
+(defn emit-return-do
+  "creates a return statement on `do` block"
+  {:added "4.0"}
+  ([arg grammar mopts]
+   (let [{:keys [space]} (get-in grammar [:default :common])
+         pre-form (butlast arg)
+         ret-form (list 'return (last arg))]
+     (*emit-fn* (apply list
+                       (concat pre-form
+                               [ret-form]))
+                grammar mopts))))
+
+(defn emit-return-base
+  "return base type"
+  {:added "4.0"}
+  ([raw args grammar mopts]
+   (let [{:keys [space sep]} (get-in grammar [:default :common])
+         {:keys [multi]} (get-in grammar [:default :return])
+         _ (if (not multi)
+             (assert (>= 2 (count args)) (str "One or Zero arguments for " raw)))
+         out (->> (emit-array args grammar mopts)
+                  (str/join (str sep space)))]
+     (cond (and (h/form? (first args))
+                (:return/none (meta (first args))))
+           out
+
+           :else
+           (str raw (if (not-empty args)
+                      space)
+                out)))))
+
+(defn emit-return
+  "creates a return type statement"
+  {:added "3.0"}
+  ([raw args grammar mopts]
+   (let [val (first args)]
+     (cond (not (h/form? val))
+           (emit-return-base raw args grammar mopts)
+
+           ('#{return} (first val))
+           (emit-return raw (apply list (rest val)) grammar mopts)
+
+           ('#{do do*} (first val))
+           (emit-return-do val grammar mopts)
+
+           :else
+           (emit-return-base raw args grammar mopts)))))
+
+;;
+;; GLOBAL
+;;
+
+(defn emit-with-global
+  "customisable emit function for global vars"
+  {:added "4.0"}
+  [_ [_ token] grammar mopts]
+  (if-let [transform (get-in grammar [:token :symbol :global])]
+    (*emit-fn* (transform token grammar mopts) grammar mopts)
+    (apply str (helper/emit-symbol-full token (namespace token) grammar))))
+
+;;
+;; TOKEN
+;;
+
+(defn emit-symbol-classify
+  "classify symbol given options
+
+   (emit-symbol-classify 't/hello {:module {:alias '{t table}}})
+   => '[:alias table]
+
+   (emit-symbol-classify 't.n/hello {:module {:alias '{t table}}})
+   => '[:unknown t.n]"
+  {:added "3.0"}
+  ([sym {:keys [lang module entry book snapshot] :as mopts}]
+   (cond (not (namespace sym))
+         [:unknown nil]
+
+         :else
+         (let [[sym-ns sym-id] (ut/sym-pair sym)]
+           (or (if-let [ns (get (:alias module) sym-ns)]
+                 [:alias ns])
+
+               (let [link-ns (or (if (get (:internal module)
+                                          sym-ns)
+                                   sym-ns)
+
+                                 (if (or (= (:id module) sym-ns)
+                                         (= (:module entry) sym-ns))
+                                   sym-ns)
+
+                                 (get (:link module) sym-ns))
+                     sym-ns  (or link-ns sym-ns)
+                     ext-module (if book
+                                  (get-in book [:modules sym-ns])
+                                  (get-in snapshot [lang :book :modules sym-ns]))]
+                 (cond (and (not link-ns)
+                            (not ext-module)) nil
+
+                       (= :defglobal (get-in ext-module [:code sym-id :op-key]))
+                       [:global sym-ns]
+
+                       (or (= (:id module) sym-ns)
+                           (= (:module entry) sym-ns))
+                       [:self sym-ns]
+
+                       :else
+                       [:link sym-ns]))
+
+               (do [:unknown sym-ns]))))))
+
+(defn emit-symbol-standard
+  "emits a standard symbol
+
+   (emit-symbol-standard 'print! helper/+default+ {:layout :full})
+   => \"printf\"
+
+   (emit-symbol-standard 'print!
+                         {:token {:symbol    {:replace {}}
+                                  :string    {:quote :single}}}
+                         {:layout :full})
+   => \"print!\""
+  {:added "3.0"}
+  ([sym grammar {:keys [lang layout module] :as mopts}]
+   (let [[type ns] (emit-symbol-classify sym mopts)
+         {:keys [link-fn] :as opts}  (get-in grammar [:token :symbol])
+         dopts (get-in grammar [:default :common])
+         module-symbol  (fn [sym]
+                          (str (or (get (:internal module)
+                                        ns)
+                                   (namespace sym))
+                               (:namespace dopts)
+                               (name sym)))
+         link-symbol (fn [sym]
+                       (cond (= layout :flat)   (name sym)
+                             (= layout :module) (if (= ns (:id module))
+                                                  (name sym)
+                                                  (module-symbol sym))
+                             ;; #_#_
+                             :else (module-symbol sym)
+
+                             #_#_
+                             :else (h/error "Not Implemented." {:input sym
+                                                               :layout layout
+                                                                :classify [type ns]})))
+         sym  (cond (= type :alias)   (str ns (:namespace dopts) (name sym))
+
+                    (= type :global)  (emit-with-global nil
+                                                        [nil (symbol (str ns) (name sym))]
+                                                        grammar mopts)
+
+                    (= type :unknown) (if ns
+                                        (h/error "Unknown namespace."
+                                                 {:lang lang
+                                                  :namespace ns
+                                                  :input sym
+                                                  :layout layout
+                                                  :classify [type ns]})
+                                        (name sym))
+
+                    link-fn           (*emit-fn* (link-fn sym mopts)
+                                                 grammar mopts)
+
+                    (#{:full
+                       :host}  layout)  (helper/emit-symbol-full sym ns grammar)
+
+                    (= type :self)     (name sym)
+
+                    (= type :link)     (link-symbol sym))]
+     (if (not (and (not= type :unknown)
+                   link-fn))
+       (apply str (replace (:replace opts) sym))
+       sym))))
+
+(defn emit-symbol
+  "emits symbol allowing for custom functions"
+  {:added "4.0"}
+  [sym grammar mopts]
+  (let [{:keys [emit-fn]}  (get-in grammar [:token :symbol])]
+    (if emit-fn
+      (emit-fn sym grammar mopts)
+      (emit-symbol-standard sym grammar mopts))))
+
+(defn emit-token
+  "customisable emit function for tokens"
+  {:added "3.0"}
+  ([key token grammar mopts]
+   (let [{:keys [emit as custom]} (get-in grammar [:token key])
+         custom-fn (case key
+                     :string (cond *emit-internal*
+                                   identity
+
+                                   (= :single (get-in grammar [:token :string :quote]))
+                                   helper/pr-single
+
+                                   :else
+                                   custom)
+                     :symbol (or (if custom
+                                   #(custom % grammar mopts))
+                                 #(emit-symbol % grammar mopts))
+                     custom)
+
+         output (cond  custom-fn (custom-fn token)
+                       as        (if (or (fn? as)
+                                         (var? as))
+                                   (as token) as)
+                       emit      (emit token grammar mopts)
+                       :else     (pr-str token))]
+     output)))
+
+(defn emit-with-decorate
+  "customisable emit function for global vars"
+  {:added "4.0"}
+  [_ [_ opts form] grammar mopts]
+  (*emit-fn* form grammar mopts))
+
+(defn emit-with-uuid
+  "injects uuid for testing"
+  {:added "4.0"}
+  [_ [_ & [seed0 seed1 :as seeds]] grammar mopts]
+  (let [code-fn (fn [x] (cond (or (number? x) (string? x))
+                              (h/hash-code x)
+
+                              :else (h/hash-code (h/strn x))))
+        uuid  (str (if (not-empty seeds)
+                     (java.util.UUID. (code-fn (or seed0 (rand)))
+                                      (code-fn (or seed1 (rand))))
+                     (java.util.UUID/randomUUID)))]
+    (str uuid)))
+
+(defn emit-with-rand
+  "injects uuid for testing"
+  {:added "4.0"}
+  [_ [_ & [type]] grammar mopts]
+  (let [token (case type
+                :int (rand-int Integer/MAX_VALUE)
+                (rand))]
+    (*emit-fn* token grammar mopts)))
+
+;;
+;; INVOKE
+;;
+
+(defn invoke-kw-parse
+  "seperates standard and keyword arguments"
+  {:added "3.0"}
+  ([args]
+   (let [idx (h/index-at keyword? args)]
+     (if (neg? idx)
+       [args []]
+       [(take idx args) (partition 2 (drop idx args))]))))
+
+(defn emit-invoke-kw-pair
+  "emits a kw argument pair"
+  {:added "3.0"}
+  ([[k v] grammar mopts]
+   (let [{:keys [assign]} (helper/get-options grammar [:default :invoke])]
+     (str (str/snake-case (h/strn k)) assign (*emit-fn* v grammar mopts)))))
+
+(defn emit-invoke-args
+  "produces the string for invoke call"
+  {:added "3.0"}
+  ([args grammar mopts]
+   (let [[args kwargs] (invoke-kw-parse args)
+         cargs (concat (if (not-empty args)
+                         (emit-array args grammar mopts))
+                       (if (not-empty kwargs)
+                         (map #(emit-invoke-kw-pair % grammar mopts) kwargs)))]
+     cargs)))
+
+(defn emit-invoke-layout
+  "layout for invoke blocks
+
+   (emit-invoke-layout [\"ab\\nc\"
+                        \"de\\nf\"]
+                       helper/+default+ {})
+   => \"(ab\\nc,de\\nf)\""
+  {:added "4.0"}
+  ([str-array grammar mopts]
+   (let [{:keys [sep space]} (helper/get-options grammar [:default :invoke])]
+     (cond (or (some str/multi-line? str-array)
+               (and (not *multiline*)
+                    (< (apply + (map count str-array)) *max-len*)))
+           (-> (str/join (str sep space) str-array)
+               (wrapped-str [:default :invoke] grammar))
+
+           :else
+           (h/-> (str/join (str sep "\n" (str/spaces 2)
+                                )
+                           str-array)
+                 (str "\n" (str/spaces 2) % "\n")
+                 (wrapped-str [:default :invoke] grammar)
+                 (str/indent-rest *indent*))))))
+
+(defn emit-invoke-raw
+  "invoke call for reserved ops"
+  {:added "3.0"}
+  ([raw args grammar mopts]
+   (let [{:keys [sep space]} (helper/get-options grammar [:default :invoke])
+         isep (str sep space)
+         cargs (emit-invoke-args args grammar mopts)]
+     (str raw  (emit-invoke-layout cargs grammar mopts)))))
+
+(defn emit-invoke-static
+  "generates a static call, alternat"
+  {:added "3.0"}
+  ([[sym & args] grammar mopts]
+   (let [sns (namespace sym)
+         sfn (name sym)
+         {:keys [static]} (helper/get-options grammar [:default :invoke])]
+     (emit-invoke-raw (str sns static sfn) args grammar mopts))))
+
+(defn emit-invoke-typecast
+  "generates typecast expression"
+  {:added "3.0"}
+  ([form grammar mopts]
+   (assert (<= 2 (count form)) (str "At least two arguments for cast"))
+   (let [{:keys [start end]} (helper/get-options grammar [:default :invoke])
+         sym   (last form)
+         casts (map name (butlast form))]
+     (str start start (str/join " " casts) end (*emit-fn* sym grammar mopts) end))))
+
+(defn emit-invoke
+  "general invoke call, incorporating keywords"
+  {:added "3.0"}
+  ([_ [sym & args :as form] grammar mopts]
+   (let [{:keys [custom keyword-fn]} (get-in grammar [:default :invoke])]
+     (cond custom
+           (custom form grammar mopts)
+
+           (keyword? sym)
+           (cond keyword-fn
+                 (keyword-fn form grammar mopts)
+
+                 (namespace sym)
+                 (emit-invoke-static form grammar mopts)
+
+                 :else
+                 (emit-invoke-typecast form grammar mopts))
+
+           :else
+           (emit-invoke-raw (emit-wrapping sym grammar mopts) args grammar mopts)))))
+
+;;
+;; New Constructor Call
+;;
+
+(defn emit-new
+  "invokes a constructor"
+  {:added "3.0"}
+  ([raw [sym & more :as args] grammar mopts]
+   (assert (<= 1 (count args)) (str "One or more arguments for " raw))
+   (let [sym (if (keyword? sym)
+               (name sym)
+               sym)]
+     (str raw " " (emit-invoke raw (cons sym more) grammar mopts)))))
+
+(defn emit-class-static-invoke
+  "creates"
+  {:added "4.0"}
+  ([raw [sym field & args] grammar mopts]
+   (let [{:keys [static]} (helper/get-options grammar [:default :invoke])]
+     (cond (keyword? field)
+           (str sym (or raw static) (name field))
+
+           :else
+           (emit-invoke-raw (str sym (or raw static) field) args grammar mopts)))))
+
+;;
+;; INDEX
+;;
+
+(defn emit-index-entry
+  "classifies the index entry"
+  {:added "3.0"}
+  ([v grammar mopts]
+   (cond (symbol? v)
+         (do (assert (nil? (namespace v)) "No namespace")
+             (str "." (emit-symbol v grammar mopts)))
+
+         (h/form? v)
+         (let [sym  (first v)
+               sym  (if (string? sym)
+                      (symbol sym)
+                      sym)
+               _     (assert (symbol? sym))
+               {:keys [apply]}   (helper/get-options grammar [:default :invoke])
+               braces (meta sym)]
+           (emit-invoke-raw (str apply
+                                 (emit-symbol sym grammar mopts)
+                                 (if (not-empty braces)
+                                   (*emit-fn* braces grammar mopts)
+                                   ""))
+                            (rest v) grammar mopts))
+
+         (vector? v)
+         (do (assert (= 1 (count v)) "Only one index")
+             (let [{:keys [start end]}   (helper/get-options grammar [:default :index])]
+               (str start (*emit-fn* (first v) grammar mopts) end)))
+
+
+         (set? v)
+         (str "." (*emit-fn* v grammar mopts))
+
+         :else (h/error "Not valid" {:input v}))))
+
+(defn emit-index
+  "creates an indexed expression"
+  {:added "3.0"}
+  ([raw args grammar mopts]
+   (assert (<= 2 (count args)) (str "Two or more arguments for raw" raw))
+   (let [[sym & more] args
+         index (mapv #(emit-index-entry % grammar mopts) more)
+         sym  (emit-wrapping sym grammar mopts)]
+     (apply str sym index))))
+
+;; Ops
+;;
+
+(defn emit-op
+  "helper for the emit op"
+  {:added "3.0"}
+  ([key [sym & args :as form] {:keys [reserved] :as grammar} mopts & [expansion]]
+   (let [{:keys [op emit transform raw default type] :as props} (get reserved sym)]
+     (case emit
+
+       ;; WHITESPACE
+       :discard       ""
+       :free          (emit-free props form grammar mopts)
+       :squash        (emit-squash key form grammar mopts)
+       :comment       (emit-comment key form grammar mopts)
+       :indent        (emit-indent key form grammar mopts)
+
+       ;; FORMS
+       :token         raw
+       :alias         (*emit-fn* (cons raw args) grammar mopts)
+       :unit          (emit-unit props form grammar mopts)
+       :internal      (emit-internal form grammar mopts)
+       :internal-str  (emit-internal-str form grammar mopts)
+       :pre           (emit-pre raw args grammar mopts)
+       :post          (emit-post raw args grammar mopts)
+       :prefix        (emit-prefix raw args grammar mopts)
+       :postfix       (emit-postfix raw args grammar mopts)
+       :infix         (emit-infix raw args grammar mopts)
+       :infix-        (emit-infix-pre raw args grammar mopts)
+       :infix*        (emit-infix-default raw args default grammar mopts)
+       :infix-if      (emit-infix-if form grammar mopts)
+       :bi            (emit-bi raw args grammar mopts)
+       :between       (emit-between raw args grammar mopts)
+       :assign        (emit-assign raw args grammar mopts)
+       :invoke        (emit-invoke-raw raw args grammar mopts)
+       :new           (emit-new raw args grammar mopts)
+       :static-invoke (emit-class-static-invoke raw args grammar mopts)
+       :index         (emit-index raw args grammar mopts)
+       :return        (emit-return raw args grammar mopts)
+       :macro         (emit-macro key form grammar mopts)
+       :template      (emit-macro key form grammar mopts)
+
+       ;; LANGUAGE SPECIFIC GLOBAL
+       :with-global   (emit-with-global key form grammar mopts)
+
+       ;; LANGUAGE SPECIFIC DECORATIONS
+       :with-decorate (emit-with-decorate key form grammar mopts)
+
+       ;; LANGUAGE HELPERS
+       :with-uuid     (emit-with-uuid key form grammar mopts)
+       :with-rand     (emit-with-rand key form grammar mopts)
+
+       ;; RESTRICTED SYMBOLS
+       :throw         (h/error "Not allowed as op" {:symbol sym :form form})
+
+       ;; HANDLE ERROR
+       (if-let [f (get expansion emit)]
+         (f key props form grammar mopts)
+         (h/error "No matching clause"
+                  {:emit emit
+                   :key key
+                   :symbol sym
+                   :form form
+                   :props props}))))))
+
+
+(defn form-key
+  "returns the key associated with the form"
+  {:added "3.0"}
+  ([form {:keys [banned reserved] :as grammar}]
+   (let [key (helper/form-key-base form)
+         check-fn  (fn [val input]
+                     (if-let [m (get reserved val)]
+                       [(:op m) (or (:type m) :statement)]
+                       input))
+         [key type check?]  (cond (vector? key) key
+
+                                 :else
+                                 (check-fn (first form)
+                                           [:invoke :invoke]))
+         _ (if (get banned key)
+             (h/error "Disallowed in form" {:form form :key key :type type}))]
+     [key type check?])))
+
+;;
+;;
+;;
+
+(def +emit-lookup+
+  {:token    #'emit-token
+   :invoke   #'emit-invoke
+   :macro    #'emit-macro})
+
+(defn emit-common-loop
+  "emits the raw string"
+  {:added "4.0"}
+  ([form grammar mopts]
+   (emit-common-loop form
+                     grammar
+                     mopts
+                     +emit-lookup+
+                     emit-op))
+  ([form grammar mopts fn-lookup fn-default]
+   (let [output-fn (fn [[key type]]
+                     (let [emit-fn (or (get fn-lookup type)
+                                       fn-default)]
+                       (emit-fn key form grammar mopts)))
+         [key type check? :as input] (form-key form grammar)]
+     (cond check?
+           (or (emit-reserved-value form grammar mopts)
+               (output-fn input))
+
+           :else
+           (output-fn input)))))
+
+(defn emit-common
+  "emits a string based on grammar"
+  {:added "4.0"}
+  [form grammar mopts]
+  (binding [*emit-fn* emit-common-loop]
+    (emit-common-loop form grammar mopts)))
+
+
+(comment
+
+  (./import)
+  (./create-tests))

--- a/src/bb/lang/base/emit_data.clj
+++ b/src/bb/lang/base/emit_data.clj
@@ -1,0 +1,282 @@
+(ns bb.lang.base.emit-data
+  (:require [bb.string :as str]
+            [bb.lib :as h]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.emit-helper :as helper]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.util :as ut]))
+
+;;
+;; DATA
+;;
+
+(defn default-map-key
+  "emits a default map key"
+  {:added "4.0"}
+  [key grammar nsp]
+  (let [key-str (if (keyword? key)
+                  (ut/sym-default-str key)
+                  key)]
+    (common/*emit-fn* key-str grammar nsp)))
+
+(defn emit-map-key
+  "emits the map key"
+  {:added "4.0"}
+  ([form grammar mopts]
+   (cond (keyword? form)
+         (let [convert (or (get-in grammar [:data :map-entry :keyword])
+                           :string)
+               tok (case convert
+                     :symbol  (symbol (h/strn form))
+                     :string  (h/strn form)
+                     :keyword form)]
+           (common/*emit-fn* tok grammar mopts))
+
+         :else
+         (common/*emit-fn* form grammar mopts))))
+
+(defn emit-map-entry
+  "emits the map entry"
+  {:added "3.0"}
+  ([[k v] grammar mopts]
+   (let [{:keys [start end sep space assign key-fn val-fn]
+          :or {key-fn emit-map-key
+               val-fn common/*emit-fn*}} (helper/get-options grammar [:data :map-entry])
+         val-e (val-fn v grammar mopts)
+         val-e (if (str/multi-line? val-e)
+                 (str/indent-rest val-e 2)
+                 val-e)]
+     (str start (str/join (str assign space)
+                          [(key-fn k grammar mopts)
+                           val-e])
+          end))))
+
+(defn emit-singleline-array?
+  "checks that array is all single lines
+
+   (emit-singleline-array? [\"1\" \"2\" \"3\"])
+   => true
+
+   (emit-singleline-array? [\"1\" \"\\n2\" \"3\"])
+   => false"
+  {:added "4.0"}
+  [body-arr]
+  (and (every? str/single-line? body-arr)
+       (and (not common/*multiline*)
+            (< (apply + (map count body-arr)) common/*max-len*))))
+
+(defn emit-maybe-multibody
+  "checks that array is all single lines
+
+   (emit-maybe-multibody [\"1\" \"2\"] \"hello\")
+   => \"2hello\"
+
+   (emit-maybe-multibody [\"1\" \"2\"] \"\\nhello\")
+   => \"1  \\n  hello\""
+  {:added "4.0"}
+  [[prefix-yes prefix-no] body & [indent]]
+  (if (str/multi-line? body)
+    (str prefix-yes (str/indent body (or indent
+                                     (+ 2 common/*indent*))))
+    (str prefix-no body)))
+
+(defn emit-coll-layout
+  "constructs the collection"
+  {:added "4.0"}
+  ([key indent str-array grammar mopts]
+   (let [{:keys [sep space tighten] :as opts} (helper/get-options grammar [:data key])]
+     (cond (emit-singleline-array? str-array)
+           (-> (str/join sep str-array)
+               (common/wrapped-str [:data key] grammar))
+
+           tighten
+           (-> (str/join (str sep "\n  ") str-array)
+               (common/wrapped-str [:data key] grammar)
+               (str/indent indent))
+
+           :else
+           (-> (str "\n"
+                    (str/indent
+                     (str "  "
+                          (str/join (str sep "\n  ") str-array)
+                          "\n")
+                     indent))
+               (common/wrapped-str [:data key] grammar))))))
+
+(defn emit-coll
+  "emits a collection"
+  {:added "3.0"}
+  ([key form grammar mopts]
+   (emit-coll key form grammar mopts common/*emit-fn*))
+  ([key form grammar mopts emit-fn]
+   (let [indent     common/*indent*
+         form      (if (map? form)
+                     (sort-by  (fn [[k v]]
+                                 (cond (= k :#)
+                                       -1
+
+                                       (= k :..)
+                                       1
+
+                                       :else 0))
+                               (seq form))
+                     form)
+         str-array (binding [common/*indent* 0]
+                     (common/emit-array form grammar mopts emit-fn))]
+     (emit-coll-layout key indent str-array grammar mopts))))
+
+(defn emit-data-standard
+  "emits either a custom string or default coll"
+  {:added "4.0"}
+  ([key form grammar mopts]
+   (let [{:keys [custom]} (helper/get-options grammar [:data key])]
+     (if custom
+       (custom form grammar mopts)
+       (emit-coll key form grammar mopts)))))
+
+(defn emit-data
+  "main function for data forms"
+  {:added "3.0"}
+  ([key form grammar mopts]
+   (let [emit (get-in grammar [:data key :emit])]
+     (cond emit
+           (emit form grammar mopts)
+
+           (= key :map-entry)
+           (emit-map-entry form grammar mopts)
+
+           :else
+           (emit-data-standard key form grammar mopts)))))
+
+(defn emit-quote
+  "emit quote structures
+
+   (emit-quote nil nil ''(1 2 3) +grammar+ {})
+   => \"(1,2,3)\""
+  {:added "4.0"}
+  [key props [sym & args :as form] grammar mopts]
+  (if (== 1 (count args))
+    (let [coll (first args)]
+      (cond (vector? coll)
+            (emit-data :free coll grammar mopts)
+
+            (h/form? coll)
+            (emit-data :tuple coll  grammar mopts)
+
+            :else
+            (emit-data :tuple [coll] grammar mopts)))
+    (emit-data :tuple args grammar mopts)))
+
+(defn emit-table-group
+  "gets table group
+
+   (emit-table-group [:a 1 :b 2 :c :d])"
+  {:added "4.0"}
+  ([args]
+   (let [is-key (fn [x] (or (keyword? x)
+                             (and (h/form? x)
+                                  (= :% (first x)))))]
+     (loop [[e :as args] args
+            out []]
+       (cond (empty? args)
+             out
+
+             (is-key e)
+             (cond (or (is-key (second args))
+                       (empty? (rest args)))
+                   (recur (rest args)
+                          (conj out (symbol (h/strn e))))
+
+                   :else
+                   (recur (drop 2 args)
+                          (conj out (vec (take 2 args)))))
+
+             :else
+             (recur (rest args)
+                    (conj out e)))))))
+
+(defn emit-table
+  "emit quote structures
+
+   (emit-table nil nil '(tab :a 1 :b 2) +grammar+ {})
+   => \"{\\\"a\\\":1,\\\"b\\\":2}\""
+  {:added "4.0"}
+  ([_ _ [_ & args] grammar mopts]
+   (let [args (emit-table-group args)
+         entry-fn (fn [e]
+                    (if (vector? e)
+                      (emit-map-entry e grammar mopts)
+                      (common/*emit-fn* e grammar mopts)))
+         indent     common/*indent*
+         str-array (binding [common/*indent* 0]
+                     (mapv entry-fn args))]
+     (emit-coll-layout :map indent str-array grammar mopts))))
+
+;;
+;; TESTING
+;;
+
+(defn test-data-loop
+  "emit for data structures
+
+   (test-data-loop '[(+ 1 2)]
+                         +grammar+
+                         {})
+   => \"[(+ 1 2)]\"
+
+   (test-data-loop '{:a (+ 1 2)}
+                         +grammar+
+                         {})
+   => \"{[:a (+ 1 2)]}\"
+
+   (test-data-loop '#{(+ 1 2)}
+                         +grammar+
+                         {})
+   => throws
+
+
+   [:quote]
+   (test-data-loop ''((+ A B) C)
+                         +grammar+
+                         {})
+   => \"((+ A B),C)\"
+
+   (test-data-loop ''[(+ A B) C]
+                         +grammar+
+                         {})
+   => \"(+ A B),C\"
+
+   [:table]
+   (test-data-loop '(tab :a (+ 1 2) :b 2)
+                         +grammar+
+                         {})
+   => \"{\\\"a\\\":(+ 1 2),\\\"b\\\":2}\"
+
+   (test-data-loop '(tab 1 (+ 1 2) 3 4 5)
+                         +grammar+
+                         {})
+   => \"{1,(+ 1 2),3,4,5}\""
+  {:added "4.0" :adopt true}
+  [form grammar mopts]
+  (common/emit-common-loop form
+                           grammar
+                           mopts
+                           (assoc common/+emit-lookup+
+                                  :data emit-data)
+                           (fn [key form grammar mopts]
+                             (common/emit-op key form grammar mopts
+                                             {:quote emit-quote
+                                              :table emit-table}))))
+
+(defn test-data-emit
+  [form grammar mopts]
+  (binding [common/*emit-fn* test-data-loop]
+    (test-data-loop form grammar mopts)))
+
+(comment
+
+  (comment
+    :quote         (emit-quote args grammar mopts)
+    :table         (emit-table form grammar mopts))
+
+  )

--- a/src/bb/lang/base/emit_fn.clj
+++ b/src/bb/lang/base/emit_fn.clj
@@ -1,0 +1,215 @@
+(ns bb.lang.base.emit-fn
+  (:require [bb.string :as str]
+            [bb.lib :as h]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.emit-helper :as helper]
+            [bb.lang.base.emit-data :as data]
+            [bb.lang.base.emit-block :as block]))
+
+(defn emit-input-default
+  "create input arg strings"
+  {:added "3.0"}
+  ([{:keys [force modifiers type symbol value] :as arg} assign grammar mopts]
+   (let [{:keys [start end]} (helper/get-options grammar [:default :index])
+         {:keys [reversed hint]
+          :as invoke}  (helper/get-options grammar [:default :invoke])
+         {vmod true kmod false} (if (:vector-last (helper/get-options grammar [:default :modifier]))
+                                  (group-by vector? modifiers)
+                                  {false modifiers})
+         {:keys [uppercase]} (:type invoke)
+         arr-fn (fn [mod]
+                  (if (keyword? mod)
+                    (cond-> (name mod)
+                      uppercase (str/upper-case))
+                    (common/*emit-fn* mod grammar mopts)))
+         tmod   (if type
+                  (vec type)
+                  [])
+
+         tmodarr (mapv arr-fn tmod)
+         kmodarr (mapv arr-fn kmod)
+         mod-rev?    (and (or (empty tmodarr)
+                              (not-empty kmodarr))
+                          reversed)
+         mod-has?    (or (not-empty tmodarr)
+                         (not-empty kmodarr))
+         mod-sym     (str (if symbol
+                            (common/*emit-fn* symbol grammar mopts))
+                          (if (and mod-rev?
+                                   mod-has?)
+                            hint))
+         mixarr    (concat (if (not mod-rev?)
+                             (concat kmodarr tmodarr)
+                             (if (not= kmodarr mod-has?)
+                               kmodarr))
+                           (filter not-empty [mod-sym])
+                           (if mod-rev? mod-has?))
+
+         #_#_
+         _         (h/prn {:mod-rev? mod-rev?
+                           :tmodarr tmodarr
+                           :kmodarr kmodarr
+                           :mod-sym mod-sym
+                           :modifiers modifiers
+                           :mixarr  mixarr
+                           :mod-has? mod-has?})
+
+         mixstr (str/join " "
+                          (filter (fn [x]
+                                    (if (seq x)
+                                      (not-empty x)
+                                      x))
+                                  mixarr))]
+     (str mixstr
+          (if (not-empty vmod)
+            (str/join
+             (map (fn [arr]
+                    (str start
+                         (if-let [n (first arr)]
+                           (common/*emit-fn* n grammar mopts))
+                         end))
+                  vmod)))
+          (if (or force value)
+            (str " " assign " " (common/*emit-fn* value grammar mopts)))))))
+
+(defn emit-hint-type
+  "emits the return type"
+  {:added "4.0"}
+  ([type name suffix grammar mopts]
+   (let [arr  (cond-> (:- (meta name))
+                :then vec
+                (not-empty suffix) (conj suffix))]
+
+     (str/join " " (map (fn [v]
+                          (cond (or (keyword? v)
+                                    (string? v)
+                                    (and (vector? v)
+                                         (empty? v)))
+                                (cond-> (h/strn v)
+                                  (:uppercase type) (str/upper-case))
+
+                                :else (common/*emit-fn* v grammar mopts)))
+                        arr)))))
+
+(defn emit-def-type
+  "emits the def type"
+  {:added "4.0"}
+  ([name suffix grammar mopts]
+   (let [{:keys [type]} (helper/get-options grammar [:default :define])]
+     (emit-hint-type type name suffix grammar mopts))))
+
+(defn emit-fn-type
+  "returns the function type"
+  {:added "3.0"}
+  ([name suffix grammar mopts]
+   (let [{:keys [type]} (helper/get-options grammar [:default :invoke])]
+     (emit-hint-type type name suffix grammar mopts))))
+
+(defn emit-fn-block
+  "gets the block options for a given grammar"
+  {:added "4.0"}
+  [key grammar]
+  (h/merge-nested (get-in grammar [:default :function])
+                  (get-in grammar [:function key])))
+
+(defn emit-fn-preamble-args
+  "constructs the function preamble args"
+  {:added "4.0"}
+  ([key args grammar mopts]
+   (let [args  (helper/emit-typed-args args grammar)
+         {:keys [sep space assign start end multiline]}
+         (h/merge-nested (helper/get-options grammar [:default :function :args])
+                         (get-in grammar [:function key :args]))]
+     (map #(emit-input-default % assign grammar mopts)
+          args))))
+
+(defn emit-fn-preamble
+  "constructs the function preamble"
+  {:added "4.0"}
+  ([[key name args] grammar mopts]
+   (let [iargs (emit-fn-preamble-args key args grammar mopts)
+         {:keys [prefix]} (helper/get-options grammar [:default :function])
+         {:keys [sep space assign start end multiline]}
+         (h/merge-nested (helper/get-options grammar [:default :function :args])
+                         (get-in grammar [:function key :args]))]
+     (str (if prefix (str prefix " "))
+          (if name (common/*emit-fn* name grammar mopts))
+          space
+          (cond (empty? iargs) (str start end)
+
+                multiline
+                (str start
+                     (common/with-indent [2]
+                       (str (common/newline-indent)
+                            (str/join (str sep (common/newline-indent))
+                                      iargs)))
+                     (common/newline-indent)
+                     end)
+
+                :else
+                (str start (str/join (str sep space) iargs) end))))))
+
+(defn emit-fn
+  "emits a function template"
+  {:added "3.0"}
+  ([key [tag & body] grammar mopts]
+   (let [[name body] (if (symbol? (first body))
+                       [(first body) (rest body)]
+                       [nil body])
+         [args & body] body
+         header-only?  (:header (meta name))
+         {:keys [compressed] :as block} (emit-fn-block key grammar)
+         {:keys [enabled assign space after]}   (helper/get-options grammar [:default :typehint])
+         typestr   (emit-fn-type name (or (:raw block) (h/strn tag)) grammar mopts)
+         prestr    (emit-fn-preamble [key name args] grammar mopts)
+         hintstr   (cond (or (not enabled)
+                             (empty? typestr)) ""
+
+                         after (str assign space typestr)
+
+                         :else (str typestr space assign))
+         blockstr  (if header-only?
+                     (get-in grammar [:default :common :statement])
+                     (binding [common/*compressed* compressed]
+                       (block/emit-block-body key block body grammar mopts)))]
+     (cond enabled
+           (cond after
+                 (str/join space (filter not-empty [prestr hintstr blockstr]))
+
+
+                 :else
+                 (str/join space (filter not-empty [hintstr prestr blockstr])))
+
+           (not-empty typestr)
+           (str typestr " " prestr blockstr)
+
+           :else
+           (str prestr " " blockstr)))))
+
+;;
+;;
+;;
+
+(defn test-fn-loop
+  "add blocks, fn, var and const to emit"
+  {:added "4.0"}
+  [form grammar mopts]
+  (common/emit-common-loop form
+                           grammar
+                           mopts
+                           (assoc common/+emit-lookup+
+                                  :data data/emit-data
+                                  :block block/emit-block)
+                           (fn [key form grammar mopts]
+                             (case key
+                               :fn (emit-fn :function form grammar mopts)
+                               (common/emit-op key form grammar mopts
+                                               {:quote data/emit-quote
+                                                :table data/emit-table})))))
+
+(defn test-fn-emit
+  "add blocks, fn, var and const to emit"
+  {:added "4.0"}
+  [form grammar mopts]
+  (binding [common/*emit-fn* test-fn-loop]
+    (test-fn-loop form grammar mopts)))

--- a/src/bb/lang/base/emit_helper.clj
+++ b/src/bb/lang/base/emit_helper.clj
@@ -1,0 +1,279 @@
+(ns bb.lang.base.emit-helper
+  (:require [bb.string :as str]
+            [bb.lib :as h]
+            [bb.lang.base.util :as ut]))
+
+(defn default-emit-fn
+  "the default emit function"
+  {:added "4.0"}
+  [form grammar mopts]
+  (pr-str form))
+
+(defn pr-single
+  "prints a single quoted string"
+  {:added "3.0"}
+  ([s]
+   (-> (pr-str s)
+       (str/replace #"'" "\\\\'")
+       (str/replace #"^\"" "'")
+       (str/replace #"\"$" "'")
+       (str/replace #"\\\"" "\""))))
+
+(def +sym-replace+
+  {\- "_"
+   \* "__"
+   \? "p"
+   \! "f"
+   \= "_eq"
+   \< "_lt"
+   \> "_gt"})
+
+(def +default+
+  {:type   :std/algol
+   :banned #{:set :keyword}
+   :allow  {:assign #{:symbol}}
+   :highlight '#{return break set= br}
+   :default {:modifier  {:vector-last true}
+             :comment   {:prefix "//" :suffix ""}
+             :common    {:start  "(" :end ")"
+                         :space " "
+                         :assign "="
+                         :statement ";"
+                         :range ":"
+                         :sep ","
+                         :namespace "."
+                         :namespace-full "____"
+                         :access "."
+                         :static "."
+                         :apply "."
+                         :line-spacing 1}
+             :symbol    {:full {:replace {\. "_"}
+                                :sep "_"}
+                         :global identity}
+             :index     {:start "[" :end "]"
+                         :offset 0  :end-inclusive false}
+             :invoke    {:space ""}
+             :macro     {:statement ""}
+             :block     {:statement ""
+                         :parameter {:start "(" :end ")"}
+                         :body      {:start "{" :end "}"}}
+             :typehint  {:enabled false :assign "->" :space " " :after false}
+             :function  {:raw "function"
+                         :args      {:start "(" :end ")" :space ""}
+                         :body      {:start "{" :end "}"}}
+             :module    {:key-fn #'ut/sym-default-str
+                         :allow  '#{defn def defgen defclass defabstract}}}
+   :token  {:string     {:quote nil}
+            :symbol     {:replace +sym-replace+}}
+   :data   {:map        {:start "{" :end "}" :space ""}
+            :map-entry  {:start ""  :end ""  :assign ":" :space "" :keyword :string}
+            :vector     {:start "[" :end "]" :space ""}
+            :tuple      {:start "(" :end ")" :space "" :tighten true}
+            :free       {:start ""  :end ""  :space ""}}
+   :block  {:branch     {:control {:elseif {:raw "else if"}}}
+            :switch     {:control {:default {:parameter {:start " " :end ""}
+                                             :body      {:start ":" :end ""}}}}}
+   :define {:defglobal  {:raw "global"}
+            :def        {:raw "def"}}})
+
+(defn get-option
+  "gets either the path option or the default one"
+  {:added "3.0"}
+  ([grammar path option]
+   (let [default [:default :common]]
+     (or (get-in grammar (conj path option))
+         (get-in grammar (conj default option))))))
+
+(defn get-options
+  "gets the path option merged with defaults"
+  {:added "3.0"}
+  ([grammar path]
+   (merge (get-in grammar [:default :common])
+          (get-in grammar path))))
+
+;;
+;; CLASSIFY
+;;
+
+(defn form-key-base
+  "gets the key for a form
+
+   (form-key-base :a)
+   => [:keyword :token true]
+
+   (form-key-base ())
+   => :expression"
+  {:added "4.0"}
+  [form]
+  (cond (char? form)      [:char :token true]
+        (keyword? form)   [:keyword :token true]
+        (symbol? form)    [:symbol :token true]
+
+        (h/form? form)    :expression
+
+        (number? form)    [:number :token]
+        (boolean? form)   [:boolean :token]
+        (h/regexp? form)  [:regex :token]
+
+        (string? form)    [:string :token]
+        (nil? form)       [:nil :token]
+        (uuid? form)      [:uuid :token]
+
+        (map? form)       [:map :data]
+        (map-entry? form) [:map-entry :data]
+        (vector? form)    [:vector :data]
+        (set? form)       [:set :data]
+
+        :else (h/error "Not Valid" {:input form
+                                    :type (type form)})))
+
+(defn basic-typed-args
+  "typed args without grammar checks
+
+   (mapv (juxt meta identity)
+         (basic-typed-args '(:int i, :const :int j)))
+   => '[[{:- [:int]} i]
+        [{:- [:const :int]} j]]"
+  {:added "4.0"}
+  ([args]
+   (:all (reduce (fn [{:keys [modifiers all]} curr]
+                   (if (symbol? curr)
+                     {:modifiers []
+                      :all (conj all (with-meta curr {:- modifiers}))}
+                     {:modifiers (conj modifiers curr)
+                      :all all}))
+                 {:modifiers []
+                  :all []}
+                 args))))
+
+;;
+;; DEFINE
+;;
+
+(defn emit-typed-allowed-args
+  "allowed declared args other than symbols"
+  {:added "4.0"}
+  [[all curr] grammar]
+  (let [{:keys [modifiers]} curr
+        arg (last modifiers)]
+    (if (contains? (get-option grammar [:allow] :assign)
+                   (first (h/seqify (form-key-base arg))))
+      [all (-> curr
+               (assoc :symbol arg
+                      :modifiers (vec (butlast modifiers))
+                      :assign true))]
+      (h/error "Cannot assign to non symbol" {:curr curr :all all}))))
+
+(defn emit-typed-args
+  "create types args from declarationns"
+  {:added "3.0"}
+  ([args grammar]
+   (loop [all  []
+          curr {:modifiers []}
+          [sym & more :as args] args]
+     (cond (empty? args)
+           (if (:symbol curr)
+             (conj all curr)
+             all)
+
+           (= := sym)
+           (if (:symbol curr)
+             (recur all (assoc curr :assign true :force true) more)
+             (let [[all curr] (emit-typed-allowed-args [all curr] grammar)]
+               (recur all (assoc curr :force true) more)))
+
+           (= :% sym)
+           (if (:symbol curr)
+             (recur (conj all curr) {:modifiers [(first more)]} (rest more))
+             (recur all (update curr :modifiers conj (first more)) (rest more)))
+
+           (:assign curr)
+           (recur (conj all (assoc curr :value sym))
+                  {:modifiers []}
+                  more)
+
+           (and (not (:symbol curr))
+                (list? sym)
+                (not (neg? (h/index-at #{:=} sym))))
+           (let [[symbol val] (remove #{:=} sym)]
+             (recur (conj all (assoc curr :symbol symbol :value val))
+                    {:modifiers []}
+                    more))
+
+           (or (symbol? sym)
+               (and (set? sym)
+                    (-> grammar
+                        :allow
+                        :assign
+                        :set))
+               (and (map? sym)
+                    (-> grammar
+                        :allow
+                        :assign
+                        :map))
+               (and (vector? sym)
+                    (-> grammar
+                        :allow
+                        :assign
+                        :vector))
+               (and (h/form? sym)
+                    (= 'quote (first sym))
+                    (-> grammar
+                        :allow
+                        :assign
+                        :quote))
+               (and (h/form? sym)
+                    (= := (first sym))))
+           (if (:symbol curr)
+             (recur (conj all curr) {:modifiers [] :symbol sym} more)
+             (recur all (assoc curr :symbol sym) more))
+
+           (and (h/form? sym)
+                (keyword? (first sym)))
+           (if (:symbol curr)
+             (recur (conj all curr) {:type   (butlast sym)
+                                     :symbol (last sym)}
+                    more)
+             (recur all (assoc curr
+                               :symbol sym
+                               :type   (butlast sym)
+                               :symbol (last sym))
+                    more))
+
+           (or (keyword? sym) (vector? sym))
+           (if (:symbol curr)
+             (recur (conj all curr) {:modifiers [sym]} more)
+             (recur all (update curr :modifiers conj sym) more))
+
+           (:symbol curr)
+           (recur (conj all (assoc curr :value sym)) {:modifiers []} more)
+
+           :else
+           (h/error "Not a valid input" {:input sym
+                                         :all all
+                                         :curr curr})))))
+
+(defn emit-symbol-full
+  "emits a full symbol"
+  {:added "4.0"}
+  [sym ns grammar]
+  (let [dopts (get-in grammar [:default :common])
+        sopts (get-in grammar [:default :symbol :full])
+        topts (get-in grammar [:token :symbol])
+        sym-str  (if ns
+                   (str ns
+                        (:namespace-full dopts)
+                        (name sym))
+                   (name sym))]
+    (cond->> (. sym-str (replaceAll "\\." (or (:namespace-sep dopts)
+                                              "_")))
+      :then   (replace (merge (:replace sopts)
+                              (:replace topts)))
+      :then   (apply str))))
+
+(defn emit-type-record
+  "formats to standard"
+  {:added "4.0"}
+  [{:keys [modifiers symbol]}]
+  {:symbol (ut/sym-default-str symbol)
+   :type (name (first modifiers))})

--- a/src/bb/lang/base/emit_preprocess.clj
+++ b/src/bb/lang/base/emit_preprocess.clj
@@ -1,0 +1,398 @@
+(ns bb.lang.base.emit-preprocess
+  (:require [bb.string :as str]
+            [bb.lib :as h]
+            [bb.lang.base.util :as ut]))
+
+(def ^:dynamic *macro-form* nil)
+
+(def ^:dynamic *macro-grammar* nil)
+
+(def ^:dynamic *macro-opts* nil)
+
+(def ^:dynamic *macro-splice* nil)
+
+(def ^:dynamic *macro-skip-deps* nil)
+
+(defn macro-form
+  "gets the current macro form"
+  {:added "4.0"}
+  []
+  *macro-form*)
+
+(defn macro-opts
+  "gets current macro-opts"
+  {:added "4.0"}
+  []
+  *macro-opts*)
+
+(defn macro-grammar
+  "gets the current grammar"
+  {:added "4.0"}
+  []
+  *macro-grammar*)
+
+(defmacro ^{:style/indent 1}
+  with:macro-opts
+  "bind macro opts"
+  {:added "4.0"}
+  [[mopts] & body]
+  `(binding [*macro-opts* ~mopts]
+     ~@body))
+
+;;
+;; RAW FORMS TO INPUT FORMS
+;;
+
+(defn to-input-form
+  "processes a form
+
+   (def hello 1)
+
+   (to-input-form '(@! (+ 1 2 3)))
+   => '(!:template (+ 1 2 3))
+
+   (to-input-form '(-/Class$$new))
+   => (any '(static-invoke -/Class \"new\")
+           nil)
+
+   (to-input-form '(Class$$new 1 2 3))
+   => (any '(static-invoke Class \"new\" 1 2 3)
+           nil)
+
+   (to-input-form '@#'hello)
+   => '(!:deref (var bb.lang.base.emit-preprocess-test/hello))
+
+   (to-input-form '@(+ 1 2 3))
+   => '(!:eval (+ 1 2 3))
+
+   (to-input-form '(@.lua (do 1 2 3)))
+   => '(!:lang {:lang :lua} (do 1 2 3))"
+  {:added "4.0"}
+  [[tag input & more :as x]]
+  (cond (h/form? tag)
+        (cond (= 'clojure.core/deref (first tag))
+              (let [tok (second tag)]
+                (cond (= tok '!)
+                      (list '!:template input)
+
+                      (and (symbol? tok)
+                           (str/starts-with? (str tok) "."))
+                      (apply list '!:lang {:lang (keyword (subs (str tok) 1))}
+                             input more)
+
+                      (and (h/form? tok)
+                           (= 'var (first tok)))
+                      (list '!:eval
+                            (apply list
+                                   (list 'var (or (h/var-sym (resolve (second tok)))
+                                                  (h/error "Var not found" {:input (second tok)})))
+                                   (if input
+                                     (cons input more)
+                                     more)))
+
+                      :else
+                      (apply list '!:decorate (apply vec (rest tag))
+                             input more)))
+
+              (= 'clojure.core/unquote (first tag))
+              (h/error "Not supported" {:input x}))
+
+        (= 'clojure.core/deref tag)
+        (if (and (h/form? input)
+                 (= 'var (first input)))
+          (list '!:deref (list 'var (or (h/var-sym (resolve (second input)))
+                                        (h/error "Var not found" {:input (second input)}))))
+          (list '!:eval input))))
+
+(defn to-input
+  "converts a form to input (extracting deref forms)"
+  {:added "4.0"}
+  [raw]
+  (let [check-fn (fn [child]
+                   (and (h/form? child)
+                        (= (first child) '(clojure.core/unquote !))))]
+    (h/prewalk (fn [x]
+                 (or (cond (h/pointer? x)
+                           (ut/sym-full x)
+
+                           (and *macro-splice*
+                                (or (vector? x)
+                                    (h/form? x))
+                                (some check-fn x))
+                           (-> (into (empty x)
+                                     (reduce (fn [acc child]
+                                               (if (check-fn child)
+                                                 (apply conj acc (eval (second child)))
+                                                 (conj acc child)))
+                                             (empty x)
+                                             x))
+                               (with-meta (meta x)))
+
+                           (h/form? x)
+                           (to-input-form x))
+                     x))
+               raw)))
+
+;;
+;; INPUT FORMS TO STAGED FORMS
+;;
+
+(defn get-fragment
+  "gets the fragment given a symbol and modules"
+  {:added "4.0"}
+  ([sym modules mopts]
+   (if (and (symbol? sym)
+            (namespace sym))
+     (let [[sym-ns sym-id] (ut/sym-pair sym)
+           {:keys [id link]} (:module mopts)
+           sym-module (or (if (= sym-ns id) id)
+                          (get link sym-ns)
+                          (first (filter #(= % sym-ns)
+                                         (vals link)))
+                          sym-ns)]
+       (or (get-in modules [sym-module :fragment sym-id])
+           (if-let [et (and (get-in modules [sym-module :code sym-id]))]
+             (if (= :defrun (:op-key et))
+               (apply list 'do (drop 2 (:form et))))))))))
+
+(defn process-namespaced-resolve
+  "resolves symbol in current namespace"
+  {:added "4.0"}
+  [sym modules {:keys [module
+                       entry] :as mopts}]
+  (let [[sym-ns sym-id] (ut/sym-pair sym)
+        sym-module (or (if (= '- sym-ns) (:id module))
+                       (get (:link module) sym-ns)
+                       (if (get modules sym-ns) sym-ns))]
+    (cond (not sym-module)
+          (h/error "Cannot resolve Module." {:input sym
+                                             :current module
+                                             :modules (keys modules)})
+
+          :else
+          [sym-module sym-id
+           (ut/sym-full sym-module sym-id)])))
+
+(defn process-namespaced-symbol
+  "process namespaced symbols"
+  {:added "4.0"}
+  [sym modules {:keys [module
+                       entry] :as mopts} deps deps-fragment walk-fn]
+  (let [walk-fn (or walk-fn identity)
+        [sym-module sym-id sym-full] (process-namespaced-resolve sym modules mopts)
+        module-id (:id module)]
+    (cond (and (= sym-module module-id)
+               (= sym-id (:id entry)))
+          sym-full
+
+          :else
+          (let [[type entry] (or (if-let [e (get-in modules [sym-module :code sym-id])]
+                                   [:code  e])
+                                 (if-let [e (get-in modules [sym-module :fragment sym-id])]
+                                   [:fragment e])
+                                 (if-let [e (get-in modules [sym-module :header sym-id])]
+                                   [:header e])
+                                 (h/error (str "Upstream not found: "
+                                               (ut/sym-full {:module sym-module
+                                                             :id sym-id}))
+                                          {:entry (ut/sym-full {:module sym-module
+                                                                :id sym-id})
+                                           :opts    (select-keys mopts [:lang
+                                                                        :module])}))]
+            (or (if *macro-skip-deps* sym-full)
+                (case type
+                  (:header :code)   (let [{:keys [op]} entry
+                                          _  (if (and (get (:suppress module) sym-module)
+                                                      (not= 'defglobal op))
+                                               (h/error "Suppressed module - macros only"
+                                                        {:sym [sym-module sym-id]
+                                                         :module (dissoc module :code :fragment)}))
+
+                                          _ (if (not (or *macro-skip-deps*
+                                                         (not deps)
+                                                         (= 'defglobal op)
+                                                         (= 'defrun op)))
+                                              (vswap! deps conj sym-full))]
+                                      sym-full)
+                  :fragment  (let [{:keys [template standalone form]} entry
+                                   _ (if (not (or *macro-skip-deps*
+                                                  (not deps-fragment)))
+                                       (vswap! deps-fragment conj sym-full))]
+                               (cond (not template) form
+
+                                     (not standalone)
+                                     (h/error "Pure templates are not allowed in body"
+                                              {:module sym-module
+                                               :id sym-id
+                                               :form sym})
+
+                                     (or (h/form? standalone)
+                                         (symbol? standalone))
+                                     (walk-fn (:standalone entry))
+
+                                     :else
+                                     (let [args (second form)]
+                                       (list 'fn args (list 'return
+                                                            (apply template args))))))))))))
+
+(defn process-inline-assignment
+  "prepares the form for inline assignment"
+  {:added "4.0"}
+  [form modules mopts & [unwrapped]]
+  (let [[_ bind-form & rdecl] (reverse form)
+        [f & args] bind-form
+        [f-module f-id] (process-namespaced-resolve f modules mopts)
+        _  (or (get-in modules [f-module :code f-id])
+               (h/error "Code entry not found:" {:input f
+                                                 :form form}))]
+    (concat (reverse rdecl)
+            [(with-meta (cons (cond-> (ut/sym-full f-module f-id)
+                                (not unwrapped) (volatile!))
+                              args)
+               {:assign/inline true})])))
+
+(defn to-staging-form
+  "different staging forms"
+  {:added "4.0"}
+  [form grammar modules mopts deps-fragment walk-fn]
+  (let [fsym      (first form)
+        reserved  (get-in grammar [:reserved (first form)])]
+    (cond (= fsym '!:template)
+          (walk-fn (eval (second form)))
+
+          ('#{!:lang !:eval !:deref !:decorate} fsym)
+          (volatile! form)
+
+          (= :template (:type reserved))
+          (walk-fn ((:macro reserved) form))
+
+          (= :hard-link (:type reserved))
+          (walk-fn (cons (:raw reserved) (rest form)))
+
+          (and (= :def-assign (:emit reserved))
+               (= :inline (last form)))
+          (walk-fn (process-inline-assignment form modules mopts))
+
+          :else
+          (let [fe (get-fragment (first form)
+                                 modules
+                                 mopts)]
+            (if (:template fe)
+              (do (if deps-fragment
+                    (vswap! deps-fragment conj (ut/sym-full fe)))
+                  (walk-fn (try (binding [*macro-form* form]
+                                  (apply (:template fe) (rest form)))
+                                (catch Throwable t
+                                  (throw t)))))
+              form)))))
+
+(defn process-standard-symbol
+  [sym mopts deps-native]
+  (let [symstr (name sym)
+        idx  (.indexOf (name sym) ".")
+        _  (if (<= 0 idx)
+             (let [symlead (symbol (subs symstr 0 idx))
+                   import  (get-in mopts
+                                   [:module
+                                    :native-lu
+                                    symlead])]
+               (if (and import deps-native)
+                 (vswap! deps-native
+                         update
+                         import
+                         (fnil #(conj % symlead) #{}))))
+             (let [import  (get-in mopts
+                                   [:module
+                                    :native-lu
+                                    sym])]
+               (if (and import deps-native)
+                 (vswap! deps-native
+                         update
+                         import
+                         (fnil #(conj % sym) #{})))))]
+    sym))
+
+(defn to-staging
+  "converts the stage"
+  {:added "4.0"}
+  [input grammar modules mopts]
+  (binding [*macro-skip-deps* false
+            *macro-grammar* grammar
+            *macro-opts* mopts]
+    (let [deps  (volatile! #{})
+          deps-fragment   (volatile! #{})
+          deps-native  (volatile! {})
+
+          _   (if-let [includes (-> mopts :module :includes)]
+                (doseq [inc-id includes]
+                  (if-let [module (get modules inc-id)]
+                    (doseq [entry (vals (:code module))]
+                      (vswap! deps conj (ut/sym-full entry))))))
+
+          form  (h/prewalk
+                 (fn walk-fn [form]
+                   (cond (h/form? form)
+                         (to-staging-form form grammar modules mopts deps-fragment walk-fn)
+
+                         (and (symbol? form))
+                         (if (namespace form)
+                           (process-namespaced-symbol form modules mopts deps deps-fragment walk-fn)
+                           (process-standard-symbol form mopts deps-native))
+
+                         :else form))
+                 input)
+          form  (h/postwalk (fn [form] (if (volatile? form)
+                                         @form
+                                         form))
+                            form)]
+
+      [form @deps @deps-fragment @deps-native])))
+
+(defn to-resolve
+  "resolves only the code symbols (no macroexpansion)"
+  {:added "4.0"}
+  [input grammar modules mopts]
+  (binding [*macro-skip-deps* true
+            *macro-grammar* grammar
+            *macro-opts* mopts]
+    (let [form  (h/prewalk
+                 (fn walk-fn [form]
+
+                   (cond  (and (h/form? form)
+                               (= (first form) '!:template))
+                          (walk-fn (eval (second form)))
+
+                          (symbol? form)
+                          (if (namespace form)
+                            (process-namespaced-symbol form modules mopts nil nil identity)
+                            (process-standard-symbol form mopts nil))
+
+                          :else
+                          form))
+                 input)]
+      form)))
+
+(defn find-natives
+  [entry mopts]
+  (let [deps-quoted  (volatile! [])
+        deps-native  (volatile! {})
+        _    (h/postwalk
+              (fn [form]
+                (if (and (list? form)
+                         (= (first form) 'quote))
+                  (vswap! deps-quoted conj (second form)))
+                form)
+              (:form entry))
+        _    (h/postwalk
+              (fn [form]
+                (cond (symbol? form)
+                      (process-standard-symbol form mopts deps-native)
+
+                      :else form))
+              @deps-quoted)]
+    @deps-native))
+
+(comment
+
+  (comment
+    (get-in (bb.lang/grammar :lua) [:reserved 'var*])))

--- a/src/bb/lang/base/emit_special.clj
+++ b/src/bb/lang/base/emit_special.clj
@@ -1,0 +1,141 @@
+(ns bb.lang.base.emit-special
+  (:require [bb.string :as str]
+            [bb.lib :as h]
+            [bb.lang.base.emit-preprocess :as preprocess]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.emit-helper :as helper]
+            [bb.lang.base.emit-data :as data]
+            [bb.lang.base.book :as book]))
+
+(defn emit-with-module-all-ids
+  "emits the module given snapshot in opts"
+  {:added "4.0"}
+  [snapshot lang module-id allow]
+  (let [book   (book/book-from snapshot lang)
+        module (book/get-module book module-id)
+
+        #_#_#_#_
+        export-sym (get-in module [:export :as])
+        _   (if (not export-sym)
+              (h/error "No Export for Module" {:module module-id
+                                               :export (get module :export)}))
+        ids (->> (:code module)
+                 (vals)
+                 (sort-by (juxt :priority :time :line))
+                 (filter (fn [{:keys [op id]}]
+                           (and (allow op))))
+                 (map :id))]
+    ids))
+
+(defn emit-with-module
+  "emits the module given snapshot in opts"
+  {:added "4.0"}
+  [_ _ [_ lang module-id] grammar {:keys [snapshot] :as mopts}]
+  (let [lang      (or lang
+                      (:lang mopts))
+        module-id (or module-id
+                      (-> mopts :module :id))
+        {:keys [key-fn allow]}  (helper/get-options grammar [:default :module])
+        token-opts  (get-in grammar [:token :symbol])
+
+        module-key-fn (fn [id]
+                        (->> (name id)
+                             (replace (:replace token-opts))
+                             (apply str)
+                             key-fn))
+        ids     (emit-with-module-all-ids snapshot lang module-id allow)
+        args    (mapv (fn [id]
+                        [(module-key-fn id)
+                         (symbol (name module-id)
+                                 (name id))])
+                      ids)]
+    (data/emit-table nil nil (cons 'tab args) grammar mopts)))
+
+;;
+;; EVAL and LANG
+;;
+
+(defn emit-with-preprocess
+  "emits an eval form
+
+   (emit-with-preprocess '(L.core/sub 1 2)
+                         (:grammar prep/+book-min+)
+                         {:lang :lua
+                          :module   (lib/get-module +library-ext+ :lua 'L.core)
+                          :snapshot (lib/get-snapshot +library-ext+)})
+   => \"(- 1 2)\""
+  {:added "4.0"}
+  [form grammar {:keys [lang snapshot] :as mopts}]
+  (let [book    (book/book-from snapshot lang)
+        [body]  (-> (preprocess/to-input form)
+                    (preprocess/to-staging grammar
+                                           (:modules book)
+                                           mopts))]
+    (common/*emit-fn* body grammar mopts)))
+
+(defn emit-with-eval
+  "emits an eval form"
+  {:added "4.0"}
+  [_ _ [_ form] grammar {:keys [lang snapshot] :as mopts}]
+  (emit-with-preprocess (eval form) grammar mopts))
+
+(defn emit-with-deref
+  "emits an embedded var"
+  {:added "4.0"}
+  [_ _ [_ form] grammar mopts]
+  (if (= 'var (first form))
+    (emit-with-preprocess (deref (eval form)) grammar mopts)
+    (h/error "Needs to be a clojure.lang.Var")))
+
+(defn emit-with-lang
+  "emits an embedded eval"
+  {:added "4.0"}
+  [_ _ form grammar {:keys [snapshot] :as mopts}]
+  (let [[_ {:keys [lang module] :as opts
+            :or {module (h/ns-sym)}}
+         body] form
+        book   (or (book/book-from snapshot lang)
+                   (h/error "Lang not found." {:lang lang
+                                               :available (keys snapshot)}))
+        {:keys [grammar]} book
+        module (book/get-module book module)
+        mopts  (merge (assoc mopts :book book :module module)
+                      opts)
+        [body] (-> (preprocess/to-input body)
+                   (preprocess/to-staging grammar
+                                          (:modules book)
+                                          mopts))]
+    (common/*emit-fn* body grammar mopts)))
+
+;;
+;; TESTING
+;;
+
+(defn test-special-loop
+  "test step for special ops"
+  {:added "4.0"}
+  [form grammar mopts]
+  (common/emit-common-loop form
+                           grammar
+                           mopts
+                           (assoc common/+emit-lookup+
+                                  :data data/emit-data)
+                           (fn [key form grammar mopts]
+                             (common/emit-op key form grammar mopts
+                                             {:quote data/emit-quote
+                                              :table data/emit-table
+                                              :with-module emit-with-module
+                                              :with-lang emit-with-lang
+                                              :with-eval emit-with-eval
+                                              :with-deref emit-with-deref}))))
+
+(defn test-special-emit
+  "test function for special ops"
+  {:added "4.0"}
+  [form grammar mopts]
+  (binding [common/*emit-fn* test-special-loop]
+    (test-special-loop form grammar mopts)))
+
+(comment
+  (./create-tests)
+  )

--- a/src/bb/lang/base/emit_top_level.clj
+++ b/src/bb/lang/base/emit_top_level.clj
@@ -1,0 +1,146 @@
+(ns bb.lang.base.emit-top-level
+  (:require [bb.string :as str]
+            [bb.lib :as h]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.emit-helper :as helper]
+            [bb.lang.base.emit-data :as data]
+            [bb.lang.base.emit-assign :as assign]
+            [bb.lang.base.emit-block :as block]
+            [bb.lang.base.emit-special :as special]
+            [bb.lang.base.emit-fn :as fn]))
+
+(defn transform-defclass-inner
+  "transforms the body to be fn.inner and var.inner"
+  {:added "4.0"}
+  [body]
+  (mapv (fn [form]
+          (if (h/form? form)
+            (cond (= (first form) 'fn)
+                  (cons 'fn.inner (cons (with-meta (second form)
+                                          (meta form))
+                                        (drop 2 form)))
+
+                  (= (first form) 'var)
+                  (cons 'var.inner (rest form))
+
+                  :else form)
+            form))
+        body))
+
+(defn emit-def
+  "creates the def string"
+  {:added "3.0"}
+  ([key [tag sym body :as form] grammar mopts]
+   (let [{:keys [raw space assign statement] :as props} (helper/get-options grammar [:define key])
+         typestr (fn/emit-def-type sym (or raw
+                                           (h/strn tag))
+                                   grammar mopts)
+         sym-str   (case key
+                     :defglobal (common/emit-with-global nil [nil sym] grammar mopts)
+                     (common/*emit-fn* sym grammar mopts))]
+     (str typestr
+          (if (not-empty typestr) space)
+          sym-str
+          space assign space
+          (common/*emit-fn* body grammar mopts)
+          statement))))
+
+(defn emit-declare
+  "emits declared
+
+   (emit-declare :def
+                 '(declare a b c)
+                 +grammar+
+                 {})
+   => \"def a,b,c\""
+  {:added "4.0"}
+  ([key [tag & syms] grammar mopts]
+   (let [{:keys [raw space sep]}  (helper/get-options grammar [:define key])
+         pre (str (or raw tag))]
+     (str pre space (str/join sep (common/emit-array (vec syms) grammar mopts))))))
+
+(defn emit-top-level
+  "generic define form
+
+   (binding [common/*emit-fn* common/emit-common]
+     (emit-top-level :defn
+                     '(defn abc [a := 0]
+                        (+ 1 2 3))
+                     +grammar+
+                     {}))
+   => \"function abc(a = 0){\\n  1 + 2 + 3;\\n}\""
+  {:added "3.0"}
+  ([key [tag sym & more :as form] grammar mopts]
+   (let [module-id (or (-> mopts :entry :module)
+                       (-> mopts :module :id))
+         sym (if (and
+                  (not (:inner (meta sym)))
+                  (or (#{:full :host} (:layout mopts))
+                      (= key :defglobal)))
+               (do (or module-id
+                       (h/error "Module not found"
+                                (select-keys mopts [:module :entry])))
+                   (with-meta (symbol (name module-id)
+                                      (name sym))
+                     (meta sym)))
+               sym)
+         form (apply list tag sym more)]
+     (case key
+       :def         (emit-def key form grammar mopts)
+       :defglobal   (emit-def key form grammar mopts)
+       :defrun      (block/emit-do  (drop 2 form) grammar mopts)
+       :defn        (fn/emit-fn  key form grammar mopts)
+       :defgen      (fn/emit-fn  key form grammar mopts)
+       :declare     (emit-declare key form grammar mopts)))))
+
+(def +emit-lookup+
+  (assoc common/+emit-lookup+
+         :data  #'data/emit-data
+         :block #'block/emit-block))
+
+(defn emit-form
+  "creates a customisable emit and integrating both top-level and statements
+   ^:hiddn
+
+   (emit-form :custom
+              '(custom 1 2 3)
+              (assoc-in +grammar+
+                        [:reserved 'custom]
+                        {:emit  (fn [_ _ _]
+                                  'CUSTOM)})
+             [])
+   => 'CUSTOM"
+  {:added "4.0"}
+  ([key [sym & args :as form] {:keys [reserved] :as grammar} mopts]
+   (let [{:keys [emit type] :as props} (get reserved sym)]
+     (if common/*trace*
+       (h/prn form))
+     (try
+       (cond (or (fn? emit)
+                 (var? emit))
+             (emit form grammar mopts)
+
+             (keyword? emit)
+             (common/emit-op key form grammar mopts
+                             {:def-assign #'assign/emit-def-assign
+                              :quote #'data/emit-quote
+                              :table #'data/emit-table
+                              :with-module #'special/emit-with-module
+                              :with-lang  #'special/emit-with-lang
+                              :with-eval  #'special/emit-with-eval
+                              :with-deref #'special/emit-with-deref})
+
+             :else
+             (case type
+               :fn         (fn/emit-fn key form grammar mopts)
+               :def        (emit-top-level key form grammar mopts)
+               :hard-link  (common/*emit-fn* (cons (:raw props) (rest form))
+                                             grammar mopts)
+               (h/error "Missing key" {:key key
+                                       :symbol sym
+                                       :props props
+                                       :entry (get reserved sym)})))
+       (catch Throwable t
+         (if common/*explode*
+           (h/prn :EMIT-ERROR form t))
+         (throw t))))))

--- a/src/bb/lang/base/grammar.clj
+++ b/src/bb/lang/base/grammar.clj
@@ -1,0 +1,307 @@
+(ns bb.lang.base.grammar
+  (:require [bb.lib :as h :refer [defimpl]]
+            [bb.string :as str]
+            [bb.lang.base.grammar-spec :as spec]
+            [bb.lang.base.grammar-macro :as macro]
+            [bb.lang.base.grammar-xtalk :as xtalk]))
+
+(defn gen-ops
+  "generates ops
+
+   (gen-ops 'bb.lang.base.grammar-spec \"spec\")
+   => vector?"
+  {:added "4.0"}
+  [ns shortcut]
+  (->> (ns-publics ns)
+       (keep (fn [[k var]]
+               (let [kname  (name k)]
+                 (if (str/starts-with? kname "+")
+                   [(keyword (subs kname 4 (dec (count kname))))
+                    var]))))
+       (sort-by (fn [[k var]]
+                  (:line (meta var))))
+       (mapv    (fn [[k var]]
+                  [k (symbol shortcut (name (h/var-sym var)))]))))
+
+(defn collect-ops
+  "collects alll ops together
+
+   (collect-ops +op-all+)
+   => map?"
+  {:added "4.0"}
+  [arr]
+  (->> (map-indexed (fn [i [k v]]
+                      [k (with-meta
+                           (h/map-juxt [:op identity]
+                                       v)
+                           {:order i})])
+                    arr)
+       (into {})))
+
+(def ^{:generator (fn []
+                    (vec (concat (gen-ops 'bb.lang.base.grammar-spec "spec")
+                                 (gen-ops 'bb.lang.base.grammar-macro "macro")
+                                 (gen-ops 'bb.lang.base.grammar-xtalk "xtalk"))))}
+  +op-all+
+  (->> [[:builtin spec/+op-builtin+]
+        [:builtin-global spec/+op-builtin-global+]
+        [:builtin-module spec/+op-builtin-module+]
+        [:builtin-helper spec/+op-builtin-helper+]
+        [:free-control spec/+op-free-control+]
+        [:free-literal spec/+op-free-literal+]
+        [:math       spec/+op-math+]
+        [:compare    spec/+op-compare+]
+        [:logic      spec/+op-logic+]
+        [:counter    spec/+op-counter+]
+        [:return     spec/+op-return+]
+        [:throw      spec/+op-throw+]
+        [:await             spec/+op-await+]
+        [:async             spec/+op-async+]
+        [:data-table        spec/+op-data-table+]
+        [:data-shortcuts    spec/+op-data-shortcuts+]
+        [:data-range        spec/+op-data-range+]
+        [:vars              spec/+op-vars+]
+        [:bit               spec/+op-bit+]
+        [:pointer           spec/+op-pointer+]
+        [:fn                spec/+op-fn+]
+        [:block             spec/+op-block+]
+        [:control-base      spec/+op-control-base+]
+        [:control-general   spec/+op-control-general+]
+        [:control-try-catch spec/+op-control-try-catch+]
+        [:top-base     spec/+op-top-base+]
+        [:top-global   spec/+op-top-global+]
+        [:class        spec/+op-class+]
+        [:for          spec/+op-for+]
+        [:coroutine    spec/+op-coroutine+]
+        [:macro         macro/+op-macro+]
+        [:macro-arrow   macro/+op-macro-arrow+]
+        [:macro-let     macro/+op-macro-let+]
+        [:macro-xor     macro/+op-macro-xor+]
+        [:macro-case    macro/+op-macro-case+]
+        [:macro-forange macro/+op-macro-forange+]
+        [:xtalk-core    xtalk/+op-xtalk-core+]
+        [:xtalk-proto   xtalk/+op-xtalk-proto+]
+        [:xtalk-global  xtalk/+op-xtalk-global+]
+        [:xtalk-custom  xtalk/+op-xtalk-custom+]
+        [:xtalk-math xtalk/+op-xtalk-math+]
+        [:xtalk-type xtalk/+op-xtalk-type+]
+        [:xtalk-bit  xtalk/+op-xtalk-bit+]
+        [:xtalk-lu   xtalk/+op-xtalk-lu+]
+        [:xtalk-obj  xtalk/+op-xtalk-obj+]
+        [:xtalk-arr  xtalk/+op-xtalk-arr+]
+        [:xtalk-str  xtalk/+op-xtalk-str+]
+        [:xtalk-js   xtalk/+op-xtalk-js+]
+        [:xtalk-return  xtalk/+op-xtalk-return+]
+        [:xtalk-socket  xtalk/+op-xtalk-socket+]
+        [:xtalk-iter    xtalk/+op-xtalk-iter+]
+        [:xtalk-cache   xtalk/+op-xtalk-cache+]
+        [:xtalk-thread  xtalk/+op-xtalk-thread+]
+        [:xtalk-file    xtalk/+op-xtalk-file+]
+        [:xtalk-b64     xtalk/+op-xtalk-b64+]
+        [:xtalk-uri     xtalk/+op-xtalk-uri+]
+        [:xtalk-special xtalk/+op-xtalk-special+]]
+       (collect-ops)))
+
+(defn ops-list
+  "lists all ops in the grammar"
+  {:added "4.0"}
+  ([]
+   (map first (sort-by (comp :order meta second) +op-all+))))
+
+(defn ops-symbols
+  "gets a list of symbols"
+  {:added "4.0"}
+  []
+  (map (fn [k]
+         [k (mapcat :symbol (vals (get +op-all+ k)))])
+       (ops-list)))
+
+(defn ops-summary
+  "gets the symbol and op name for a given category"
+  {:added "4.0"}
+  ([& [ks]]
+   (mapv (fn [k]
+           [k (h/map-vals :symbol
+                          (get +op-all+ k))])
+         (or ks (ops-list)))))
+
+(defn ops-detail
+  "get sthe detail of the ops"
+  {:added "4.0"}
+  ([k]
+   (get +op-all+ k)))
+
+;;
+;;
+;;  Build Grammer Keywords
+;;
+;;
+
+(defn build
+  "selector for picking required ops in grammar"
+  {:added "3.0"}
+  ([]
+   (apply merge (vals +op-all+)))
+  ([& {:keys [lookup
+              include
+              exclude]
+       :or {lookup +op-all+}}]
+   (let [sel-fn (fn [[k tag entries]]
+                  (let [all (get lookup k)]
+                    (case tag
+                      :include (select-keys all entries)
+                      :exclude (apply dissoc all entries))))
+         selected (cond include
+                        (reduce (fn [out sel]
+                                  (cond (vector? sel)
+                                        (assoc out (first sel) (sel-fn sel))
+
+                                        :else
+                                        (assoc out sel (get lookup sel))))
+                                {}
+                                include)
+
+                        exclude
+                        (reduce (fn [out sel]
+                                  (cond (vector? sel)
+                                        (assoc out (first sel) (sel-fn sel))
+
+                                        :else
+                                        (dissoc out sel)))
+                                lookup
+                                exclude))]
+     (apply merge (vals selected)))))
+
+(defn build-min
+  "minimum ops example for a language"
+  {:added "4.0"}
+  [& [arr]]
+  (build :include (concat [:builtin
+                           :builtin-module
+                           :builtin-helper
+                           :free-control
+                           :free-literal
+                           :math
+                           :compare
+                           :logic
+                           :return
+                           :vars
+                           :fn
+                           :data-table
+                           :control-base
+                           :control-general
+                           :top-base
+                           :top-global
+                           :macro]
+                          arr)))
+
+(defn build-xtalk
+  "xtalk ops
+
+   (build-xtalk)
+   => map?"
+  {:added "4.0"}
+  []
+  (build :include [:xtalk-core
+                   :xtalk-proto
+                   :xtalk-global
+                   :xtalk-custom
+                   :xtalk-math
+                   :xtalk-type
+                   :xtalk-bit
+                   :xtalk-lu
+                   :xtalk-obj
+                   :xtalk-arr
+                   :xtalk-str
+                   :xtalk-js
+                   :xtalk-return
+                   :xtalk-socket
+                   :xtalk-iter
+                   :xtalk-cache
+                   :xtalk-thread
+                   :xtalk-file
+                   :xtalk-b64
+                   :xtalk-uri
+                   :xtalk-special]))
+
+(defn build:override
+  "overrides existing ops in the map"
+  {:added "4.0"}
+  [build m]
+  (let [ks (h/difference (set (keys m))
+                         (set (keys build)))
+        _  (if (not-empty ks)
+             (h/error "Keys not in original map: " {:keys ks}))]
+    (h/merge-nested build m)))
+
+(defn build:extend
+  "adds new  ops in the map"
+  {:added "4.0"}
+  [build m]
+  (let [ks (h/intersection (set (keys m))
+                           (set (keys build)))
+        _  (if (not-empty ks)
+             (h/error "Keys in original map: " {:keys ks}))]
+    (merge build m)))
+
+(defn to-reserved
+  "convert op map to symbol map"
+  {:added "3.0"}
+  ([build]
+   (->> build
+        (mapcat (fn [[k m]]
+                  (map (fn [sym]
+                         [sym m])
+                       (:symbol m))))
+        (into {}))))
+
+(defn grammar-structure
+  "returns all the `:block` and `:fn` forms"
+  {:added "3.0"}
+  ([reserved]
+   (h/map-juxt [identity
+                (fn [k] (set (keys (h/filter-vals (comp #{k} :type) reserved))))]
+               [:block :def :fn])))
+
+(defn grammar-sections
+  "process sections witihin the grammar"
+  {:added "3.0"}
+  ([reserved]
+   (set (vals (h/keep-vals :section reserved)))))
+
+(defn grammar-macros
+  "process macros within the grammar"
+  {:added "3.0"}
+  ([reserved]
+   (set (keys (h/filter-vals (comp #{:def} :type) reserved)))))
+
+(defn- grammar-string
+  ([{:keys [tag structure reserved banned highlight macros sections] :as grammar}]
+   (str "#grammar " [tag] " "
+        (assoc structure
+               :sections sections
+               :ops (count reserved)
+               :banned banned
+               :highlight highlight
+               :macros macros))))
+
+(defimpl Grammer [tag emit structure reserved banned highlight]
+  :string grammar-string)
+
+(defn grammar?
+  "checks that an object is instance of grammar"
+  {:added "3.0"}
+  ([obj]
+   (instance? Grammer obj)))
+
+(defn grammar
+  "constructs a grammar"
+  {:added "3.0" :style/indent 1}
+  ([tag reserved template]
+   (-> template
+       (assoc :tag tag
+              :reserved reserved
+              :sections  (grammar-sections reserved)
+              :macros    (grammar-macros reserved)
+              :structure (grammar-structure reserved))
+       (map->Grammer))))

--- a/src/bb/lang/base/grammar_macro.clj
+++ b/src/bb/lang/base/grammar_macro.clj
@@ -1,0 +1,188 @@
+(ns bb.lang.base.grammar-macro
+  (:require [bb.lib :as h :refer [defimpl]]
+            [bb.lang.base.grammar-spec :as spec]))
+
+;;
+;; macros
+;;
+
+(defn tf-macroexpand
+  "macroexpands the current form"
+  {:added "3.0"}
+  ([form]
+   (macroexpand-1 form)))
+
+(defn tf-when
+  "transforms `when` to branch
+
+   (tf-when '(when true :A :B :C))
+   => '(br* (if true :A :B :C))"
+  {:added "3.0"}
+  ([[_ check & body]]
+   `(~'br* (~'if ~check ~@body))))
+
+(defn tf-if
+  "transforms `if` to branch
+
+   (tf-if '(if true :A :B))
+   => '(br* (if true :A) (else :B))"
+  {:added "3.0"}
+  ([[_ check then & [else]]]
+   `(~'br*
+     (~'if ~check ~then)
+     ~@(if else
+         `[(~'else ~else)]))))
+
+(defn tf-cond
+  "transforms `cond` to branch"
+  {:added "3.0"}
+  ([[_ check then & more]]
+   (let [args (partition 2 more)
+         [ei el] (if (= :else (first (last args)))
+                   [(butlast args) (last args)]
+                   [args nil])]
+     `(~'br*
+       (~'if ~check ~then)
+       ~@(map (fn [[check then]]
+                `(~'elseif ~check ~then))
+              ei)
+       ~@(if el
+           `[(~'else ~(second el))])))))
+
+(defn tf-let-bind
+  "converts to a statement"
+  {:added "4.0"}
+  ([[_ bindings & body]]
+   `(~'do* ~@(map
+              (fn [[sym val]]
+                (if (= '_ sym)
+                  val
+                  `(~'var ~sym := ~val)))
+              (partition 2 bindings))
+     ~@body)))
+
+(defn tf-case
+  "transforms the case statement to switch representation"
+  {:added "4.0"}
+  ([[_ val & options]]
+   (let [cs (partition-all 2 options)
+         [cs df] (if (= 1 (count (last cs)))
+                   [(butlast cs) [(last cs)]]
+                   [cs []])]
+     `(~'switch [~val]
+       ~@(map (fn [[val body]]
+                `(~'case [~val] ~body))
+              cs)
+       ~@(map (fn [[body]]
+                `(~'default ~body))
+              df)))))
+
+(defn tf-lambda-arrow
+  "generalized lambda transformation"
+  {:added "4.0"}
+  ([[_ & more]]
+   (let [[args & exprs] (if (= 1 (count more))
+                          [[] (first more)]
+                          more)
+         final   (last exprs)
+         body    (butlast exprs)]
+     `(~'fn ~args ~@body (~'return ~final)))))
+
+(defn tf-tcond
+  "transforms the ternary cond
+
+   (tf-tcond '(:?> :a a :b b :else c))
+   => '(:? :a [a (:? :b [b c])])"
+  {:added "4.0"}
+  ([[_ & more]]
+   {:op :tcond     :symbol '#{:?>}    :macro tf-tcond         :type :macro}
+   (let [pairs (map vec (partition 2 more))
+         _ (if (not= :else (first (last pairs)))
+             (h/error "ternary cond has to end with :else" {:form (last pairs)}))]
+     (reduce (fn [acc [q alt]]
+               (list :? q [alt acc]))
+             (last (last pairs))
+             (reverse (butlast pairs))))))
+
+(defn tf-xor
+  "transforms to xor using ternary if
+
+   (tf-xor '(xor a b))
+   => '(:? a b (not b))"
+  {:added "4.0"}
+  ([[_ a b]]
+   (list :? a b (list 'not b))))
+
+(defn tf-doto
+  "basic transformation for `doto` syntax"
+  {:added "4.0"}
+  ([[_ sym & forms]]
+   (let [sforms (map (fn [form]
+                       (apply list (first form) sym (rest form)))
+                     forms)]
+     (apply list 'do sforms))))
+
+(defn tf-do-arrow
+  "do:> transformation
+
+   (tf-do-arrow '(do:>
+                  1 2 (return 3)))
+   => '((quote ((fn [] 1 2 (return 3)))))"
+  {:added "4.0"}
+  ([[_ & body]]
+   `('((~'fn [] ~@body)))))
+
+(defn tf-forange
+  "creates the forange form
+
+   (tf-forange '(forange [i 10] (print i)))
+   => '(for [(var i 0) (< i 10) [(:= i (+ i 1))]] (print i))
+
+   (tf-forange '(forange [i [10 3 -2]] (print i)))
+   => '(for [(var i 10) (< i 3) [(:= i (- i 2))]] (print i))"
+  {:added "4.0"}
+  ([[_ [type? sym size params] & body]]
+   (let [[types sym size params] (if (keyword? type?)
+                                   [[type?] sym size params]
+                                   [nil type? sym size])
+         [start end step] (if (vector? size)
+                            size
+                            [0 size])
+         step (or step 1)
+         [sign step] (if (and (number? step)
+                              (neg? step))
+                       ['- (- step)]
+                       ['+ step])]
+     `(~'for [(~'var ~@types ~sym ~start) (~'< ~sym ~end) [(:= ~sym (~sign ~sym ~step))
+                                                           ~@params]]
+             ~@body))))
+
+(def +op-macro+
+  [{:op :tfirst    :symbol #{'->}     :emit :macro  :macro #'tf-macroexpand   :type :template}
+   {:op :tlast     :symbol #{'->>}    :emit :macro  :macro #'tf-macroexpand   :type :template}
+   {:op :doto      :symbol #{'doto}   :emit :macro  :macro  #'tf-doto     :type :block}
+   {:op :if        :symbol #{'if}     :emit :macro  :macro  #'tf-if       :type :block}
+   {:op :cond      :symbol #{'cond}   :emit :macro  :macro  #'tf-cond     :type :block}
+   {:op :when      :symbol #{'when}   :emit :macro  :macro  #'tf-when     :type :block}])
+
+(def +op-macro-arrow+
+  [{:op :dofn      :symbol #{'do:>}   :emit :macro :macro #'tf-do-arrow       :type :template}
+   {:op :fn-arrow  :symbol '#{fn:>}   :emit :macro :macro #'tf-lambda-arrow   :type :template}])
+
+(def +op-macro-let+
+  [{:op :let-bind  :symbol #{'let}    :macro #'tf-let-bind       :type :macro}])
+
+(def +op-macro-xor+
+  [{:op :txor      :symbol #{'xor}    :macro #'tf-xor            :type :macro}])
+
+(def +op-macro-case+
+  [{:op :switch     :symbol #{'switch}     :emit :inner
+    :type :block    :block  {:main #{:parameter  :body}
+                             :control [[:case     {:required true
+                                                   :main #{:parameter :body}}]
+                                       [:default  {:main #{:body}}]]}}
+   {:op :case       :symbol #{'case}   :emit :macro  :macro  #'tf-case     :type :block}])
+
+(def +op-macro-forange+
+  [{:op :forange :symbol '#{forange} :style/indent 1
+    :emit :macro  :macro  #'tf-forange  :type :block}])

--- a/src/bb/lang/base/grammar_spec.clj
+++ b/src/bb/lang/base/grammar_spec.clj
@@ -1,0 +1,294 @@
+(ns bb.lang.base.grammar-spec
+  (:require [bb.lib :as h :refer [defimpl]]
+            [bb.string :as str]))
+
+(def ^:dynamic *symbol* nil)
+
+(defn get-comment
+  "gets the comment access prefix for a language
+
+   (get-comment helper/+default+ {})
+   => \"//\""
+  {:added "4.0"}
+  [grammar _]
+  (-> grammar :default :comment :prefix))
+
+(defn format-fargs
+  "formats function inputs"
+  {:added "3.0"}
+  ([[doc? attr? & body]]
+   (let [[doc attr body] (h/fn:init-args doc? attr? body)
+         body (cond (vector? (first body))
+                    body
+
+                    (vector? (ffirst body))
+                    (first body)
+
+                    :else (h/error "Invalid body" {:body body}))]
+     [doc attr body])))
+
+(defn format-defn-mixins
+  "applies all mixins in order"
+  {:added "4.0"}
+  [m mixins]
+  (reduce (fn [m entry]
+            (cond (symbol? entry)
+                  ((resolve entry) m)
+
+                  (h/form? entry)
+                  (eval entry)
+
+                  (map? entry)
+                  (merge m (eval entry))
+
+                  :else m))
+          m
+          mixins))
+
+(defn format-defn
+  "standardize defn forms"
+  {:added "3.0"}
+  ([[op sym & args]]
+   (let [[doc attr body] (format-fargs args)
+         attr (merge attr {:doc doc})
+         {mixins :!
+          :as sym-meta} (meta sym)
+         mixed (if (not (nil? mixins))
+                 (binding [*symbol* sym]
+                   (format-defn-mixins (merge attr sym-meta)
+                                       (if (vector?  mixins)
+                                         mixins
+                                         [mixins]))))]
+     [attr
+      (concat (list op (with-meta sym
+                         (dissoc (merge sym-meta mixed) :!)))
+              body)])))
+
+(defn tf-for-index
+  "default for-index transform
+
+   (tf-for-index '(for:index
+                   [i [0 2 3]]))
+   => '(for [(var i := 0) (< i 2) (:= i (+ i 3))])"
+  {:added "4.0"}
+  [[_ [i [start stop step]] & body]]
+  (let [step (or step 1)
+        sign (if (and (number? step)
+                      (pos? step))
+               '<
+               '>)]
+    `(~'for [(var ~i := ~start) (~sign ~i ~stop) (:= ~i (~'+ ~i ~step))]
+      ~@body)))
+
+;;
+;; SPEC;
+;;
+
+(def +op-builtin+
+  [{:op :with-lang     :symbol #{'!:lang}      :emit :with-lang}
+   {:op :with-eval     :symbol #{'!:eval}      :emit :with-eval}
+   {:op :with-deref    :symbol #{'!:deref}     :emit :with-deref}
+   {:op :with-decorate :symbol #{'!:decorate}  :emit :with-decorate}
+   {:op :free          :symbol #{:-}           :emit :free      :sep " " :type :free}
+   {:op :squash        :symbol #{:%}           :emit :squash}
+   {:op :comment       :symbol #{:#}           :emit :comment   :value #'get-comment :type :free}
+   {:op :index         :symbol #{'.}           :emit :index     :value true   :raw "."  :free " "}
+   {:op :quote         :symbol #{'quote}       :emit :quote}
+   {:op :internal      :symbol #{'%}           :emit :internal}
+   {:op :internal-str  :symbol #{'-%%-}        :emit :internal-str}])
+
+(def +op-builtin-global+
+  [{:op :with-global   :symbol #{'!:G}         :emit :with-global}])
+
+(def +op-builtin-module+
+  [{:op :with-module   :symbol #{'!:module}    :emit :with-module}])
+
+(def +op-builtin-helper+
+  [{:op :with-uuid     :symbol #{'!:uuid}      :emit :with-uuid}
+   {:op :with-rand     :symbol #{'!:rand}      :emit :with-rand}])
+
+(def +op-free-control+
+  [{:op :c-slash     :symbol #{\\}           :emit :free       :raw "\n"  :value true   :sep " "  :type :free}
+   {:op :c-star      :symbol #{\*}           :emit :free       :raw "\n"  :value true   :sep " "  :type :free}
+   {:op :c-minus     :symbol #{\- 'comment}  :emit :discard    :raw " "   :value true   :free " " :sep " " :type :free}
+   {:op :c-vert      :symbol #{\|}           :emit :indent     :raw "|"   :value true}])
+
+(def +op-free-literal+
+  [{:op :c-null      :symbol #{\0}           :emit :throw   :raw ""    :value true   :free  ""}
+   {:op :c-hat       :symbol #{\^}           :emit :throw   :raw "^"   :value true   :free  "^"}
+   {:op :c-comma     :symbol #{\,}           :emit :throw   :raw ","   :value true   :free  ","}
+   {:op :c-colon     :symbol #{\:}           :emit :throw   :raw ":"   :value true   :free  ":" }
+   {:op :c-semicolon :symbol #{\;}           :emit :throw   :raw ";"   :value true   :free  ";" }
+   {:op :c-lparens   :symbol #{\(}           :emit :throw   :raw "("   :value true   :free  "(" }
+   {:op :c-rparens   :symbol #{\)}           :emit :throw   :raw ")"   :value true   :free  ")" }
+   {:op :c-lbracket  :symbol #{\[}           :emit :throw   :raw "["   :value true   :free  "["}
+   {:op :c-rbracket  :symbol #{\]}           :emit :throw   :raw "]"   :value true   :free  "]"}
+   {:op :c-lcurly    :symbol #{\{}           :emit :throw   :raw "["   :value true   :free  "{"}
+   {:op :c-rcurly    :symbol #{\}}           :emit :throw   :raw "}"   :value true   :free  "}"}
+   {:op :c-dquote    :symbol #{\"}           :emit :throw   :raw "\""  :value true   :free  "\""}
+   {:op :c-squote    :symbol #{\'}           :emit :throw   :raw "'"   :value true   :free  "'"}
+   {:op :c-at        :symbol #{\@}           :emit :throw   :raw "@"   :value true   :free  "@"}
+   {:op :c-tilda     :symbol #{\~}           :emit :throw   :raw "~"   :value true   :free  "~"}
+   {:op :c-backtick  :symbol #{\`}           :emit :throw   :raw "`"   :value true   :free  "`"}])
+
+(def +op-math+
+  [{:op :add         :symbol #{'+}           :emit :infix   :raw "+"}
+   {:op :mul         :symbol #{'*}           :emit :infix   :raw "*"}
+   {:op :sub         :symbol #{'-}           :emit :infix-  :raw "-"}
+   {:op :div         :symbol #{'/}           :emit :infix*  :raw "/"   :default 1}
+   {:op :pow         :symbol #{'pow}         :emit :bi      :raw "^"}
+   {:op :mod         :symbol #{'mod}         :emit :bi      :raw "%"}])
+
+(def +op-compare+
+  [{:op :eq          :symbol #{'==}          :emit :bi      :raw "=="}
+   {:op :neq         :symbol #{'not=}        :emit :bi      :raw "!="}
+   {:op :lt          :symbol #{'<}           :emit :infix   :raw "<"}
+   {:op :lte         :symbol #{'<=}          :emit :bi      :raw "<="}
+   {:op :gt          :symbol #{'>}           :emit :bi      :raw ">"}
+   {:op :gte         :symbol #{'>=}          :emit :bi      :raw ">="}])
+
+(def +op-logic+
+  [{:op :inif        :symbol #{:?}           :emit :infix-if}
+   {:op :not         :symbol #{'not}         :emit :pre     :raw "!"}
+   {:op :or          :symbol #{'or}          :emit :infix   :raw "||"}
+   {:op :and         :symbol #{'and}         :emit :infix   :raw "&&"}])
+
+(def +op-counter+
+  [{:op :incby       :symbol #{:+=}          :emit :assign   :raw "+="}
+   {:op :decby       :symbol #{:-=}          :emit :assign   :raw "-="}
+   {:op :mulby       :symbol #{:*=}          :emit :assign   :raw "*="}
+   {:op :incto       :symbol #{:++}          :emit :pre      :raw "++"}
+   {:op :decto       :symbol #{:--}          :emit :pre      :raw "--"}])
+
+(def +op-return+
+  [{:op :ret         :symbol #{'return}      :emit :return   :raw "return"}
+   {:op :break       :symbol #{'break}       :emit :return   :raw "break"}])
+
+(def +op-throw+
+  [{:op :throw       :symbol #{'throw}       :emit :return   :raw "throw"}])
+
+(def +op-await+
+  [{:op :await       :symbol #{'await}       :emit :return   :raw "await"}])
+
+(def +op-async+
+  [{:op :async       :symbol #{'async}       :emit :return   :raw "async"}])
+
+(def +op-data-table+
+  [{:op :table       :symbol #{'tab}         :emit :table}])
+
+(def +op-data-shortcuts+
+  [{:op :spread      :symbol #{:..}          :emit :pre  :raw "..."}])
+
+(def +op-data-range+
+  [{:op :range       :symbol #{:to}          :emit :between  :value true :raw ":"}])
+
+(def +op-vars+
+  [{:op :seteq       :symbol #{:=}           :emit :assign      :raw "="}
+   {:op :var         :symbol #{'var}         :emit :def-assign  :raw ""      :assign "="}])
+
+(def +op-bit+
+  [{:op :bor         :symbol #{'b:|}      :emit :infix    :raw "|"}
+   {:op :band        :symbol #{'b:&}      :emit :infix    :raw "&"}
+   {:op :bxor        :symbol #{'b:xor}    :emit :infix    :raw "^"}
+   {:op :bsr         :symbol #{'b:>>}     :emit :bi       :raw ">>"}
+   {:op :bsl         :symbol #{'b:<<}     :emit :bi       :raw "<<"}])
+
+(def +op-pointer+
+  [{:op :ptr-deref   :symbol '#{:&}  :raw "&" :emit :pre}
+   {:op :ptr-ref     :symbol '#{:*}  :raw "*" :emit :pre}])
+
+;;
+;; LAMBDA
+;;
+
+(def +op-fn+
+  [{:op   :fn        :symbol #{'fn}
+    :type :fn        :block  {:raw "function"
+                              :main #{:body}}}])
+
+(def +op-block+
+  [{:op   :block     :symbol #{'block}
+    :type :block     :block  {:raw ""
+                              :main #{:body}}}])
+
+;;
+;; BLOCKS
+;;
+
+
+(def +op-control-base+
+  [{:op :do*         :symbol #{'do*}        :emit :do*  :type :block}
+   {:op :do          :symbol #{'do}         :emit :do   :type :block}])
+
+(def +op-control-general+
+  [{:op :for         :symbol #{'for}
+    :type :block     :block  {:main  #{:parameter :body}}}
+   {:op :while       :symbol #{'while}
+    :type :block     :block  {:main #{:parameter :body}}}
+   {:op :branch      :symbol #{'br*}
+    :type :block     :block  {:main  #{}
+                              :raw ""
+	                      :control [[:if      {:required true
+	                                           :main #{:parameter :body}}]
+                                        [:elseif  {:main #{:parameter :body}}]
+                                        [:else    {:main #{:body}}]]}}])
+
+(def +op-control-try-catch+
+  [{:op :try         :symbol #{'try}
+    :type :block     :block  {:main #{:body}
+                              :control [[:catch   {:required true
+                                                   :main #{:parameter :body}}]
+                                        [:finally {:main #{:body}}]]}}])
+
+;;
+;; TOP LEVEL
+;;
+
+(def +op-top-base+
+  [{:op :defn        :symbol #{'defn 'defn- 'defabstract} :spec :defn
+    :type :def       :section :code             :fn true
+    :arglists '([sym doc? & [attr? & body]])
+    :format #'format-defn}
+
+   {:op :def         :symbol #{'def}        :spec :def
+    :type :def       :section :code
+    :arglists '([sym body])}
+
+   {:op :defrun      :symbol #{'defrun}     :spec :defrun
+    :type :def       :section :code
+    :arglists '([sym & body])}])
+
+(def +op-top-global+
+  [{:op :defglobal   :symbol #{'defglobal 'deftemp}  :spec :def
+    :type :def       :section :code         :raw ""
+    :arglists '([sym body])}])
+
+;;
+;; OBJECT ORIENTATED
+;;
+
+(def +op-class+
+  [{:op :new         :symbol #{'new}        :emit :new  :value true :raw "new"}
+   {:op :defclass    :symbol #{'defclass}   :spec :defclass
+    :type :def       :section :code         :abstract true}
+   {:op :static-invoke      :symbol #{'$}   :emit :static-invoke}
+   {:op :this        :symbol #{'this}       :emit :throw     :raw "this"  :value true}
+   {:op :super       :symbol #{'super}      :emit :invoke    :raw "super" :value true}
+   {:op :fn.inner    :symbol #{'fn.inner}   :type :fn :block  {:raw "" :main #{:body}}}
+   {:op :var.inner   :symbol #{'var.inner}  :assign "=" :raw "" :emit :def-assign}])
+
+(def +op-for+
+  [{:op :for-index   :symbol #{'for:index}     :emit :macro :macro #'tf-for-index :style/indent 1}
+   {:op :for-object  :symbol #{'for:object}    :emit :abstract :style/indent 1}
+   {:op :for-array   :symbol #{'for:array}     :emit :abstract :style/indent 1}
+   {:op :for-iter    :symbol #{'for:iter}      :emit :abstract :style/indent 1}
+   {:op :for-return  :symbol #{'for:return}    :emit :abstract :style/indent 1}
+   {:op :for-async   :symbol #{'for:async}     :emit :abstract :style/indent 1}
+   {:op :for-try     :symbol #{'for:try}       :emit :abstract :style/indent 1}])
+
+(def +op-coroutine+
+  [{:op :defgen    :symbol #{'defgen}   :spec :defgen
+    :type :def     :section :code       :abstract true :fn true
+    :arglists '([sym doc? & [attr? & body]])
+    :format #'format-defn}
+   {:op :yield     :symbol #{'yield}     :emit :return   :raw "yield"}])

--- a/src/bb/lang/base/grammar_xtalk.clj
+++ b/src/bb/lang/base/grammar_xtalk.clj
@@ -1,0 +1,447 @@
+(ns bb.lang.base.grammar-xtalk
+  (:require [bb.string :as str]
+            [bb.lang.base.emit-preprocess :as preprocess]
+            [bb.lib :as h]))
+
+(defn tf-throw
+  "wrapper for throw transform"
+  {:added "4.0"}
+  [[_ obj]]
+  (list 'throw obj))
+
+(defn tf-eq-nil?
+  "equals nil transform"
+  {:added "4.0"}
+  [[_ obj]]
+  (list '== nil obj))
+
+(defn tf-not-nil?
+  "not nil transform"
+  {:added "4.0"}
+  [[_ obj]]
+  (list 'not= nil obj))
+
+(defn tf-proto-create
+  "creates the prototype map"
+  {:added "4.0"}
+  [[_ m]] (list 'return m))
+
+(defn tf-has-key?
+  "has key default transform"
+  {:added "4.0"}
+  [[_ obj key check]]
+  (let [val (list 'not= (list 'x:get-key obj key) nil)]
+    (if check
+      (list '== check val)
+      val)))
+
+(defn tf-get-path
+  "get-in transform"
+  {:added "4.0"}
+  [[_ obj ks default]]
+  (let [val (if (symbol? obj)
+              (apply list '. obj (map vector ks))
+              (apply list '. (list 'quote (list obj)) (map vector ks)))]
+    (if default
+      (list 'or val default)
+      val)))
+
+(defn tf-get-key
+  "get-key transform"
+  {:added "4.0"}
+  [[_ obj k default]]
+  (let [val (if (symbol? obj)
+              (list '. obj [k])
+              (list '. (list 'quote (list obj)) [k]))]
+    (if default
+      (list 'or val default)
+      val)))
+
+(defn tf-set-key
+  "set-key transform"
+  {:added "4.0"}
+  [[_ obj k v]]
+  (list := (list '. obj [k])
+        v))
+
+(defn tf-del-key
+  "del-key transform"
+  {:added "4.0"}
+  [[_ obj k]]
+  (list 'x:del (list '. obj [k])))
+
+(defn tf-copy-key
+  "copy-key transform"
+  {:added "4.0"}
+  [[_ dst src idx]]
+  (let [[dk sk] (if (vector? idx)
+                  idx
+                  [idx idx])]
+    (tf-set-key [nil dst dk (tf-get-key [nil src sk])])))
+
+;;
+;;
+;;
+
+(defn tf-grammar-offset
+  "del-key transform"
+  {:added "4.0"}
+  []
+  (let [grammar preprocess/*macro-grammar*]
+    (or (get-in grammar [:default :index :offset]) 0)))
+
+(defn tf-grammar-end-inclusive
+  "gets the end inclusive flag"
+  {:added "4.0"}
+  []
+  (let [grammar preprocess/*macro-grammar*]
+    (get-in grammar [:default :index :end-inclusive])))
+
+(defn tf-offset-base
+  "calculates the offset"
+  {:added "4.0"}
+  [offset n]
+  (if (nil? n)
+    offset
+    (cond (zero? offset) n
+
+          (integer? n)
+          (+ n offset)
+
+          :else
+          (list '+ n offset))))
+
+(defn tf-offset
+  "gets the offset"
+  {:added "4.0"}
+  [[_ n]]
+  (tf-offset-base (tf-grammar-offset)
+                  n))
+
+(defn tf-offset-rev
+  "gets the reverse offset"
+  {:added "4.0"}
+  [[_ n]]
+  (tf-offset-base (- (tf-grammar-offset) 1)
+                  n))
+
+(defn tf-offset-len
+  "gets the length offset"
+  {:added "4.0"}
+  [[_ n]]
+  (tf-offset-base (if (tf-grammar-end-inclusive)
+                    0 -1)
+                  n))
+
+(defn tf-offset-rlen
+  "gets the reverse length offset"
+  {:added "4.0"}
+  [[_ n]]
+  (tf-offset-base (if (tf-grammar-end-inclusive)
+                    -1 0)
+                  n))
+
+;;
+;; GLOBAL
+;;
+
+(defn tf-global-set
+  "default global set transform"
+  {:added "4.0"}
+  [[_ sym val]]
+  (list 'x:set-key '!:G (str sym) val))
+
+(defn tf-global-has?
+  "default global has transform"
+  {:added "4.0"}
+  [[_ sym]]
+  (list 'not (list 'x:nil? (list 'x:get-key '!:G (str sym)))))
+
+(defn tf-global-del
+  "default global del transform"
+  {:added "4.0"}
+  [[_ sym val]]
+  (list 'x:set-key '!:G (str sym) nil))
+
+;;
+;; LU
+;;
+
+(defn tf-lu-eq
+  "lookup equals transform"
+  {:added "4.0"}
+  [[_ o1 o2]]
+  (list '== o1 o2))
+
+
+;;
+;; BIT
+;;
+
+(defn tf-bit-and
+  "bit and transform"
+  {:added "4.0"}
+  [[_ i1 i2]]
+  (list 'b:& i1 i2))
+
+(defn tf-bit-or
+  "bit or transform"
+  {:added "4.0"}
+  [[_ i1 i2]]
+  (list 'b:| i1 i2))
+
+(defn tf-bit-lshift
+  "bit left shift transform"
+  {:added "4.0"}
+  [[_ x n]]
+  (list 'b:<< x n))
+
+(defn tf-bit-rshift
+  "bit right shift transform"
+  {:added "4.0"}
+  [[_ x n]]
+  (list 'b:>> x n))
+
+(defn tf-bit-xor
+  "bit xor transform"
+  {:added "4.0"}
+  [[_ x n]]
+  (list 'b:xor x n))
+
+;;
+;; X-LANG
+;;
+
+(def +op-xtalk-core+
+  [{:op :x-del            :symbol #{'x:del}             :emit :abstract}
+   {:op :x-cat            :symbol #{'x:cat}             :emit :abstract}
+   {:op :x-len            :symbol #{'x:len}             :emit :abstract}
+   {:op :x-err            :symbol #{'x:err}             :emit :abstract}
+   {:op :x-throw          :symbol #{'x:throw}           :macro #'tf-throw  :emit :macro}
+   {:op :x-eval           :symbol #{'x:eval}            :emit :abstract}
+   {:op :x-apply          :symbol #{'x:apply}           :emit :abstract}
+   {:op :x-unpack         :symbol #{'x:unpack}          :emit :abstract}
+   {:op :x-print          :symbol #{'x:print}           :emit :abstract}
+   {:op :x-random         :symbol #{'x:random}          :emit :abstract}
+   {:op :x-shell          :symbol #{'x:shell}           :emit :abstract}
+   {:op :x-now-ms         :symbol #{'x:now-ms}          :emit :abstract}
+   {:op :x-type-native    :symbol #{'x:type-native}     :emit :abstract}])
+
+(def +op-xtalk-proto+
+  [{:op :x-this            :symbol #{'x:this}            :emit :abstract}
+   {:op :x-proto-get       :symbol #{'x:proto-get}       :emit :abstract}
+   {:op :x-proto-set       :symbol #{'x:proto-set}       :emit :abstract}
+   {:op :x-proto-create    :symbol #{'x:proto-create}    :macro #'tf-proto-create   :emit :macro}
+   {:op :x-proto-tostring  :symbol #{'x:proto-tostring}  :emit :abstract}])
+
+(def +op-xtalk-global+
+  [{:op :x-global-set     :symbol #{'x:global-set}      :macro #'tf-global-set   :emit :macro}
+   {:op :x-global-del     :symbol #{'x:global-del}      :macro #'tf-global-del   :emit :macro}
+   {:op :x-global-has?    :symbol #{'x:global-has?}     :macro #'tf-global-has?  :emit :macro}])
+
+(def +op-xtalk-custom+
+  [{:op :x-not-nil?       :symbol #{'x:not-nil?}        :macro #'tf-not-nil?    :emit :macro}
+   {:op :x-nil?           :symbol #{'x:nil?}            :macro #'tf-eq-nil?     :emit :macro}
+   {:op :x-has-key?       :symbol #{'x:has-key?}        :macro #'tf-has-key?    :emit :macro}
+   {:op :x-del-key        :symbol #{'x:del-key}         :macro #'tf-del-key     :emit :macro}
+
+   {:op :x-get-key        :symbol #{'x:get-key}         :macro #'tf-get-key     :emit :macro}
+   {:op :x-get-path       :symbol #{'x:get-path}        :macro #'tf-get-path    :emit :macro}
+   {:op :x-get-idx        :symbol #{'x:get-idx}         :macro #'tf-get-key     :emit :macro}
+
+   {:op :x-set-key        :symbol #{'x:set-key}         :macro #'tf-set-key     :emit :macro}
+   {:op :x-set-idx        :symbol #{'x:set-idx}         :macro #'tf-set-key     :emit :macro}
+
+   {:op :x-copy-key       :symbol #{'x:copy-key}        :macro #'tf-copy-key    :emit :macro}
+   {:op :x-offset         :symbol #{'x:offset}          :macro #'tf-offset      :emit :macro}
+   {:op :x-offset-rev     :symbol #{'x:offset-rev}      :macro #'tf-offset-rev  :emit :macro}
+   {:op :x-offset-len     :symbol #{'x:offset-len}      :macro #'tf-offset-len  :emit :macro}
+   {:op :x-offset-rlen    :symbol #{'x:offset-rlen}     :macro #'tf-offset-rlen :emit :macro}
+   {:op :x-callback       :symbol #{'x:callback}        :emit :unit :default nil}])
+
+(def +op-xtalk-math+
+  [{:op :x-m-abs          :symbol #{'x:m-abs}        :emit :abstract}
+   {:op :x-m-acos         :symbol #{'x:m-acos}       :emit :abstract}
+   {:op :x-m-asin         :symbol #{'x:m-asin}       :emit :abstract}
+   {:op :x-m-atan         :symbol #{'x:m-atan}       :emit :abstract}
+   {:op :x-m-ceil         :symbol #{'x:m-ceil}       :emit :abstract}
+   {:op :x-m-cos          :symbol #{'x:m-cos}        :emit :abstract}
+   {:op :x-m-cosh         :symbol #{'x:m-cosh}       :emit :abstract}
+   {:op :x-m-exp          :symbol #{'x:m-exp}        :emit :abstract}
+   {:op :x-m-floor        :symbol #{'x:m-floor}      :emit :abstract}
+   {:op :x-m-loge         :symbol #{'x:m-loge}       :emit :abstract}
+   {:op :x-m-log10        :symbol #{'x:m-log10}      :emit :abstract}
+   {:op :x-m-max          :symbol #{'x:m-max}        :emit :abstract}
+   {:op :x-m-mod          :symbol #{'x:m-mod}        :emit :abstract}
+   {:op :x-m-min          :symbol #{'x:m-min}        :emit :abstract}
+   {:op :x-m-pow          :symbol #{'x:m-pow}        :emit :abstract}
+   {:op :x-m-quot         :symbol #{'x:m-quot}       :emit :abstract}
+   {:op :x-m-sin          :symbol #{'x:m-sin}        :emit :abstract}
+   {:op :x-m-sinh         :symbol #{'x:m-sinh}       :emit :abstract}
+   {:op :x-m-sqrt         :symbol #{'x:m-sqrt}       :emit :abstract}
+   {:op :x-m-tan          :symbol #{'x:m-tan}        :emit :abstract}
+   {:op :x-m-tanh         :symbol #{'x:m-tanh}       :emit :abstract}])
+
+(def +op-xtalk-type+
+  [{:op :x-to-string      :symbol #{'x:to-string}       :emit :abstract}
+   {:op :x-to-number      :symbol #{'x:to-number}       :emit :abstract}
+   {:op :x-is-string?     :symbol #{'x:is-string?}      :emit :abstract}
+   {:op :x-is-number?     :symbol #{'x:is-number?}      :emit :abstract}
+   {:op :x-is-integer?    :symbol #{'x:is-integer?}     :emit :abstract}
+   {:op :x-is-boolean?    :symbol #{'x:is-boolean?}     :emit :abstract}
+   {:op :x-is-function?   :symbol #{'x:is-function?}    :emit :abstract}
+   {:op :x-is-object?     :symbol #{'x:is-object?}      :emit :abstract}
+   {:op :x-is-array?      :symbol #{'x:is-array?}       :emit :abstract}])
+
+(def +op-xtalk-bit+
+  [{:op :x-bit-and         :symbol #{'x:bit-and}          :macro #'tf-bit-and  :emit :macro}
+   {:op :x-bit-or          :symbol #{'x:bit-or}           :macro #'tf-bit-or  :emit :macro}
+   {:op :x-bit-lshift      :symbol #{'x:bit-lshift}       :macro #'tf-bit-lshift  :emit :macro}
+   {:op :x-bit-rshift      :symbol #{'x:bit-rshift}       :macro #'tf-bit-rshift  :emit :macro}
+   {:op :x-bit-xor         :symbol #{'x:bit-xor}          :macro #'tf-bit-xor  :emit :macro}])
+
+(def +op-xtalk-lu+
+  [{:op :x-lu-create      :symbol #{'x:lu-create}       :emit :unit :default {}}
+   {:op :x-lu-eq          :symbol #{'x:lu-eq}           :macro #'tf-lu-eq :emit :macro}
+   {:op :x-lu-get         :symbol #{'x:lu-get}          :emit :abstract}
+   {:op :x-lu-set         :symbol #{'x:lu-set}          :emit :abstract}
+   {:op :x-lu-del         :symbol #{'x:lu-del}          :emit :abstract}])
+
+(def +op-xtalk-obj+
+  [{:op :x-obj-keys       :symbol #{'x:obj-keys}          :type :hard-link
+    :raw 'xt.lang.base-lib/obj-keys}
+   {:op :x-obj-vals       :symbol #{'x:obj-vals}          :type :hard-link
+    :raw 'xt.lang.base-lib/obj-vals}
+   {:op :x-obj-pairs      :symbol #{'x:obj-pairs}         :type :hard-link
+    :raw 'xt.lang.base-lib/obj-pairs}
+   {:op :x-obj-clone      :symbol #{'x:obj-clone}         :type :hard-link
+    :raw 'xt.lang.base-lib/obj-clone}
+   {:op :x-obj-assign     :symbol #{'x:obj-assign}        :type :hard-link
+    :raw 'xt.lang.base-lib/obj-assign}])
+
+(def +op-xtalk-arr+
+  [{:op :x-arr-clone       :symbol #{'x:arr-clone}        :type :hard-link
+    :raw 'xt.lang.base-lib/arr-clone}
+   {:op :x-arr-slice       :symbol #{'x:arr-splice}       :type :hard-link
+    :raw 'xt.lang.base-lib/arr-slice}
+   {:op :x-arr-reverse     :symbol #{'x:arr-reverse}      :type :hard-link
+    :raw 'xt.lang.base-lib/arr-reverse}
+   {:op :x-arr-find        :symbol #{'x:arr-find}         :type :hard-link
+    :raw 'xt.lang.base-lib/arr-find}
+   {:op :x-arr-remove      :symbol #{'x:arr-remove}       :emit :abstract}
+   {:op :x-arr-push        :symbol #{'x:arr-push}         :emit :abstract}
+   {:op :x-arr-pop         :symbol #{'x:arr-pop}          :emit :abstract}
+   {:op :x-arr-push-first  :symbol #{'x:arr-push-first}   :emit :abstract}
+   {:op :x-arr-pop-first   :symbol #{'x:arr-pop-first}    :emit :abstract}
+   {:op :x-arr-insert      :symbol #{'x:arr-insert}       :emit :abstract}
+   {:op :x-arr-sort        :symbol #{'x:arr-sort}         :emit :abstract}
+   {:op :x-arr-str-comp    :symbol #{'x:arr-str-comp}     :emit :abstract}])
+
+(def +op-xtalk-str+
+  [{:op :x-str-len         :symbol #{'x:str-len}         :emit :alias :raw 'x:len}
+   {:op :x-str-char        :symbol #{'x:str-char}        :emit :abstract}
+   {:op :x-str-format      :symbol #{'x:str-format}      :emit :abstract}
+   {:op :x-str-split       :symbol #{'x:str-split}       :emit :abstract}
+   {:op :x-str-join        :symbol #{'x:str-join}        :emit :abstract}
+   {:op :x-str-index-of    :symbol #{'x:str-index-of}    :emit :abstract}
+   {:op :x-str-substring   :symbol #{'x:str-substring}   :emit :abstract}
+   {:op :x-str-to-upper    :symbol #{'x:str-to-upper}    :emit :abstract}
+   {:op :x-str-to-lower    :symbol #{'x:str-to-lower}    :emit :abstract}
+   {:op :x-str-to-fixed    :symbol #{'x:str-to-fixed}    :emit :abstract}
+   {:op :x-str-replace     :symbol #{'x:str-replace}     :emit :abstract}
+   {:op :x-str-trim        :symbol #{'x:str-trim}        :emit :abstract}
+   {:op :x-str-trim-left   :symbol #{'x:str-trim-left}   :emit :abstract}
+   {:op :x-str-trim-right  :symbol #{'x:str-trim-right}  :emit :abstract}])
+
+(def +op-xtalk-js+
+  [{:op :x-json-encode      :symbol #{'x:json-encode}       :emit :abstract}
+   {:op :x-json-decode      :symbol #{'x:json-decode}       :emit :abstract}])
+
+(def +op-xtalk-return+
+  [{:op :x-return-encode   :symbol #{'x:return-encode}   :emit :abstract}
+   {:op :x-return-wrap     :symbol #{'x:return-wrap}     :emit :abstract}
+   {:op :x-return-eval     :symbol #{'x:return-eval}     :emit :abstract}])
+
+(def +op-xtalk-socket+
+  [{:op :x-socket-connect  :symbol #{'x:socket-connect}   :emit :abstract}
+   {:op :x-socket-send     :symbol #{'x:socket-send}      :emit :abstract}
+   {:op :x-socket-close    :symbol #{'x:socket-close}     :emit :abstract}])
+
+(def +op-xtalk-iter+
+  [{:op :x-iter-from-obj  :symbol #{'x:iter-from-obj}   :emit :abstract}
+   {:op :x-iter-from-arr  :symbol #{'x:iter-from-arr}   :emit :abstract}
+   {:op :x-iter-from      :symbol #{'x:iter-from}       :emit :abstract}
+   {:op :x-iter-eq        :symbol #{'x:iter-eq}         :emit :abstract}
+   {:op :x-iter-null      :symbol #{'x:iter-null}       :emit :unit :default '(return)}
+   {:op :x-iter-next      :symbol #{'x:iter-next}       :emit :abstract}
+   {:op :x-iter-has?      :symbol #{'x:iter-has?}       :emit :abstract}
+   {:op :x-iter-native?   :symbol #{'x:iter-native?}    :emit :abstract}])
+
+(def +op-xtalk-cache+
+  [{:op :x-cache          :symbol #{'x:cache}           :emit :abstract}
+   {:op :x-cache-list     :symbol #{'x:cache-list}      :emit :abstract}
+   {:op :x-cache-flush    :symbol #{'x:cache-flush}     :emit :abstract}
+   {:op :x-cache-get      :symbol #{'x:cache-get}       :emit :abstract}
+   {:op :x-cache-set      :symbol #{'x:cache-set}       :emit :abstract}
+   {:op :x-cache-del      :symbol #{'x:cache-del}       :emit :abstract}
+   {:op :x-cache-incr     :symbol #{'x:cache-incr}      :emit :abstract}])
+
+(def +op-xtalk-thread+
+  [{:op :x-thread-spawn   :symbol #{'x:thread-spawn}    :emit :abstract}
+   {:op :x-thread-join    :symbol #{'x:thread-join}     :emit :abstract}
+   {:op :x-with-delay     :symbol #{'x:with-delay}      :emit :abstract}
+   {:op :x-start-interval :symbol #{'x:start-interval}  :emit :abstract}
+   {:op :x-stop-interval  :symbol #{'x:stop-interval}   :emit :abstract}])
+
+(def +op-xtalk-file+
+  [{:op :x-slurp          :symbol #{'x:slurp}         :emit :abstract}
+   {:op :x-spit           :symbol #{'x:spit}          :emit :abstract}])
+
+(def +op-xtalk-b64+
+  [{:op :x-b64-encode      :symbol #{'x:b64-encode}     :emit :abstract}
+   {:op :x-b64-decode      :symbol #{'x:b64-decode}     :emit :abstract}])
+
+(def +op-xtalk-uri+
+  [{:op :x-uri-encode      :symbol #{'x:uri-encode}     :emit :abstract}
+   {:op :x-uri-decode      :symbol #{'x:uri-decode}     :emit :abstract}])
+
+(def +op-xtalk-special+
+  [{:op :x-notify-http     :symbol #{'x:notify-http}    :type :hard-link
+    :raw 'xt.lang.base-repl/notify-socket-http}])
+
+
+
+
+(comment
+  (./reload-specs)
+
+  )
+
+
+(comment
+  (def +op-xtalk-notify+
+    [{:op :x-notify-socket   :symbol #{'x:notify-socket}   :emit :abstract}
+     {:op :x-notify-http     :symbol #{'x:notify-http}     :emit :abstract}])
+
+  (def +op-xtalk-service+
+    [{:op :x-client-basic    :symbol #{'x:client-basic}    :emit :abstract}
+     {:op :x-client-ws       :symbol #{'x:client-ws}       :emit :abstract}
+     {:op :x-server-basic    :symbol #{'x:server-basic}    :emit :abstract}
+     {:op :x-server-ws       :symbol #{'x:server-ws}       :emit :abstract}])
+
+  (def +op-xtalk-arr-generic+
+  '[{:op :x-arr-every       :symbol #{'x:arr-every}   :emit :alias
+     :raw xt.lang.base-lib/arr-every}
+    {:op :x-arr-some        :symbol #{'x:arr-some}
+     :raw xt.lang.base-lib/arr-every}
+    {:op :x-arr-foldl       :symbol #{'x:arr-foldl}
+     :raw xt.lang.base-lib/arr-foldl}
+    {:op :x-arr-foldr       :symbol #{'x:arr-foldr}         :macro #'tf-arr-foldr   :emit :macro}
+    {:op :x-arr-reverse     :symbol #{'x:arr-reverse}       :macro #'tf-arr-reverse :emit :macro}])
+  {:op :x-str-pad-left    :symbol #{'x:str-pad-left}    :macro #'tf-str-pad-left  :emit :macro}
+  {:op :x-str-pad-right   :symbol #{'x:str-pad-right}   :macro #'tf-str-pad-right :emit :macro}
+  {:op :x-str-starts-with :symbol #{'x:str-starts-with} :macro #'tf-str-starts-with :emit :macro}
+  {:op :x-str-ends-with   :symbol #{'x:str-ends-with}   :macro #'tf-str-ends-with :emit :macro}
+  {:op :x-ws-connect      :symbol #{'x:ws-connect}       :emit :abstract}
+  {:op :x-ws-send         :symbol #{'x:ws-send}          :emit :abstract}
+  {:op :x-ws-close        :symbol #{'x:ws-close}         :emit :abstract})

--- a/src/bb/lang/base/impl.clj
+++ b/src/bb/lang/base/impl.clj
@@ -1,0 +1,362 @@
+(ns bb.lang.base.impl
+  (:require [bb.string :as str]
+            [bb.lib :as h]
+            [bb.lang.base.emit :as emit]
+            [bb.lang.base.emit-preprocess :as preprocess]
+            [bb.lang.base.emit-common :as emit-common]
+            [bb.lang.base.impl-entry :as entry]
+            [bb.lang.base.impl-deps :as deps]
+            [bb.lang.base.grammar :as grammar]
+            [bb.lang.base.library-snapshot :as snap]
+            [bb.lang.base.library :as lib]
+            [bb.lang.base.util :as ut]))
+
+(defonce ^:dynamic *library* nil)
+
+(defonce ^:dynamic *print-form* nil)
+
+(defmacro ^{:style/indent 1}
+  with:library
+  "injects a library as the default"
+  {:added "4.0"}
+  ([[lib] & body]
+   `(binding [*library* ~lib]
+      ~@body)))
+
+(h/res:spec-add
+ {:type :hara/lang.library
+  :mode {:allow #{:global}
+         :default :global}
+  :instance {:create #'lib/library:create
+             :start h/start
+             :stop h/stop}})
+
+(defn default-library
+  "gets the default library"
+  {:added "4.0"}
+  ([& [override]]
+   (or override
+       *library*
+       (h/res :hara/lang.library))))
+
+(defn default-library:reset
+  "clears the default library, including all grammars"
+  {:added "4.0"}
+  ([& [override]]
+   (if-let [lib (or override *library*)]
+     (h/stop lib)
+     (h/res:stop :hara/lang.library))))
+
+(defn clone-default-library
+  "clones the default library"
+  {:added "4.0"}
+  []
+  (lib/library:create
+   {:snapshot (lib/get-snapshot (default-library))}))
+
+(defn runtime-library
+  "gets the current runtime (annex or default)
+
+   (runtime-library)
+   => lib/library?"
+  {:added "4.0"}
+  []
+  (or  *library*
+      (:library (h/p:space-rt-get :lang.annex))
+      (default-library)))
+
+(defn grammar
+  "gets the grammar"
+  {:added "4.0"}
+  [lang]
+  (:grammar (lib/get-book (runtime-library) lang)))
+
+;;
+;;
+;;
+
+(defn- emit-options-raw
+  [library snapshot lang]
+  (let [snapshot (or snapshot
+                     (let [library (or library (runtime-library))]
+                       (lib/get-snapshot library)))
+        book   (snap/get-book snapshot lang)]
+    [snapshot book]))
+
+(defn emit-options
+  "create emit options
+
+   (emit-options {:lang :lua})
+   => vector?"
+  {:added "4.0"}
+  [{:keys [lang library snapshot emit] :as meta}]
+  (let [_ (assert (identity lang) "Lang Required")
+        [snapshot book] (emit-options-raw library snapshot lang)]
+    (emit/prep-options (assoc meta
+                              :book book
+                              :snapshot snapshot))))
+
+(defn to-form
+  "input to form"
+  {:added "4.0"}
+  [form meta]
+  (let [[stage grammar book namespace mopts] (emit-options meta)]
+    (first (emit/prep-form stage form grammar book mopts))))
+
+(defmacro %.form
+  "converts to a form"
+  {:added "4.0"}
+  [form]
+  (list 'quote (to-form form (merge {:lang :xtalk} (meta &form)))))
+
+;;
+;;
+;;
+
+(defn- emit-bulk?
+  [form]
+  (boolean (and (vector? form)
+                (:bulk (meta form)))))
+
+(defn emit-direct
+  "adds additional controls to transform form"
+  {:added "4.0"}
+  [grammar form namespace {:keys [lang
+                                  emit
+                                  bulk]
+                           :as mopts}]
+  (or lang (h/error "Lang required." {:input (keys mopts)}))
+  (binding [preprocess/*macro-grammar* grammar
+            preprocess/*macro-opts* mopts]
+    (if (not (:suppress emit))
+      (let [{:keys [trim transform]} emit
+            form (cond-> form transform (transform mopts))
+            _    (if *print-form* (h/p :FORM form))
+            body (emit/emit form
+                            grammar
+                            (the-ns namespace)
+                            mopts)
+            body (cond-> body trim (trim))]
+        body))))
+
+(defn emit-str
+  "converts to an output string"
+  {:added "4.0"}
+  [form meta]
+  (let [[stage grammar book namespace mopts] (emit-options meta)
+        bulk (emit-bulk? form)
+        [form]  (emit/prep-form stage form grammar book mopts)]
+    (emit-direct grammar
+                 form
+                 namespace
+                 (assoc mopts :bulk bulk))))
+
+(defmacro %.str
+  "converts to an output string"
+  {:added "4.0"}
+  [form]
+  (emit-str form (merge {:lang :xtalk} (meta &form))))
+
+(defn emit-as
+  "helper function for emitting multiple forms"
+  {:added "4.0"}
+  [lang forms & [meta]]
+  (->> forms
+       (map (fn [form] (emit-str form (merge {:lang lang}
+                                             meta))))
+       (str/join "\n\n")))
+
+(defn emit-symbol
+  "emits string given symbol and grammar"
+  {:added "4.0"}
+  [lang sym & [mopts]]
+  (let [[_ book] (emit-options-raw nil nil lang)
+        {:keys [grammar]} book]
+    (emit-common/emit-symbol sym grammar (merge {:layout :flat}
+                                                mopts))))
+
+(defn get-entry
+  "gets an entry"
+  {:added "4.0"}
+  [library lang module id]
+  (lib/get-entry library {:lang lang
+                          :module module
+                          :section :code
+                          :id id}))
+
+(defn emit-entry
+  "emits an entry given parameters and options"
+  {:added "4.0"}
+  [{:keys [lang
+           module
+           id
+           section]
+    :or {section :code}}
+   {:keys [library] :as meta}]
+  (let [[stage grammar book namespace mopts] (emit-options meta)
+        {:keys [snapshot]} mopts
+        module  (get-in snapshot [lang :book :modules module])
+        entry   (get-in module [section id])]
+    (entry/emit-entry grammar
+                      entry
+                      (assoc mopts :module module))))
+
+(defn emit-entry-deps-collect
+  "only collects the dependencies"
+  {:added "4.0"}
+  [{:keys [lang
+           module
+           id] :as ptr}
+   {:keys [library] :as meta}]
+  (let [[stage grammar book namespace mopts] (emit-options meta)]
+    (first (deps/collect-script-entries book [(ut/sym-full ptr)]))))
+
+(defn emit-entry-deps
+  "emits only the entry deps"
+  {:added "4.0"}
+  [{:keys [lang
+           module
+           id] :as ptr}
+   {:keys [library] :as meta}]
+  (let [[stage grammar book namespace mopts] (emit-options meta)
+        [deps] (deps/collect-script-entries book [(ut/sym-full ptr)])]
+    (str/join "\n\n"
+              (map #(emit-entry % mopts) deps))))
+
+(defn emit-script-imports
+  "emit imports"
+  {:added "4.0"}
+  [natives emit [stage grammar book namespace mopts :as input]]
+  (if (not (-> emit :native :suppress))
+    (let [imports-opts (update mopts :emit merge (:native emit))]
+
+      (mapcat (fn [[name module]]
+                (let [{:keys [bundle]} module
+                      form-bundled (if (not-empty bundle)
+                                     (emit-script-imports bundle emit input))
+                      form (deps/module-import-form book name module imports-opts)]
+                  (if form
+                    (concat form-bundled
+                            [(emit-direct grammar
+                                          (list 'do form)
+                                          namespace
+                                          imports-opts)]))))
+              natives))))
+
+(defn emit-script-deps
+  "emits the script deps"
+  {:added "4.0"}
+  [entries emit [stage grammar book namespace mopts]]
+  (let [deps-opts    (-> mopts
+                         (update :emit merge (:code emit))
+                         (dissoc :module))
+        deps-arr     (keep (fn [entry]
+                             (entry/emit-entry grammar entry deps-opts))
+                           entries)]
+    deps-arr))
+
+(defn emit-script-join
+  "joins the necessary parts of the script"
+  {:added "4.0"}
+  [imports-arr deps-arr body]
+  (->> [(if (not-empty imports-arr)
+          (str/join "\n" imports-arr))
+        (if (not-empty deps-arr)
+          (str/join "\n\n" deps-arr))
+        body]
+       (filter not-empty)
+       (str/join "\n\n")))
+
+(defn emit-script
+  "emits a script with all dependencies"
+  {:added "4.0"}
+  [form
+   {:keys [library
+           lang
+           emit] :as meta}]
+  (let [[stage grammar book namespace mopts] (emit-options
+                                              (update meta :emit merge {:type :script}))
+        bulk (emit-bulk? form)
+        [form deps natives]  (deps/collect-script book form mopts)
+        imports-arr  (emit-script-imports natives emit [stage grammar book namespace mopts])
+        deps-arr     (emit-script-deps deps emit [stage grammar book namespace mopts])
+        body         (emit-direct grammar
+                                  form
+                                  namespace
+                                  (-> mopts
+                                      (update :emit
+                                              merge
+                                              (:body emit))
+                                      (assoc :bulk bulk)))]
+    (emit-script-join imports-arr deps-arr body)))
+
+(defn emit-scaffold-raw-imports
+  "gets only the scaffold imports"
+  {:added "4.0"}
+  [modules emit [stage grammar book namespace mopts] ]
+  (let [natives      (deps/collect-script-natives modules {})]
+    [natives (emit-script-imports natives emit [stage grammar book namespace mopts])]))
+
+(defn emit-scaffold-raw
+  "creates entries only for defglobal and defrun entries"
+  {:added "4.0"}
+  [transform
+   module-id
+   {:keys [library
+           lang
+           emit] :as meta}]
+  (let [[stage grammar book namespace mopts] (emit-options meta)
+        module-ids   (transform (h/deps:ordered book [module-id]))
+        modules      (map (:modules book) module-ids)
+        [_ imports-arr]  (emit-scaffold-raw-imports
+                          modules emit
+                          [stage grammar book namespace mopts] )
+        globals      (vec (mapcat (fn [module]
+                                   (keep (fn [{:keys [op] :as entry}]
+                                           (if ('#{defrun defglobal} op)
+                                             (ut/sym-full entry)))
+                                         (vals (:code module))))
+                                  modules))
+        [deps]       (deps/collect-script-entries book globals)
+        deps-arr     (emit-script-deps deps emit [stage grammar book namespace mopts])
+        body         (emit-direct grammar
+                                  (mapv (juxt h/strn identity)
+                                        globals)
+                                  namespace
+                                  (-> mopts
+                                      (update :emit merge (:body emit))))]
+    (emit-script-join imports-arr deps-arr body)))
+
+(defn emit-scaffold-for
+  "creates scaffold for module and its deps"
+  {:added "4.0"}
+  [module-id meta]
+  (emit-scaffold-raw identity module-id meta))
+
+(defn emit-scaffold-to
+  "creates scaffold up to module"
+  {:added "4.0"}
+  [module-id meta]
+  (emit-scaffold-raw butlast module-id meta))
+
+(defn emit-scaffold-imports
+  "create scaggold to expose native imports"
+  {:added "4.0"}
+  [module-id {:keys [emit] :as meta}]
+  (let [[stage grammar book namespace mopts] (emit-options meta)
+        module-ids   (h/deps:ordered book [module-id])
+        modules      (map (:modules book) module-ids)
+        [natives imports-arr] (emit-scaffold-raw-imports
+                               modules emit
+                               [stage grammar book namespace mopts])]
+    (str/join "\n" (conj (vec imports-arr)
+                         (emit-direct grammar
+                                      (list 'do:>
+                                            (list 'return (h/postwalk (fn [x]
+                                                                        (if (or (symbol? x)
+                                                                                (keyword? x))
+                                                                          (name x)
+                                                                          x))
+                                                                      natives)))
+                                      namespace
+                                      mopts)))))

--- a/src/bb/lang/base/impl_deps.clj
+++ b/src/bb/lang/base/impl_deps.clj
@@ -1,0 +1,152 @@
+(ns bb.lang.base.impl-deps
+  (:require [bb.lang.base.util :as ut]
+            [bb.lang.base.emit :as emit]
+            [bb.lang.base.emit-preprocess :as preprocess]
+            [bb.lang.base.impl-entry :as entry]
+            [bb.lang.base.book :as b]
+            [bb.lang.base.impl-deps-imports :as imports]
+            [bb.string :as str]
+            [bb.lib :as h]
+            [clojure.set :as set]))
+
+;;
+;;
+;;
+
+(defn module-import-form
+  "import form"
+  {:added "4.0"}
+  [{:keys [meta] :as book} name module opts]
+  (if-let [f (:module-import meta)] (f name module opts)))
+
+(defn module-export-form
+  "export form"
+  {:added "4.0"}
+  [{:keys [meta] :as book} module opts]
+  (if-let [f (:module-export meta)] (f module opts)))
+
+(defn module-link-form
+  "link form for projects"
+  {:added "4.0"}
+  [{:keys [meta] :as book} ns options]
+  (if-let [f (:module-link meta)] (f ns options)))
+
+(defn has-module-form
+  "checks if module is available"
+  {:added "4.0"}
+  [{:keys [meta] :as book} module]
+  (if-let [f (:has-module meta)] (f module)))
+
+(defn setup-module-form
+  "setup the module"
+  {:added "4.0"}
+  [{:keys [meta] :as book} module]
+  (if-let [f (:setup-module meta)] (f module)))
+
+(defn teardown-module-form
+  "teardown the module"
+  {:added "4.0"}
+  [{:keys [meta] :as book} module]
+  (if-let [f (:teardown-module meta)] (f module)))
+
+(defn has-ptr-form
+  "form to check if pointer exists"
+  {:added "4.0"}
+  [{:keys [meta] :as book} ptr]
+  (if-let [f (:has-ptr meta)] (f ptr)))
+
+(defn setup-ptr-form
+  "form to setup pointer"
+  {:added "4.0"}
+  [{:keys [meta] :as book} ptr]
+  (if-let [f (:setup-ptr meta)] (f ptr)))
+
+(defn teardown-ptr-form
+  "form to teardown pointer"
+  {:added "4.0"}
+  [{:keys [meta] :as book} ptr]
+  (if-let [f (:teardown-ptr meta)] (f ptr)))
+
+(defn collect-script-natives
+  "gets native imported modules"
+  {:added "4.0"}
+  [modules initial]
+  (reduce (fn [out {:keys [native id]}]
+            (reduce-kv (fn [out k v]
+                         (let [ov (get out k)]
+                           (cond (nil? ov)
+                                 (assoc out k v)
+
+                                 (= ov v)
+                                 out
+
+                                 :else
+                                 (h/error "Imports not of the same name"
+                                          {:ns   id
+                                           :key  k
+                                           :curr ov
+                                           :new  v}))))
+                       out
+                       native))
+          (or initial {})
+          modules))
+
+(defn collect-script-entries
+  "collects all entries"
+  {:added "4.0"}
+  ([{:keys [modules] :as book} sym-ids]
+   (let [ids  (h/seqify sym-ids)
+         ids  (:all (h/deps:resolve book ids))
+         module-ids (set (map ut/sym-module ids))
+         module-lu  (->> (h/deps:ordered book module-ids)
+                         (map (fn [i id]
+                                [id {:index i :module (get modules  id)}])
+                              (range))
+                         (into {}))
+
+         ;; sort by module order and line number
+         entries (->> (map (partial b/get-code-entry book) ids)
+                      (sort-by (juxt (comp :index module-lu :module)
+                                     :priority :line :time)))]
+     [entries module-lu])))
+
+(defn collect-script
+  "collect dependencies given a form and book"
+  {:added "4.0"}
+  [book form mopts]
+  (let [_ (assert book "Book required.")
+        input (preprocess/to-input form)
+        [form sym-ids]  (preprocess/to-staging input
+                                               (:grammar book)
+                                               (:modules book) mopts)
+        [entries module-lu] (collect-script-entries book sym-ids)
+        natives (imports/script-imports book entries)]
+    [form entries natives]))
+
+(defn collect-script-summary
+  "summaries the output of `collect-script`"
+  {:added "4.0"}
+  [[form entries natives]]
+  [form (map ut/sym-full entries) natives])
+
+;;
+;;
+;;
+
+(defn collect-module
+  "collects information for the entire module"
+  {:added "4.0"}
+  [book
+   {:keys [native]
+    :as module}]
+  (let [setup    (setup-module-form book module)
+        teardown (teardown-module-form book module)
+        {:keys [direct
+                native]} (imports/module-imports book (:id module))
+        code    (->> (vals (:code module))
+                     (sort-by (juxt :priority :line :time)))]
+    {:setup    setup
+     :teardown teardown
+     :code     code
+     :native   native
+     :direct   direct}))

--- a/src/bb/lang/base/impl_deps_imports.clj
+++ b/src/bb/lang/base/impl_deps_imports.clj
@@ -1,0 +1,107 @@
+(ns bb.lang.base.impl-deps-imports
+  (:require [bb.lang.base.util :as ut]
+            [bb.lang.base.impl-entry :as entry]
+            [bb.lang.base.book :as b]
+            [bb.lang.base.book-module :as module]
+            [bb.string :as str]
+            [bb.lib :as h]
+            [clojure.set :as set]))
+
+(defn get-entry-imports
+  "gets all fragment imports from code entries"
+  {:added "4.0"}
+  [entries]
+  (->> entries
+       (filter (comp not-empty :deps-native))
+       (map (juxt ut/sym-full :deps-native))
+       (into {})))
+
+(defn get-namespace-imports
+  "merges imports for both fragment and code entries"
+  {:added "4.0"}
+  [imports]
+  (->> imports
+       (map (fn [[sym m]]
+              {(symbol (namespace sym))
+               m}))
+       (apply merge-with #(merge-with set/union %1 %2))))
+
+;;
+;; script imports
+;;
+
+(defn get-fragment-deps
+  "gets all the fragment dependencies"
+  {:added "4.0"}
+  ([book entries]
+   (get-fragment-deps book entries #{}))
+  ([book entries seen]
+   (let [fragments (->> (map :deps-fragment entries)
+                        (apply set/union)
+                        (filter (comp not seen)))]
+     (if (empty? fragments)
+       seen
+       (get-fragment-deps
+        book
+        (map #(b/get-fragment-entry book %) fragments)
+        (set/union seen (set fragments)))))))
+
+(defn format-namespace-imports
+  [book ns-imports]
+  (reduce (fn [out [module-id m]]
+            (let [module  (b/get-module book module-id)
+                  imports (select-keys (:native module) (keys m))]
+              (merge out imports)))
+          {}
+          ns-imports))
+
+(defn script-import-deps
+  "collect all native imports"
+  {:added "4.0"}
+  [book entries]
+  (let [fragments (get-fragment-deps book entries)
+        fentries  (map #(b/get-fragment-entry book %) fragments)
+        fnatives  (get-entry-imports fentries)
+        natives   (get-entry-imports entries)]
+    (get-namespace-imports (concat natives fnatives))))
+
+(defn script-imports
+  "gets the ns imports for a script"
+  {:added "4.0"}
+  [book entries]
+  (let [ns-imports  (script-import-deps book entries)]
+    (format-namespace-imports book ns-imports)))
+
+;;
+;;
+;;
+
+(defn module-imports
+  "gets the ns imports for a script"
+  {:added "4.0"}
+  [book module-id]
+  (let [module    (b/get-module book module-id)
+        links     (module/module-deps-code module)
+        entries   (vals (:code module))]
+    {:native (script-imports book entries)
+     :direct links}))
+
+(defn module-code-deps
+  "resolves all dependencies"
+  {:added "3.0"}
+  ([book module-ids]
+   (module-code-deps book module-ids {:all #{} :graph {}}))
+  ([book module-ids deps]
+   (let [submap (h/map-juxt [identity
+                             (comp set
+                                   module/module-deps-code
+                                   (partial b/get-module book))]
+                            module-ids)
+         ndeps  (-> deps
+                    (update :graph merge submap)
+                    (update :all into (concat module-ids)))
+         nids  (set/difference (apply set/union (vals (:graph ndeps)))
+                               (:all ndeps))]
+     (if (not-empty nids)
+       (module-code-deps book nids ndeps)
+       ndeps))))

--- a/src/bb/lang/base/impl_entry.clj
+++ b/src/bb/lang/base/impl_entry.clj
@@ -1,0 +1,316 @@
+(ns bb.lang.base.impl-entry
+  (:require [bb.lang.base.util :as ut]
+            [bb.lang.base.emit :as emit]
+            [bb.lang.base.emit-preprocess :as preprocess]
+            [bb.lang.base.book :as book]
+            [bb.lib :as h :refer [definvoke]]
+            [bb.string :as str]
+            [std.print.ansi :as ansi]))
+
+;;;;
+;;
+;; CREATE ENTRY
+;;
+
+(def ^:dynamic *extra* {})
+
+(defn create-common
+  "create entry common keys from metadata"
+  {:added "4.0"}
+  [{:keys [lang namespace module line time]
+    :or {namespace (h/ns-sym)}
+    :as meta}]
+  (merge
+   {:lang lang
+    :namespace namespace
+    :module (or module namespace)
+    :line line
+    :time time}
+   (h/qualified-keys meta [:static :rt :api])))
+
+(defn create-code-raw
+  "creates a raw entry compatible with submit"
+  {:added "4.0"}
+  ([[op sym & body :as form-raw] reserved meta]
+   (let [{:keys [section priority format format-hook]
+          :or {priority 5}} reserved
+         modifiers  (:- (clojure.core/meta sym))
+         sym        (if (some symbol? modifiers)
+                      (with-meta sym
+                        (assoc (clojure.core/meta sym)
+                               :-
+                               (mapv #(if (symbol? %)
+                                        (h/var-sym (resolve %))
+                                        %)
+                                     modifiers)))
+                      sym)
+         form-raw     (if (some symbol? modifiers)
+                        (apply list op sym body)
+                        form-raw)
+         [tmeta form]  (if format
+                         (format form-raw)
+                         [nil form-raw])
+         form-input (preprocess/to-input form)
+         entry (book/book-entry (merge {:op op
+                                        :op-key (:op reserved)
+                                        :id (cond (vector? sym)
+                                                  (first (filter symbol? sym))
+
+                                                  :else sym)
+                                        :form-input form-input
+                                        :section (or section :code)
+                                        :priority priority}
+                                       tmeta
+                                       (create-common meta)))]
+     (if format-hook (format-hook entry))
+     [tmeta entry])))
+
+(defn create-code-base
+  "creates the base code entry"
+  {:added "4.0"}
+  ([[op sym & body :as form] meta grammar]
+   (let [reserved (get-in grammar [:reserved op])]
+     (second (create-code-raw form reserved meta)))))
+
+(defn create-code-hydrate
+  "hydrates the forms"
+  {:added "4.0"}
+  ([entry reserved grammar modules & [mopts]]
+   (let [{:keys [hydrate hydrate-hook]} reserved
+         {:keys [form-input]} entry
+         [hmeta form-hydrate] (if hydrate
+                                (hydrate form-input grammar mopts)
+                                [nil form-input])
+         module (assoc (get modules (:module entry))
+                       :display :brief)
+         [form
+          deps
+          deps-fragment
+          deps-native] (preprocess/to-staging form-hydrate
+                                              grammar
+                                              modules
+                                              (merge {:module module
+                                                      :entry (assoc entry :display :brief)}
+                                                     mopts))
+
+         entry (merge (assoc entry
+                             :form form
+                             :deps deps
+                             :deps-fragment deps-fragment
+                             :deps-native   deps-native)
+                      hmeta
+                      *extra*)
+         entry (cond-> entry
+                 (:static/template entry) (assoc :static/template.cache (atom {})))
+         _     (if hydrate-hook (hydrate-hook entry))]
+     entry)))
+
+(defn create-code
+  "creates the code entry"
+  {:added "4.0"}
+  ([form meta book]
+   (create-code form meta book {}))
+  ([form meta book mopts]
+   (let [{:keys [modules]} book]
+     (create-code form meta
+                  (:grammar book)
+                  (:modules book)
+                  (merge {:module (-> modules
+                                      (get (:module meta))
+                                      (assoc :display :brief))}
+                         mopts))))
+  ([[op sym & body :as form] meta grammar modules mopts]
+   (let [reserved (get-in grammar [:reserved op])]
+     (-> form
+         (create-code-raw reserved meta)
+         second
+         (create-code-hydrate reserved grammar modules mopts)))))
+
+(defn create-fragment
+  "creates a fragment"
+  {:added "4.0"}
+  [[_ sym value] {return :-
+                  :as meta}]
+  (book/book-entry (merge {:op 'def$
+                           :id sym
+                           :form value
+                           :section :fragment
+                           :static/return return}
+                          (create-common meta)
+                          (h/qualified-keys meta :rt))))
+
+(defn create-fragment-hydrate
+  "hydrates the forms"
+  {:added "4.0"}
+  ([entry grammar modules mopts]
+   (if (:template entry)
+     (let [deps-native  (preprocess/find-natives entry
+                                                 mopts)]
+       (assoc entry
+              :deps #{}
+              :deps-fragment #{}
+              :deps-native   deps-native))
+     (let [{:keys [form]} entry
+           [_
+            deps
+            deps-fragment
+            deps-native]   (preprocess/to-staging form
+                                                  grammar
+                                                  modules
+                                                  mopts)]
+       (assoc entry
+              :deps #{}
+              :deps-fragment deps-fragment
+              :deps-native   deps-native)))))
+
+(defn create-macro
+  "creates a macro"
+  {:added "4.0"}
+  [[_ sym & body] {return :-
+                   :keys [standalone] :as meta}]
+  (let [form (apply list 'fn body)
+        template (eval (apply list 'fn body))]
+    (book/book-entry (merge {:op 'defmacro
+                             :id sym
+                             :form form
+                             :template template
+                             :section :fragment
+                             :standalone standalone
+                             :static/return return}
+                            (create-common meta)
+                            (h/qualified-keys meta :rt)))))
+
+
+;;;;
+;;
+;; EMIT ENTRY
+;;
+;; This is the major workhorse function for
+;; most of the library and optimisations should
+;; start from here because it's used everywhere
+;;
+;; Methods for generation of code from entries
+;; - single entry (for use in modules)
+;; - entry and all dependencies (with native imports and declarations at the top)
+;;    - layout can be specified
+;;
+
+(def ^:dynamic *cache-none* false)
+
+(def ^:dynamic *cache-force* false)
+
+(defmacro with:cache-none
+  "skips the cache"
+  {:added "4.0"}
+  [& body]
+  `(binding [*cache-none* true]
+     ~@body))
+
+(defmacro with:cache-force
+  "forces the cache to update"
+  {:added "4.0"}
+  [& body]
+  `(binding [*cache-force* true]
+     ~@body))
+
+(defn emit-entry-raw
+  "emits using the raw entry"
+  {:added "4.0"}
+  ([grammar entry {:keys [emit]
+                   :as mopts}]
+   (assert entry "Entry cannot be null")
+   (let [{:keys [form]}  entry
+         form (if (:transform emit)
+                ((:transform emit) form mopts)
+                form)
+         mopts (assoc mopts :entry (assoc entry :display :brief))]
+     (binding [preprocess/*macro-opts* mopts
+               preprocess/*macro-grammar* grammar]
+       (try
+         (emit/emit form grammar
+                    (:namespace entry)
+                    mopts)
+         (catch Throwable t
+           (h/p   (str (:module entry) " - [" (:line entry) "] - "
+                       (:id entry) "\n" (ansi/red (h/date))))
+           (h/pp  form)
+           (throw t)))))))
+
+(def +cached-emit-keys+
+  [:transform
+   :label
+   :trim])
+
+(def +cached-keys+
+  [:layout :emit])
+
+(definvoke emit-entry-cached
+  "emits using a potentially cached entry"
+  {:added "4.0"}
+  [:recent {:key (fn [{:keys [entry mopts]}]
+                   [(ut/sym-full entry) (select-keys mopts +cached-keys+)])
+            :compare (fn [{:keys [grammar entry mopts]}]
+                       [(:lang mopts)
+                        (h/hash-id grammar)
+                        (h/hash-id entry)
+                        (select-keys mopts +cached-keys+)
+                        (h/qualified-keys mopts :lang)])}]
+  ([{:keys [grammar entry mopts]}]
+   (emit-entry-raw grammar entry mopts)))
+
+(defn emit-entry-label
+  "emits the entry label"
+  {:added "4.0"}
+  [grammar entry]
+  (let [{:keys [prefix suffix]} (get-in grammar [:default :comment])]
+    (str prefix " " (ut/sym-full entry) " [" (:line entry) "] " suffix)))
+
+(defn emit-entry
+  "emits a given entry"
+  {:added "4.0"}
+  ([grammar entry {:keys [snapshot module emit]
+                   :as mopts}]
+   (if (not (:suppress emit))
+     (let [mopts  (or (and (not module)
+                           snapshot
+                           (let [{:keys [lang module]} entry]
+                             (assoc mopts :module (get-in snapshot [lang :book :modules module]))))
+                      mopts)
+           {:keys [label trim cache]} emit
+           body (cond (or *cache-none*
+                          (:static/no-cache entry)
+                          (= cache :none))
+                      (emit-entry-raw grammar entry mopts)
+
+                      :else
+                      (binding [bb.lib.invoke/*force* (or *cache-force* (= cache :force))]
+                        (emit-entry-cached {:grammar grammar
+                                            :entry   entry
+                                            :mopts   mopts})))
+           body (reduce (fn [body transform]
+                          (transform body {:grammar grammar
+                                           :entry   entry
+                                           :mopts   mopts}))
+                        body
+                        (-> emit :code :transforms :entry))
+           body (reduce (fn [body transform]
+                          (transform body {:grammar grammar
+                                           :entry   entry
+                                           :mopts   mopts}))
+                        body
+                        (get-in snapshot [(:lang mopts) :book :meta :transforms :entry]))
+           body (cond->> body
+                  label (str (emit-entry-label grammar entry) "\n")
+                  trim  (trim))]
+       body))))
+
+(comment
+  (-> (bb.lang/get-snapshot
+       (bb.lang/default-library))
+      :js
+      :book
+      :meta)
+
+  (:meta (bb.lang/grammar :js))
+
+  )

--- a/src/bb/lang/base/impl_lifecycle.clj
+++ b/src/bb/lang/base/impl_lifecycle.clj
@@ -1,0 +1,350 @@
+(ns bb.lang.base.impl-lifecycle
+  (:require [bb.lang.base.util :as ut]
+            [bb.lang.base.emit :as emit]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.book-module :as module]
+            [bb.lang.base.impl :as impl]
+            [bb.lang.base.impl-deps :as deps]
+            [bb.lang.base.impl-entry :as entry]
+            [bb.string :as str]
+            [std.fs :as fs]
+            [bb.lib :as h]
+            [bb.lang.base.compile-links :as links]))
+
+(defn emit-module-prep
+  "prepares the module for emit"
+  {:added "4.0"}
+  [module-id
+   {:keys [library
+           lang
+           emit] :as meta}]
+  (let [_ (assert lang "Lang required.")
+        [stage grammar book namespace mopts] (impl/emit-options (merge {:layout :module}
+                                                                       meta))
+        module (get-in book [:modules module-id])]
+    [[stage grammar book namespace (assoc mopts :module module)]
+     (deps/collect-module book module)]))
+
+;;
+;; SETUP
+;;
+
+(defn emit-module-setup-concat
+  "joins setup raw into individual blocks"
+  {:added "4.0"}
+  [{:keys [setup-body
+           native-arr
+           link-arr
+           header-arr
+           code-arr
+           export-body]
+    :as raw}]
+  (->> (concat [setup-body]
+               native-arr
+               link-arr
+               header-arr
+               code-arr
+               [export-body])
+       (filter not-empty)))
+
+(defn emit-module-setup-join
+  "joins setup raw into the setup code"
+  {:added "4.0"}
+  [{:keys [setup-body
+           native-arr
+           link-arr
+           header-arr
+           code-arr
+           export-body]
+    :as raw}]
+  (->> [setup-body
+        (str/join "\n\n" native-arr)
+        (str/join "\n\n" link-arr)
+        (str/join "\n\n" header-arr)
+        (str/join "\n\n" code-arr)
+        export-body]
+       (filter not-empty)
+       (str/join "\n\n")))
+
+(defn emit-module-setup-native-arr
+  "creates the setup code for native imports"
+  {:added "4.0"}
+  [{:keys [library
+           lang
+           emit] :as meta}
+   prep]
+  (let [[[_ grammar book namespace mopts]
+         {:keys [native]}] prep
+        native-opts  (update mopts
+                             :emit
+                             merge (:native emit) {:import :native})
+        native (if (-> emit :native :suppress)
+                 []
+                 native)
+        native-bundled  (apply merge (map :bundle (vals native)))]
+
+    (keep (fn [[name module]]
+            (if-let [form (deps/module-import-form book name module native-opts)]
+              (impl/emit-direct grammar
+                                form
+                                namespace
+                                native-opts)))
+          (merge native native-bundled))))
+
+(defn emit-module-setup-link-import
+  [type curr-ns link-ns links module
+   {:keys [root-prefix
+           path-separator]
+    :or {path-separator "/"}
+    :as link-opts}
+   root-ns]
+  (let [link-as (get (:internal module) link-ns)]
+    (case type
+      :graph
+      (let [entry (get links link-ns)
+            {:keys [rel label suffix]} (if (and (:rel entry) (:label entry))
+                                         entry
+                                         (links/link-attributes root-ns link-ns link-opts))
+            curr (get links curr-ns)
+            curr (if (and (:rel curr) (:label curr))
+                   curr
+                   (links/link-attributes root-ns curr-ns link-opts))]
+        {:ns (str (fs/relativize (:rel curr)
+                                 rel)
+                  path-separator
+                  label)
+         :suffix suffix
+         :as link-as})
+
+      (let [entry (get links link-ns)
+            {:keys [rel label suffix]} (if (and (:rel entry) (:label entry))
+                                         entry
+                                         (links/link-attributes root-ns link-ns link-opts))
+            root-prefix (if (map? root-prefix)
+                          (or (links/get-link-lookup link-ns (dissoc root-prefix :default))
+                              (:default root-prefix))
+                          root-prefix)]
+        {:ns (->> [root-prefix rel label]
+                  (filter (fn [s] (and s (not= s ""))))
+                  (str/join path-separator))
+         :suffix suffix
+         :as link-as}))))
+
+(defn emit-module-setup-link-arr
+  "creates the setup code for internal links"
+  {:added "4.0"}
+  [{:keys [library
+           lang
+           emit] :as meta}
+   prep]
+  (let [[[_ grammar book namespace mopts]
+         {:keys [direct]}]  prep
+        {:keys [links type root-ns]} (:compile emit)
+        {:keys [module]} mopts]
+    (keep (fn [ns]
+            (let [import  (emit-module-setup-link-import
+                           type
+                           (:id module)
+                           ns
+                           links
+                           module
+                           (:link (:code emit))
+                           root-ns)
+                  form (deps/module-import-form book
+                                                (:ns import)
+                                                import
+                                                (assoc-in mopts [:emit :import] :link))]
+              (if form
+                (impl/emit-direct grammar
+                                  form
+                                  namespace
+                                  mopts))))
+          direct)))
+
+(defn emit-module-setup-export-body
+  "creates the setup code for internal links"
+  {:added "4.0"}
+  [{:keys [library
+           lang
+           emit] :as meta}
+   prep]
+  (let [[[_ grammar book namespace mopts]]  prep
+        {:keys [module]} mopts]
+    (if (and (= :module (:layout mopts))
+             (not (-> emit :export :suppress))
+             (not (false? (-> module :static :export))))
+      (let [form (deps/module-export-form book module mopts)]
+        (if form
+          (impl/emit-direct grammar
+                            form
+                            namespace
+                            mopts))))))
+
+(defn emit-module-setup-raw
+  "creates module setup map of array strings"
+  {:added "4.0"}
+  [module-id
+   {:keys [library
+           lang
+           emit] :as meta}]
+  (let [prep   (emit-module-prep module-id meta)
+        [[stage grammar book namespace mopts]
+         {:keys [setup
+                 native
+                 link
+                 header
+                 code
+                 export]}] prep
+        setup-body   (if (and (not (-> emit :setup :suppress))
+                              setup)
+                       (impl/emit-direct grammar
+                                         setup
+                                         namespace
+                                         (update mopts :emit merge (:setup emit))))
+
+        native-arr   (emit-module-setup-native-arr meta prep)
+        link-arr     (emit-module-setup-link-arr meta prep)
+        header-arr   (if (not (-> emit :header :suppress))
+                       (let [header-opts  (update mopts :emit merge (:header emit))]
+                         (keep (fn [entry]
+                                 (binding [*ns* (:namespace entry)]
+                                   (entry/emit-entry grammar entry header-opts)))
+                               header)))
+        code-arr     (if (not (-> emit :code :suppress))
+                       (let [code-opts    (update mopts :emit merge (:code emit))]
+                         (keep (fn [entry]
+                                 (binding [*ns* (:namespace entry)]
+                                   (entry/emit-entry grammar entry code-opts)))
+                               code)))
+        export-body  (emit-module-setup-export-body meta prep)]
+    {:setup-body setup-body
+     :native-arr native-arr
+     :link-arr   link-arr
+     :header-arr header-arr
+     :code-arr code-arr
+     :export-body export-body}))
+
+(defn emit-module-setup
+  "emits the entire module as string"
+  {:added "4.0"}
+  [module-id
+   {:keys [library
+           lang
+           emit] :as meta}]
+  (let [raw (emit-module-setup-raw module-id meta)]
+    (emit-module-setup-join raw)))
+
+;;
+;; TEARDOWN
+;;
+
+(defn emit-module-teardown-concat
+  "joins teardown raw into individual blocks
+
+   (-> (emit-module-teardown-raw 'xt.lang.base-lib
+                                 {:lang :lua})
+       (emit-module-teardown-concat))
+   => coll?"
+  {:added "4.0"}
+  [{:keys [teardown-body
+           code-arr
+           native-arr]
+    :as raw}]
+  (->> (concat code-arr
+               native-arr
+               [teardown-body])
+       (filter not-empty)))
+
+(defn emit-module-teardown-join
+  "joins teardown raw into code
+
+   (-> (emit-module-teardown-raw 'xt.lang.base-lib
+                                 {:lang :lua})
+       (emit-module-teardown-join))
+   => string?"
+  {:added "4.0"}
+  [{:keys [teardown-body
+           code-arr
+           native-arr]
+    :as raw}]
+  (->> [(str/join "\n\n" code-arr)
+        (str/join "\n\n" native-arr)
+        teardown-body]
+       (filter not-empty)
+       (str/join "\n\n")))
+
+(defn emit-module-teardown-raw
+  "creates module teardown map of array strings"
+  {:added "4.0"}
+  [module-id
+   {:keys [library
+           lang
+           emit] :as meta}]
+  (let [[[stage grammar book namespace mopts]
+         {:keys [teardown
+                 native
+                 code]}] (emit-module-prep module-id meta)
+        code-arr       (if (not (-> emit :code :suppress))
+                         (let [code-opts    (assoc mopts :emit (:code emit))]
+                           (keep (fn [entry]
+                                   (if-let [form (deps/teardown-ptr-form book entry)]
+                                     (impl/emit-direct grammar
+                                                       form
+                                                       namespace
+                                                       code-opts)))
+                                 (reverse code))))
+        native-arr     (if (not (-> emit :native :suppress))
+                         (let [native-opts  (assoc mopts :emit (:native emit))]
+                           (keep (fn [[name module]]
+                                   (if-let [form (deps/teardown-module-form book module)]
+                                     (impl/emit-direct grammar
+                                                       form
+                                                       namespace
+                                                       native-opts)))
+                                 native)))
+        teardown-body  (if (and (not (-> emit :teardown :suppress))
+                                teardown)
+                         (impl/emit-direct grammar
+                                           teardown
+                                           namespace
+                                           (assoc mopts :emit (:teardown emit))))]
+    {:code-arr code-arr
+     :native-arr native-arr
+     :teardown-body teardown-body}))
+
+(defn emit-module-teardown
+  "creates the teardown script"
+  {:added "4.0"}
+  [module-id
+   {:keys [library
+           lang
+           emit] :as meta}]
+  (let [raw (emit-module-teardown-raw module-id meta)]
+    (emit-module-teardown-join raw)))
+
+
+(comment
+
+  #_(when (and (= :module (:layout mopts))
+               (-> mopts :module :export :as)
+               (not (-> emit :export :suppress)))
+      (when-not (:as export)
+        (h/prn   "Missing export `:as` field" {:input export
+                                               :module module-id})
+        (h/error "Missing export `:as` field" {:input export
+                                               :module module-id}))
+      (when-not (:entry export)
+        (h/prn   "Missing export `:entry` field" {:input export
+                                                  :module module-id})
+        (h/error "Missing export `:entry` field" {:input export
+                                                  :module module-id}))
+      (str (entry/emit-entry grammar (:entry export)
+                             (update mopts :emit merge (:export emit)))
+           "\n\n"
+           (impl/emit-direct
+            grammar
+            (deps/module-export-form book
+                                     (-> mopts :module :export)
+                                     mopts)
+            namespace
+            mopts))))

--- a/src/bb/lang/base/library.clj
+++ b/src/bb/lang/base/library.clj
@@ -1,0 +1,297 @@
+(ns bb.lang.base.library
+  (:require [bb.lib :as h :refer [defimpl]]
+            [std.protocol.component :as protocol.component]
+            [bb.lang.base.library-snapshot :as snap]
+            [bb.lang.base.impl-entry :as entry]
+            [bb.lang.base.book-module :as m]
+            [bb.lang.base.book-entry :as e]
+            [bb.lang.base.book :as b]
+            [bb.lang.base.util :as ut]
+            [std.concurrent :as cc]))
+
+(def ^:dynamic *strict* false)
+
+(def +ops+
+  {:add-book    (fn [snapshot book]
+                  [(:lang book) (snap/add-book snapshot book)])
+   :delete-book (fn [snapshot lang]
+                  [lang (dissoc snapshot lang)])
+   :set-module     snap/set-module
+   :delete-module  snap/delete-module
+   :delete-entry   snap/delete-entry})
+
+(defn wait-snapshot
+  "gets the current waiting snapshot
+
+   (lib/wait-snapshot +library+)
+   => snap/snapshot?
+
+   (meta (lib/wait-snapshot +library+))
+   => {:parent nil}"
+  {:added "4.0"}
+  [lib]
+  (let [parent (if-let [p (:parent lib)]
+                 (wait-snapshot (if (or (var? p)(fn? p))
+                                  (p)
+                                  p)))
+        #_#__    (cc/hub:wait (get-in lib [:dispatch :runtime :queue]))]
+    (with-meta (snap/snapshot-merge parent @(:instance lib))
+      {:parent parent})))
+
+(defn wait-apply
+  "get the library state when task queue is empty"
+  {:added "4.0"}
+  [lib f & args]
+  (let [snapshot (wait-snapshot lib)]
+    (apply f snapshot args)))
+
+(defn wait-mutate!
+  "mutates library once task queue is empty"
+  {:added "4.0"}
+  [lib f & args]
+  (let [{:keys [parent]} (meta (wait-snapshot lib))]
+    (h/swap-return! (:instance lib)
+      (fn [snapshot]
+        (binding [snap/*parent* parent]
+          (let [out (apply f snapshot args)
+                _   (when *strict*
+                      (h/map-vals (comp snap/install-check-merged :book) (second out)))]
+            out))))))
+
+(defn get-snapshot
+  "gets the current snapshot for the library"
+  {:added "4.0"}
+  [lib]
+  (wait-apply lib identity))
+
+(defn get-book
+  "gets a book from library"
+  {:added "4.0"}
+  [lib lang]
+  (wait-apply lib snap/get-book lang))
+
+(defn get-book-raw
+  "gets the raw book, without merge
+
+   (b/list-entries (lib/get-book-raw +library+ :redis))
+   => empty?
+
+   (b/list-entries (lib/get-book +library+ :redis))
+   => coll?"
+  {:added "4.0"}
+  [lib lang]
+  (wait-apply lib snap/get-book-raw lang))
+
+(defn get-module
+  "gets a module from library"
+  {:added "4.0"}
+  [lib lang module-id]
+  (b/get-entry (wait-apply lib snap/get-book lang)
+               module-id))
+
+(defn get-entry
+  "gets an entry from library"
+  {:added "4.0"}
+  [lib {:keys [lang id module section]
+        :as entry}]
+  (b/get-base-entry (wait-apply lib snap/get-book lang)
+                    module id (or section
+                                  :code)))
+
+(defn add-book!
+  "adds a book to the library"
+  {:added "4.0"}
+  [lib book]
+  (wait-mutate! lib
+               (fn [snapshot book]
+                 [book (snap/add-book snapshot book)])
+               book))
+
+(defn delete-book!
+  "deletes a book"
+  {:added "4.0"}
+  [lib lang]
+  (wait-mutate! lib
+                (fn [snapshot lang]
+                  [(get snapshot lang) (dissoc snapshot lang)])
+               lang))
+
+(defn reset-all!
+  "resets the library"
+  {:added "4.0"}
+  ([lib]
+   (reset-all! lib nil))
+  ([lib new-snapshot]
+   (wait-mutate! lib (fn [snapshot]
+                      [snapshot (or new-snapshot
+                                    (snap/snapshot {}))]))))
+
+(defn list-modules
+  "lists all modules"
+  {:added "4.0"}
+  [lib lang]
+  (wait-apply lib snap/list-modules lang))
+
+(defn list-entries
+  "lists entries"
+  {:added "4.0"}
+  ([lib lang]
+   (wait-apply lib snap/list-entries lang))
+  ([lib lang module-id]
+   (wait-apply lib snap/list-entries lang module-id))
+  ([lib lang module-id section]
+   (wait-apply lib snap/list-entries lang module-id section)))
+
+(defn add-module!
+  "adds a module to the library
+
+   (lib/add-module! +library+ (module/book-module '{:lang :redis
+                                                    :id L.redis.hello
+                                                    :link {r L.redis
+                                                           u L.core}}))
+   => coll?
+
+   (lib/delete-module! +library+ :redis 'L.redis.hello )
+   => coll?"
+  {:added "4.0"}
+  [lib module]
+  (wait-mutate! lib snap/set-module module))
+
+(defn delete-module!
+  "deletes a module from the library"
+  {:added "4.0"}
+  [lib lang module-id]
+  (wait-mutate! lib snap/delete-module lang module-id))
+
+(defn delete-modules!
+  "deletes a bunch of modules from the library"
+  {:added "4.0"}
+  [lib lang module-ids]
+  (wait-mutate! lib snap/delete-modules lang module-ids))
+
+(defn library-string
+  "returns the library string"
+  {:added "4.0"}
+  ([{:keys [id parent instance]}]
+   (str "#lib " (vec (sort (keys @instance))))))
+
+(defimpl Library [id instance]
+  :final true
+  :string library-string
+  #_#_
+  :protocols [protocol.component/IComponent
+              :body {-start (do (h/start (:dispatch component))
+                                component)
+                     -stop  (do (h/stop (:dispatch component))
+                                component)
+                     -kill  (do (h/comp:kill (:dispatch component))
+                                component)}])
+
+(defn library?
+  "checks if object is a library"
+  {:added "4.0"}
+  ([obj]
+   (instance? Library obj)))
+
+(defn library:create
+  "creates a new library"
+  {:added "4.0"}
+  ([{:keys [id parent snapshot] :as m}]
+   (let [instance (atom (or snapshot
+                            (snap/snapshot {})))
+         settings (atom {})
+         library  (map->Library {:parent parent
+                                 #_#_:dispatch (create-dispatch instance settings)
+                                 :settings settings
+                                 :instance instance})
+         _ (swap! settings assoc :library library)]
+     library)))
+
+(defn library
+  "creates and start a new library"
+  {:added "4.0"}
+  [{:keys [id parent snapshot] :as m}]
+  (-> (library:create m)
+      (h/start)))
+
+(defn add-entry!
+  "adds the entry with the bulk dispatcher"
+  {:added "4.0"}
+  [{:keys [dispatch] :as lib} entry]
+  (dispatch entry))
+
+(defn add-entry-single!
+  "adds an entry synchronously"
+  {:added "4.0"}
+  [lib entry & [opts]]
+  (wait-mutate! lib snap/set-entry entry opts))
+
+(defn delete-entry!
+  "deletes an entry from the library"
+  {:added "4.0"}
+  [lib {:keys [lang module section id] :as m}]
+  (wait-mutate! lib snap/delete-entry m))
+
+;;
+;;
+;;
+
+(defn install-module!
+  "installs a module to library"
+  {:added "4.0"}
+  [lib lang module-id options]
+  (wait-mutate! lib
+                (fn [snapshot]
+                  (let [out (snap/install-module snapshot lang module-id options)]
+                    [out (first out)]))))
+
+(defn install-book!
+  "installs a book to library"
+  {:added "4.0"}
+  [lib book]
+  (wait-mutate! lib
+                (fn [snapshot]
+                  (let [out (snap/install-book snapshot book)]
+                    [out (first out)]))))
+
+(defn purge-book!
+  "clears all modules from book"
+  {:added "4.0"}
+  [lib lang]
+  (wait-mutate! lib
+                (fn [snapshot]
+                  (let [book (assoc (or (snap/get-book-raw snapshot lang)
+                                        (h/error "Book not found" {:lang lang}))
+                                    :modules {})]
+                    [book (snap/add-book snapshot book)]))))
+
+(comment
+  [std.dispatch :as dispatch]
+
+  (defn create-dispatch-handler
+    "the actual dispatch handler"
+    {:added "4.0"}
+    [instance settings dispatch entries]
+    (let [{:keys [library] :as opts} @settings]
+      (try
+        (wait-mutate! library snap/set-entries entries (dissoc opts :library))
+        (catch Throwable t
+          (h/beep)
+          (h/prn t)))))
+
+  (defn create-dispatch
+    "creates the dispatch for adding entries in bulk"
+    {:added "4.0"}
+    [instance settings]
+    (dispatch/create
+     {:type :queue
+      :handler (fn [m entries]
+                 (create-dispatch-handler instance settings m entries))
+      :hooks   {:on-startup (fn [_])
+                :on-process (fn [_ entries])}
+      :options {:queue {:max-batch 500
+                        :interval 100
+                        :delay 10}}})))
+
+(comment
+  (./import))

--- a/src/bb/lang/base/library_load.clj
+++ b/src/bb/lang/base/library_load.clj
@@ -1,0 +1,174 @@
+(ns bb.lang.base.library-load
+  (:require [bb.lang.base.library :as lib]
+            [bb.lang.base.impl :as impl]
+            [bb.lang.base.script :as script]
+            [bb.lang :as l]
+            [clojure.core :as core]
+            [bb.lib :as h]
+            [clojure.tools.reader :as reader]
+            [clojure.tools.reader.reader-types :as readers]
+            [code.project :as project]))
+
+(defn eval-in-library
+  "Evaluates a form within the context of a specific library instance.
+   Handles `l/script` specially to register modules in the provided library.
+   Injects module metadata for other forms to ensure correct registration without relying on global runtime state."
+  [form lib-instance ns-sym]
+  (if (and (seq? form) (= 'l/script (first form)))
+    (let [[_ lang config] form
+           config (if (map? config) config {})
+           module-id ns-sym]
+      ;; l/script expands into script-fn, which calls script-fn-base.
+      ;; script-fn-base sets up the module and runtime config in the library.
+      (script/script-fn-base lang module-id config lib-instance))
+
+    ;; For other forms (defn.js, etc.)
+    (if (and (seq? form) (symbol? (first form))
+             (or (.endsWith (name (first form)) ".js")
+                 (.endsWith (name (first form)) ".lua")
+                 (.endsWith (name (first form)) ".python")
+                 ;; Add other extensions as needed
+                 ))
+      (let [module-id ns-sym
+            ;; Inject module into metadata of the form
+            form-with-meta (vary-meta form assoc :module module-id)]
+        (impl/with:library [lib-instance]
+          (binding [*ns* (the-ns ns-sym)]
+            (eval form-with-meta))))
+
+      ;; Fallback for other forms
+      (impl/with:library [lib-instance]
+        (binding [*ns* (the-ns ns-sym)]
+          (eval form))))))
+
+(defn load-string-into-library
+  "Loads code from a string into a specific library instance.
+   Tracks namespace changes via `ns` forms.
+
+   Note: This function performs standard entry hydration (via `create-code-hydrate`)
+   which resolves links and adds metadata as defined by the language grammar.
+   However, it does NOT:
+   1. Recursively load required files (file-level hydration).
+   2. Initialize language runtimes (runtime hydration).
+   3. Execute side effects outside of the library structure."
+  [content lib-instance initial-ns-sym]
+  ;; Create namespace if it doesn't exist
+  (when-not (find-ns initial-ns-sym)
+    (create-ns initial-ns-sym))
+
+  (binding [*ns* *ns*] ;; Bind *ns* so it can be set! by `ns` forms or `in-ns`
+    (let [reader (readers/push-back-reader (java.io.StringReader. content))
+          eof    (Object.)]
+      (loop [current-ns-sym initial-ns-sym]
+        (let [form (reader/read reader false eof)]
+          (when (not= form eof)
+            (let [next-ns-sym (if (and (seq? form) (= 'ns (first form)))
+                                  (second form)
+                                  current-ns-sym)]
+              (if (= 'ns (first form))
+                ;; Evaluate ns form to ensure requires are processed
+                (eval form)
+                ;; Evaluate other forms in the library context
+                (eval-in-library form lib-instance current-ns-sym))
+
+              (recur next-ns-sym))))))))
+
+(defn load-file-into-library
+  "Loads a file into a specific library instance."
+  [filepath lib-instance]
+  (let [content (slurp filepath)
+        ;; Heuristic: if we can read the ns from the file, use it as initial.
+        ;; Otherwise use current ns.
+        initial-ns (or (h/suppress (second (read-string content))) (h/ns-sym))]
+    (load-string-into-library content lib-instance initial-ns)))
+
+(defn clone-and-load
+  "Clones the default library and loads the given file into it.
+   Useful for comparing versions."
+  [filepath]
+  (let [lib (impl/clone-default-library)]
+    (load-file-into-library filepath lib)
+    lib))
+
+(defn analyze-string
+  "Analyzes code string to find namespace and dependencies.
+   Returns a map with :ns, :requires (Clojure), and :std-requires (bb.lang)."
+  [content]
+  (let [reader (readers/push-back-reader (java.io.StringReader. content))
+        eof    (Object.)
+        info   (atom {:ns nil :requires #{} :std-requires #{}})]
+    (loop []
+      (let [form (try (reader/read reader false eof)
+                      (catch Exception e nil))]
+        (when (and form (not= form eof))
+          (cond
+            ;; Handle (ns ...)
+            (and (seq? form) (= 'ns (first form)))
+            (let [ns-name (second form)
+                  deps    (->> (rest form)
+                               (filter #(and (seq? %) (= :require (first %))))
+                               (mapcat rest)
+                               (map #(if (vector? %) (first %) %))
+                               set)]
+              (swap! info assoc :ns ns-name)
+              (swap! info update :requires into deps))
+
+            ;; Handle (l/script ...) or (bb.lang/script ...)
+            (and (seq? form) (or (= 'l/script (first form))
+                                 (= 'bb.lang/script (first form))))
+            (let [[_ _ config] form
+                  script-deps (if (map? config)
+                                (->> (:require config)
+                                     (map #(if (vector? %) (first %) %))
+                                     set)
+                                #{})]
+              (swap! info update :std-requires into script-deps)))
+          (recur))))
+    @info))
+
+(defn analyze-file
+  "Analyzes a file to find namespace and dependencies."
+  [filepath]
+  (assoc (analyze-string (slurp filepath))
+         :file filepath))
+
+(defn create-dependency-graph
+  "Creates a dependency graph from a list of files.
+   Returns a map where keys are namespaces and values are sets of dependencies."
+  [files]
+  (reduce (fn [graph file]
+            (let [{:keys [ns requires std-requires]} (analyze-file file)
+                  all-deps (into requires std-requires)]
+              (if ns
+                (assoc graph ns all-deps)
+                graph)))
+          {}
+          files))
+
+(defn load-namespace
+  "Recursively loads a namespace and its dependencies into the library.
+
+   args:
+     lib-instance - The library to load into.
+     root-ns      - The root namespace symbol to start loading from.
+     opts         - Options map.
+       :loaded    - Atom containing a set of already loaded namespaces.
+       :project   - Project map for resolving paths (defaults to code.project/project).
+
+   Returns the library instance."
+  [lib-instance root-ns & [opts]]
+  (let [loaded (get opts :loaded (atom #{}))
+        project (get opts :project (project/project))]
+    (when-not (contains? @loaded root-ns)
+      (let [filepath (project/get-path root-ns project)]
+        (when filepath
+          (let [{:keys [requires std-requires]} (analyze-file filepath)
+                all-deps (into requires std-requires)]
+            ;; Recursively load dependencies
+            (doseq [dep all-deps]
+              (load-namespace lib-instance dep {:loaded loaded :project project}))
+
+            ;; Load the current file
+            (load-file-into-library filepath lib-instance)
+            (swap! loaded conj root-ns)))))
+    lib-instance))

--- a/src/bb/lang/base/library_snapshot.clj
+++ b/src/bb/lang/base/library_snapshot.clj
@@ -1,0 +1,290 @@
+(ns bb.lang.base.library-snapshot
+  (:require [std.protocol.deps :as protocol.deps]
+            [bb.lang.base.util :as ut]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.impl-entry :as entry]
+            [bb.lib.atom :as atom]
+            [bb.lib :as h :refer [defimpl]]))
+
+(def ^:dynamic *parent* nil)
+
+(defn get-deps
+  "gets a dependency chain"
+  {:added "4.0"}
+  ([snapshot id]
+   (if-let [parent (get-in snapshot [id :book :parent])]
+     #{parent}
+     #{})))
+
+(defn snapshot-string
+  "gets the snapshot string"
+  {:added "4.0"}
+  ([snapshot]
+   (str "#lib.snapshot " (vec (sort (keys snapshot))))))
+
+(defimpl Snapshot []
+  :final true
+  :string snapshot-string
+  :protocols [protocol.deps/IDeps
+              :method {-get-entry  get
+                       -list-entries keys}])
+
+(defn snapshot?
+  "checks if object is a snapshot"
+  {:added "4.0"}
+  ([obj]
+   (instance? Snapshot obj)))
+
+(defn snapshot
+  "creates a snapshot"
+  {:added "4.0"}
+  ([m]
+   (map->Snapshot m)))
+
+
+
+;;
+;;
+;;
+
+(defn snapshot-reset
+  "resets a snapshot to it's blanked modules"
+  {:added "4.0"}
+  ([snapshot]
+   (snapshot-reset snapshot nil))
+  ([snapshot ks]
+   (map->Snapshot
+    (h/map-vals (fn [m]
+                  (assoc-in m [:book :modules] {}))
+                (if ks
+                  (select-keys snapshot ks)
+                  snapshot)))))
+
+(defn snapshot-merge
+  "a rough merge of only the modules from the child to the parent"
+  {:added "4.0"}
+  ([parent child]
+   (cond (not parent)
+         child
+
+         :else
+         (reduce-kv (fn [parent lang {:keys [book]}]
+                      (if (get parent lang)
+                        (update-in parent [lang :book :modules] merge (:modules book))
+                        (h/error "Parent has no book" {:lang lang})))
+                    parent
+                    child))))
+
+;;
+;; merge access
+;;
+
+(defn get-book-raw
+  "gets the raw book"
+  {:added "4.0"}
+  [snapshot lang]
+  (get-in snapshot [lang :book]))
+
+(defn get-book
+  "gets the merged book for a given language"
+  {:added "4.0"}
+  [snapshot lang]
+  (or lang (h/error "Lang cannot be null." {:input lang}))
+  (book/book-from snapshot lang))
+
+;;
+;; snapshot methods
+;;
+
+(defn add-book
+  "adds a book to a snapshot"
+  {:added "4.0"}
+  [snapshot {:keys [lang] :as book}]
+  (or lang (h/error "Lang cannot be null." {:input book}))
+  (assoc snapshot lang {:id lang
+                        :book book}))
+
+(defn set-module
+  "sets a module in the snapshot"
+  {:added "4.0"}
+  [snapshot module]
+  (let [{:keys [lang]} module]
+    (atom/update-diff snapshot [lang :book]
+                      (fn [book]
+                        (book/set-module book module)))))
+
+(defn delete-module
+  "deletes a module in the snapshot"
+  {:added "4.0"}
+  [snapshot lang module-id]
+  (atom/update-diff snapshot [lang :book]
+                    (fn [book]
+                      (book/delete-module book module-id))))
+
+(defn delete-modules
+  "deletes a bunch of modules in the snapshot"
+  {:added "4.0"}
+  [snapshot lang module-ids]
+  (atom/update-diff snapshot [lang :book]
+                    (fn [book]
+                      (book/delete-modules book module-ids))))
+
+(defn list-modules
+  "list modules for a snapshot"
+  {:added "4.0"}
+  [snapshot lang]
+  (book/list-entries (get-book snapshot lang) :module))
+
+(defn list-entries
+  "lists entries for a snapshot"
+  {:added "4.0"}
+  ([snapshot lang]
+   (book/list-entries (get-book snapshot lang) :code))
+  ([snapshot lang module-id]
+   (let [book (get-book snapshot lang)]
+     (h/map-juxt [identity
+                  (fn [section]
+                    (keys (get-in book [:modules module-id section])))]
+                 [:code :fragment])))
+  ([snapshot lang module-id section]
+   (-> (get-book snapshot lang)
+       (get-in [:modules module-id section])
+       keys)))
+
+(defn set-entry
+  "sets an entry in the snapshot"
+  {:added "4.0"}
+  [snapshot entry & [mopts]]
+  (let [{:keys [lang module section]} entry
+        shadow-snapshot (snapshot-merge *parent* snapshot)
+        {:keys [grammar modules]
+         :as book} (get-book shadow-snapshot lang)
+        mopts  (merge {:lang lang
+                       :snapshot shadow-snapshot
+                       :module (book/get-module book module)}
+                      mopts)
+        entry  (if (= section :fragment)
+                 (entry/create-fragment-hydrate entry
+                                                grammar
+                                                modules
+                                                mopts)
+
+                 (entry/create-code-hydrate entry
+                                            (get-in grammar [:reserved (:op entry)])
+                                            grammar
+                                            modules
+                                            mopts))]
+    (atom/update-diff snapshot [lang :book]
+                      book/set-entry entry)))
+
+(defn set-entries
+  "sets an entry in the snapshot"
+  {:added "4.0"}
+  [snapshot entries & [opts]]
+  (reduce (fn [[diffs snapshot] {:keys [namespace] :as entry}]
+            (binding [*ns* (the-ns namespace)]
+              (let [[diff new-snapshot] (set-entry snapshot entry opts)]
+                [(concat diffs diff) new-snapshot])))
+          [[] snapshot]
+          entries))
+
+(defn delete-entry
+  "deletes an entry from the snapshot"
+  {:added "4.0"}
+  [snapshot {:keys [lang module section id]}]
+  (atom/update-diff snapshot [lang :book]
+                    (fn [book]
+                      (book/delete-entry book module section id))))
+
+(defn delete-entries
+  "delete entries from the snapshot"
+  {:added "4.0"}
+  [snapshot entries]
+  (reduce (fn [[diffs snapshot] entry]
+            (let [[diff new-snapshot] (delete-entry snapshot entry)]
+              [(concat diffs diff) new-snapshot]))
+          [[] snapshot]
+          entries))
+
+
+;;
+;;
+;;
+
+(defn install-check-merged
+  "checks that the book is not merged (used to check mutate)"
+  {:added "4.0"}
+  [book & [module-id]]
+  (when (< 1 (count (:merged book)))
+    (h/prn  [module-id (:merged book)
+             (sort (keys (:modules book)))])
+    (h/error "MERGED BOOK DISALLOWED")))
+
+(defn install-module-update
+  "updates the book module"
+  {:added "4.0"}
+  [book {module-id :id
+         :as module}]
+  (let [soft-keys    [:code :fragment #_#_:bundle :export #_:macro-only]
+        soft-maps    (select-keys module soft-keys)
+        hard-maps    (apply dissoc module soft-keys)
+
+        [soft-diffs new-book] (atom/atom-put-fn book [:modules module-id] soft-maps)
+        [hard-diffs new-book] (atom/atom-set-keys-fn new-book [:modules module-id] hard-maps)
+
+        soft-changes (atom/atom:put-changed soft-diffs)
+        hard-changes (atom/atom:set-changed hard-diffs)
+        all-changes  (merge  (second soft-changes)
+                             (second hard-changes))]
+    (if (empty? all-changes)
+      [new-book :no-change]
+      [new-book :changed all-changes])))
+
+
+(defn install-module
+  "adds an new module or update fields if exists"
+  {:added "4.0"}
+  ([snapshot lang module-id options]
+   (let [new-module (-> (get-book snapshot lang)
+                        (book/module-create module-id (assoc options
+                                                             :lang lang
+                                                             :id module-id)))
+         book       (get-book-raw snapshot lang)
+         [new-book status changes]  (if (book/has-module? book module-id)
+                                      (install-module-update book new-module)
+                                      [(second (book/set-module book new-module)) :new new-module])
+         new-snapshot (if (= status :no-change)
+                        snapshot
+                        (assoc snapshot lang {:id lang
+                                              :book new-book}))]
+     [new-snapshot status changes])))
+
+;;
+;;
+;;
+
+(defn install-book-update
+  "updates the book grammar, meta and parent"
+  {:added "4.0"}
+  [snapshot {:keys [lang grammar parent meta]}]
+  (let [new-book  (-> (get-book-raw snapshot lang)
+                      (assoc :meta meta))
+        [diffs new-book] (atom/atom-set-keys-fn new-book []
+                                                {:parent parent
+                                                 :grammar grammar})]
+    (if (empty? diffs)
+      [new-book :no-change]
+      (vec (cons (add-book snapshot new-book) (atom/atom:set-changed diffs))))))
+
+(defn install-book
+  "adds a new book or updates grammar if exists"
+  {:added "4.0"}
+  [snapshot {:keys [lang parent] :as new-book}]
+  (let [_ (if parent
+            (or (get-book-raw snapshot parent)
+                (h/error "Parent not installed"
+                         {:options (keys snapshot)})))
+        _ (install-check-merged new-book nil)]
+    (if (not (get-book-raw snapshot lang))
+      [(add-book snapshot new-book) :new new-book]
+      (install-book-update snapshot new-book))))

--- a/src/bb/lang/base/manage.clj
+++ b/src/bb/lang/base/manage.clj
@@ -1,0 +1,392 @@
+(ns bb.lang.base.manage
+  (:require [std.task :as task]
+            [bb.lang.base.impl :as impl]
+            [bb.lang.base.library :as lib]
+            [bb.lang.base.util :as ut]
+            [bb.lang.base.workspace :as workspace]
+            [bb.string :as str]
+            [bb.lib :as h :refer [definvoke]]
+            [std.print.format.common :as common]
+            [std.print.ansi :as ansi]))
+
+(def ^:dynamic *current-lang* nil)
+
+(def ^:dynamic *current-module* nil)
+
+(def ^:dynamic *current-entry* nil)
+
+(def library-template
+  {:params    {:print {:function false
+                       :item false
+                       :result false
+                       :summary false}}
+   :warning   {:output  :data}
+   :error     {:output  :data}
+   :item      {:pre     identity
+               :post    identity
+               :output  identity
+               :display identity}
+   :result    {:keys    {:count count}
+               :ignore  empty?
+               :output  identity
+               :columns [{:key    :key
+                          :align  :left
+                          :color  #{:white :bold}}
+                         {:key    :data
+                          :align  :left
+                          :length 60}]}
+   :summary   {:aggregate {:total [:count + 0]}}})
+
+(defmethod task/task-defaults :lang.library
+  ([_]
+   library-template))
+
+(defn lib-overview-format
+  "formats the lib overview"
+  {:added "4.0"}
+  [{:keys [modules] :as book} & []]
+  (let [order (sort (keys modules))]
+    (->> order
+         (map (fn [id]
+                (let [module (get modules id)]
+                  (str (common/pad:right
+                        (ansi/style (str id) #{:bold :white})
+                        50)
+                       (common/pad:left
+                        (str/join
+                         (map (fn [[d style]]
+                                (if (pos? d)
+                                  (ansi/style (common/pad:left (str d) 6) style)
+                                  (ansi/style (common/pad:left "." 6) #{:grey})))
+                              [[(count (:code module)) #{:green :bold}]
+                               [(count (:fragment module)) #{:magenta}]
+                               [(dec (count (:link module))) #{:blue}]]))
+                        18)))))
+         (str/join "\n"))))
+
+(definvoke ^{:arglists '([] [lang])}
+  lib-overview
+  "specifies lib overview task"
+  {:added "4.0"}
+  [:task {:template :lang.library
+          :construct {:env      (fn [_]
+                                  (let [snapshot (lib/get-snapshot (impl/default-library))]
+                                    {:snapshot snapshot}))
+                      :input    (fn [_] *current-lang*)
+                      :lookup   (fn [_ {:keys [snapshot]}]
+                                  snapshot)}
+          :params {:title "LIBRARY OVERVIEW - [:code :fragment :link]"
+                   :print {:function false
+                           :item false
+                           :result true
+                           :summary true}}
+          :item    {:list    (fn [snapshot _]  (sort (keys snapshot)))}
+          :result  {:format  {:data lib-overview-format}
+                    :columns [{:key    :key
+                               :align  :left
+                               :color  #{:yellow :bold}}
+                              {:key    :data
+                               :align  :left
+                               :length 60}]}
+          :main    {:argcount 4
+                    :fn  (fn [lang params snapshot _]
+                           (get-in snapshot [lang :book]))}}])
+
+(comment
+  (./create-tests)
+  (lib-overview '[(:js)])
+  (lib-overview '#{:js})
+  (lib-overview :all))
+
+(defn lib-module-env
+  "compiles the lib-module task environment
+
+   (lib-module-env nil)
+   => map?"
+  {:added "4.0"}
+  [_]
+  {:modules (apply merge
+                   (map (fn [[id {:keys [book]}]]
+                          (:modules book))
+                        (lib/get-snapshot (impl/default-library))))})
+
+(defn lib-module-filter
+  "filters modules based on :lang"
+  {:added "4.0"}
+  [module-id {:keys [lang]} modules _]
+  (if-let [module (get modules (or module-id
+                                   (h/ns-sym)))]
+    (if (or (not lang)
+            (= lang (:lang module)))
+      module)))
+
+(defmethod task/task-defaults :lang.module
+  ([_]
+   (h/merge-nested library-template
+                   {:construct {:env      #'lib-module-env
+                                :input    (fn [_] *current-lang*)
+                                :lookup   (fn [_ {:keys [modules]}] modules)}
+                    :params {:print {:function false
+                                     :item false
+                                     :result true
+                                     :summary true}}
+                    :item    {:list    (fn [modules _] (sort (keys modules)))}
+                    :main    {:argcount 4}})))
+
+;;
+;;
+;; OVERVIEW
+;;
+;;
+
+(defn lib-module-overview-format
+  "formats the module overview"
+  {:added "4.0"}
+  [{:keys [lang id code fragment link native suppress export] :as module} & [{:keys [counts
+                                                                                     deps]}]]
+  (str/join-lines
+    [(if (not (false? counts))
+       (str (ansi/style (common/pad:left (name lang) 10) #{:yellow :bold})
+            "  "
+            (ansi/style (common/pad:right (str (count code)) 5)
+                        #{:bold :green})
+            (ansi/style (common/pad:right (str (count fragment)) 5)
+                        #{:magenta})
+            "  "
+            (:as export)))
+     (if deps
+       (str/indent  (str/join-lines
+                     (concat (map #(ansi/style (str %) #{:blue})
+                                  (vals (dissoc link '-)))
+                             (map #(ansi/style (str %) #{:cyan :bold})
+                                  (keys native))))
+                    12))]))
+
+(definvoke ^{:arglists '([] [module-id] [module-id {:keys [lang entry]}])}
+  lib-module-overview
+  "lists all modules"
+  {:added "4.0"}
+  [:task {:template :lang.module
+          :params {:title "MODULES OVERVIEW"}
+          :result  {:format  {:data #'lib-module-overview-format}}
+          :main    {:fn  #'lib-module-filter}}])
+
+(comment
+  (lib-module-overview :all {:lang :lua})
+  (lib-module-overview :all {:lang :js
+                             :counts true
+                             :deps true})
+  (lib-module-overview :all))
+
+;;
+;;
+;; ENTRIES
+;;
+;;
+
+(defn lib-module-entries-format-section
+  "formats either code or fragment section"
+  {:added "4.0"}
+  [module section style & [op]]
+  (->> (vals (get module section))
+       (sort-by (fn [e]
+                  (mapv #(get e %) [:namespace :line :time])))
+       (map (fn [{:keys [id line] :as e}]
+              (str (common/pad:right (str line) 5)
+                   (ansi/style
+                    (str (common/pad:right
+                          (str id)
+                          45))
+                    style)
+                   (common/pad:left
+                    (str (if op (or (:op-key e)
+                                    (if (:template e)
+                                      :macro
+                                      :fragment))))
+                    12))))
+       (str/join "\n")))
+
+(defn lib-module-entries-format
+  "formats the entries of a module"
+  {:added "4.0"}
+  [{:keys [lang code fragment export] :as module} & [params]]
+  (str (str/join "\n--------------------------------------------------------------\n"
+         [(str (ansi/style (name lang) #{:yellow :bold}) " " (:as export))
+          (->> (lib-module-overview-format module {:counts false
+                                                   :deps true})
+               (str/split-lines)
+               (map str/trim-left)
+               (str/join "\n"))
+          (str/join "\n--------------------------------------------------------------\n"
+            [(if (not (false? (:code params)))
+               (lib-module-entries-format-section module :code #{:green :bold} true))
+             (if (not (false? (:fragment params)))
+               (lib-module-entries-format-section module :fragment #{:magenta} true))])])
+       "\n"))
+
+(definvoke ^{:arglists '([] [module-id] [module-id {:keys [lang entry]}])}
+  lib-module-entries
+  "outputs module entries"
+  {:added "4.0"}
+  [:task {:template :lang.module
+          :params {:title "MODULES OVERVIEW"}
+          :result  {:format  {:data #'lib-module-entries-format}}
+          :main    {:fn  #'lib-module-filter}}])
+
+(comment (comment
+           (lib-module-entries '[js])
+           (lib-module-entries '[kmi])
+           (lib-module-entries :all {:lang :lua})
+           (lib-module-entries :all)))
+
+;;
+;;
+;; PURGE
+;;
+;;
+
+(defn lib-module-purge-fn
+  "the purge module function"
+  {:added "4.0"}
+  [module-id params modules env]
+  (if-let [{:keys [lang id] :as module} (lib-module-filter module-id params modules env)]
+    (second (first (lib/delete-module! (impl/default-library)
+                                       (:lang module)
+                                       module-id)))))
+
+(definvoke ^{:arglists '([] [module-id] [module-id {:keys [lang]}])}
+  lib-module-purge
+  "purges modules"
+  {:added "4.0"}
+  [:task {:template :lang.module
+          :params {:title "PURGE MODULES"}
+          :result  {:format  {:data  #'lib-module-entries-format}}
+          :main    {:fn  #'lib-module-purge-fn}}])
+
+(comment (comment
+           (lib-module-purge '[rt.postgres])
+           (do (./reset '[rt.postgres])
+               (require '[rt.postgres])
+               (lib-overview '[:postgres]))
+           (lib-module-entries '[statsdb])
+           (lib-module-purge '[statsdb])
+           (do (./reset '[statsdb])
+               (require '[statsdb.core.infra])
+               (lib-overview '[:postgres]))))
+
+;;
+;;
+;; UNUSED DEPS
+;;
+;;
+
+(defn lib-module-unused-fn
+  "analyzes the module for unused links"
+  {:added "4.0"}
+  [module-id params modules env]
+  (if-let [{:keys [code link] :as module}
+           (lib-module-filter module-id params modules env)]
+    (let [{:keys [ignore]} params
+          lookup (h/transpose link)
+          unused (volatile! (apply dissoc link '-
+                                   (mapcat (fn [ns]
+                                             [ns (lookup ns)])
+                                           ignore)))]
+      (doseq [entry (vals code)]
+        (let [{:keys [form-input]} entry]
+          (h/prewalk (fn [form]
+                       (if-let [ns (and (symbol? form)
+                                        (namespace form))]
+                         (let [ns (symbol ns)]
+                           (vswap! unused dissoc ns (lookup ns))))
+                       form)
+                     form-input)))
+      (vec (sort (vals @unused))))
+    []))
+
+(definvoke ^{:arglists '([] [module-id] [module-id {:keys [lang]}])}
+  lib-module-unused
+  "lists unused modules"
+  {:added "4.0"}
+  [:task {:template :lang.module
+          :params {:title "UNUSED DEPENDENCIES"}
+          :result  {:format  {:data  (fn [result _]
+                                       (str/join "\n" result))}}
+          :main    {:fn  #'lib-module-unused-fn}}])
+
+(comment (comment
+           (lib-module-unused [(fn [s]
+                                 (str/ends-with? s "test"))])
+
+           (lib-module-unused [(fn [s]
+                                 (not (str/ends-with? s "test")))]
+                              {:ignore '[xt.lang.base-lib
+                                         js.react
+                                         js.core]})
+
+           (lib-module-unused '[#"test$"])
+           (lib-module-unused '[melbourne])))
+
+;;
+;;
+;; MISSING LINES
+;;
+;;
+
+(defn lib-module-missing-line-number-fn
+  "helper function to `lib-module-missing-line-number`"
+  {:added "4.0"}
+  [module-id params modules env]
+  (if-let [{:keys [code link] :as module}
+           (lib-module-filter module-id params modules env)]
+    (if (some (comp nil? :line) (vals code))
+      module)))
+
+(definvoke ^{:arglists '([] [module-id] [module-id {:keys [lang]}])}
+  lib-module-missing-line-number
+  "lists modules with entries that are missing line numbers (due to inproper macros)"
+  {:added "4.0"}
+  [:task {:template :lang.module
+          :params {:title "MISSING LINE NUMBER"}
+          :result  {:format  {:data  #'lib-module-entries-format}}
+          :main    {:fn  #'lib-module-missing-line-number-fn}}])
+
+
+(comment (comment
+           (lib-module-missing-line-number :all)))
+
+;;
+;;
+;; UNUSED DEPS
+;;
+;;
+
+(defn lib-module-incorrect-alias-fn
+  "helper function to `lib-module-incorrect-alias`"
+  {:added "4.0"}
+  [module-id params modules env]
+  (if-let [{:keys [link] :as module}
+           (lib-module-filter module-id params modules env)]
+    (let [all (filter (fn [[id ns]]
+                        (when (and (< 3 (count (str id)))
+                                   (str/includes? (str id) "-")
+                                   (not (str/ends-with? (str ns)
+                                                        (str id))))
+                          [id ns]))
+                      link)]
+      (when (not-empty all)
+        all))))
+
+(definvoke ^{:arglists '([] [module-id] [module-id {:keys [lang]}])}
+  lib-module-incorrect-alias
+  "lists modules that have an incorrect alias"
+  {:added "4.0"}
+  [:task {:template :lang.module
+          :params {:title "INCORRECT ALIASES"}
+          :result  {:format  {:data  (fn [result _]
+                                       (str/join "\n" result))}}
+          :main    {:fn  #'lib-module-incorrect-alias-fn}}])
+
+
+(comment (comment
+           (lib-module-incorrect-alias :all)))

--- a/src/bb/lang/base/pointer.clj
+++ b/src/bb/lang/base/pointer.clj
@@ -1,0 +1,331 @@
+(ns bb.lang.base.pointer
+  (:require [bb.lang.base.emit :as emit]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.impl :as impl]
+            [bb.lang.base.impl-deps :as deps]
+            [bb.lang.base.library :as lib]
+            [bb.lang.base.library-snapshot :as snap]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.book-entry :as e]
+            [bb.lang.base.util :as ut]
+            [bb.string :as str]
+            [std.json :as json]
+            [bb.lib :as h]))
+
+(defn- default-rt-wrap [f]
+  (fn [rt input]
+    (f rt input)))
+
+;; controls whether to copy a form
+(def ^:dynamic *clip* nil)
+
+;; controls whether to copy a form
+(def ^:dynamic *rt-wrap* #'default-rt-wrap)
+
+;; controls whether to print a form
+(def ^:dynamic *print* #{})
+
+;; controls whether to shortcut at the input string
+(def ^:dynamic *input* #{})
+
+;; controls returning the raw output
+(def ^:dynamic *output* #{:full})
+
+(defmacro with:clip
+  "form to control `clip` option"
+  {:added "4.0"}
+  ([& body]
+   `(binding [*clip* true]
+      ~@body)))
+
+(defmacro ^{:style/indent 0}
+  with:print
+  "form to control `print` option"
+  {:added "4.0"}
+  ([& body]
+   (let [[params & body] (if (and (vector? (first body))
+                                  (not-empty (first body)))
+                           body
+                         (cons #{:input} body))]
+     `(binding [*print* ~(set params)]
+        ~@body))))
+
+(defmacro ^{:style/indent 0}
+  with:print-all
+  "toggles print for all intermediate steps"
+  {:added "4.0"}
+  ([& body]
+   `(binding [*print* #{:input-form
+                        :raw-input
+                        :raw-output}]
+      ~@body)))
+
+(defmacro with:rt-wrap
+  "wraps an additional function to the invoke function"
+  {:added "4.0"}
+  ([[f] & body]
+   `(binding [*rt-wrap* ~f]
+      ~@body)))
+
+(defmacro with:rt
+  "forcibly applies a runtime"
+  {:added "4.0"}
+  ([[rt] & body]
+   `(binding [bb.lib.context.pointer/*runtime* ~rt]
+      ~@body)))
+
+(defmacro ^{:style/indent 0}
+  with:input
+  "form to control `input` option"
+  {:added "4.0"}
+  ([& body]
+   (let [[params & body] (if (and (vector? (first body))
+                                  (not-empty (first body)))
+                           body
+                           (cons #{:default} body))]
+     `(binding [*input* ~(set params)]
+        ~@body))))
+
+(defmacro with:raw
+  "form to control `raw` option"
+  {:added "4.0"}
+  ([& body]
+   `(binding [*output* #{:raw}]
+      ~@body)))
+
+(defn get-entry
+  "gets the library entry given pointer"
+  {:added "4.0"}
+  ([{:keys [lang id module section library runtime] :as ptr}]
+   (let [library (or library (impl/runtime-library))]
+     (lib/get-entry library ptr))))
+
+;;
+;;
+;;
+
+(defn ptr-tag
+  "creates a tag for the pointer"
+  {:added "4.0"}
+  ([ptr tag]
+   (vec (cons tag [(ut/sym-full ptr) (:section ptr)]))))
+
+(defn ptr-deref
+  "gets the entry or the free pointer data"
+  {:added "4.0"}
+  ([ptr]
+   (let [{:keys [lang module id]} ptr]
+     (if (and lang module id)
+       (get-entry ptr)
+       (into {} ptr)))))
+
+(defn ptr-display
+  "emits the display string for pointer"
+  {:added "4.0"}
+  ([{:keys [lang form id module section library] :as ptr} meta]
+   (let [meta  (assoc meta
+                      :lang lang
+                      :module module
+                      :library (or library (impl/runtime-library)))]
+     (cond form
+           (impl/emit-str form meta)
+
+           (not id)
+           (cond->  "<free"
+             module (str ":" module)
+             :then (str ">"))
+
+           :else
+           (let [entry (get-entry ptr)]
+             (cond (nil? entry)
+                   (str (ptr-tag ptr :not-found))
+
+                   (= :fragment section)
+                   (let [{:keys [form standalone template]} entry]
+                     (cond (h/form? standalone)
+                           (str/trim (with-out-str (clojure.pprint/pprint (second standalone))))
+
+                           (not template)
+                           (impl/emit-str form meta)
+
+                           :else
+                           (let [args (second form)]
+                             (str/trim (with-out-str (clojure.pprint/pprint
+                                                      (or (h/suppress (list 'fn:> args (apply template args)))
+                                                          form)))))))
+                   :else
+                   (impl/emit-entry entry meta)))))))
+
+(defn ptr-invoke-meta
+  "prepares the meta for a pointer"
+  {:added "4.0"}
+  [{:keys [library] :as ptr} {:keys [module
+                                        emit]
+                                 :as meta}]
+  (let [lang     (or (:lang meta)
+                     (:lang ptr))
+        library  (or library (impl/runtime-library))
+        snapshot (cond-> (lib/get-snapshot library)
+                   module (-> (snap/set-module module) second))
+        book     (snap/get-book snapshot lang)
+        module   (or module
+                     (get-in book [:modules (:module ptr)]))
+
+        module   (if-let [internal (-> emit :runtime :module/internal)]
+                   (assoc module
+                          :link (h/transpose internal)
+                          :internal internal)
+                   module)]
+    (assoc meta
+           :lang lang
+           :snapshot snapshot
+           :module module)))
+
+(defn rt-macro-opts
+  "creates the default macro-opts for a runtime"
+  {:added "4.0"}
+  [lang-or-runtime]
+  (let [{:keys [lang module] :as rt} (if (keyword? lang-or-runtime)
+                                       (ut/lang-rt lang-or-runtime)
+                                       lang-or-runtime)]
+    (ptr-invoke-meta (ut/lang-pointer lang
+                                      {:module module})
+                     (select-keys rt [:lang :layout :emit]))))
+
+(defn ptr-invoke-string
+  "emits the invoke string"
+  {:added "4.0"}
+  [ptr args meta]
+  (let [meta (ptr-invoke-meta ptr meta)]
+    (binding [impl/*print-form* (:input-form *print*)]
+      (cond (:id ptr)
+            (let [entry (-> (snap/get-book (:snapshot meta)
+                                           :lang)
+
+                            (book/get-base-entry (:module ptr)
+                                                 (:id ptr)
+                                                 (:section ptr)))]
+              (if (= :defrun (:op-key entry))
+                (impl/emit-str (apply list 'do (drop 2 (:form @ptr))) meta)
+               (impl/emit-str (apply list ptr args) meta)))
+
+            :else
+            (impl/emit-str (with-meta (vec args)
+                             {:bulk true})
+                           meta)))))
+
+(defn ptr-invoke-script
+  "emits a script with dependencies"
+  {:added "4.0"}
+  [ptr args meta]
+  (let [meta (ptr-invoke-meta ptr (merge {:layout :full}
+                                         meta))]
+    (binding [impl/*print-form* (:input-form *print*)]
+      (cond (:form ptr)
+            (impl/emit-script (:form ptr) meta)
+
+            (:id ptr)
+            (if (= :defrun (:op-key @ptr))
+              (impl/emit-script (apply list 'do (drop 2 (:form @ptr))) meta)
+              (impl/emit-script (apply list ptr args) meta))
+
+            :else
+            (impl/emit-script (with-meta (vec args)
+                                {:bulk true})
+                              meta)))))
+
+(defn ptr-intern
+  "interns the symbol into the workspace environment"
+  {:added "4.0"}
+  [ns name {:keys [lang id module section form template standalone] :as m}]
+  (let [ks [:lang :id :module :section]
+        ptr (ut/lang-pointer lang (select-keys m ks))]
+    (intern ns name ptr)))
+
+(defn ptr-output-json
+  "extracetd function from ptr-output"
+  {:added "4.0"}
+  [out]
+  (let [{:strs [type value return]} out
+        type (h/unseqify type)
+        out (case type
+              "data"    value
+              "raw"     (h/wrapped value identity return)
+              "error"   (throw (if (map? value)
+                                 (ex-info "" value)
+                                 (ex-info "" {:err (vec (filter not-empty
+                                                                (str/split-lines (str value))))})))
+              out)
+        _    (when (:output *print*)
+               (h/pl out))]
+    out))
+
+(defn ptr-output
+  "output types for embedded return values"
+  {:added "4.0"}
+  [out json]
+  (cond (:raw *output*) out
+
+        (or (var? json)
+            (fn? json)) (json out)
+
+        :else
+        (let [out (if (= json :string)
+                    (str out)
+                    out)]
+          (if (and (string? out)
+                   json)
+
+            (let [out (try (json/read out)
+                           (catch Throwable t
+                             (h/wrapped out)))]
+              (if (:json *output*)
+                out
+                (if (and (= json :full)
+                         (not (h/wrapped? out)))
+                  (ptr-output-json out)
+                  out)))
+
+            out))))
+
+(defn ptr-invoke
+  "invokes the pointer"
+  {:added "4.0"}
+  [rt raw-eval body main json]
+  (let [in-fn   (fn [body]
+                  (cond-> body (:in main)  ((:in main))))
+        out-fn  (fn [body]
+                  (cond-> body (:out main) ((:out main))))
+        _    (when *clip*
+               (h/clip body))
+        _    (when (:input *print*)
+               (h/pl body))]
+    (cond (not-empty *input*)
+          (cond-> body
+            (:raw *input*) in-fn)
+
+          :else
+          (let [input (in-fn body)
+                _    (when (:raw-input *print*)
+                       (h/local :println
+                                "\n"
+                                (h/pl-add-lines input)
+                                "\n"))
+                raw-eval (if *rt-wrap*
+                           (*rt-wrap* raw-eval)
+                           raw-eval)
+                raw   (try (out-fn (raw-eval rt input))
+                           (catch Throwable t
+                             (when common/*explode*
+                               (h/prn :OUTPUT-ERROR t))
+                             (throw t)))
+                _    (when (:raw-output *print*)
+                       (try (let [data (json/read raw)
+                                  {:strs [type value]}  data]
+                              (cond (= type "error")
+                                    (doseq [[k v] value]
+                                      (h/pl (str k ":\n" v)))))
+                            (catch Throwable t
+                              (h/pl raw))))
+                output (ptr-output raw json)]
+            output))))

--- a/src/bb/lang/base/registry.clj
+++ b/src/bb/lang/base/registry.clj
@@ -1,0 +1,71 @@
+(ns bb.lang.base.registry)
+
+(def +registry+
+  (atom {[:postgres :default]          'rt.postgres.grammar
+         [:postgres :jdbc]             'rt.postgres.client
+         [:postgres :jdbc.client]      'rt.postgres.client
+
+         [:redis    :default]          'rt.redis
+         [:redis    :redis]            'rt.redis
+
+         [:solidity :default]          'rt.solidity.grammar
+
+	 [:bash   :oneshot]            'rt.basic.impl.process-bash
+	 [:bash   :basic]              'rt.shell
+	 [:bash   :remote]             'rt.shell
+
+         [:lua    :oneshot]            'rt.basic.impl.process-lua
+         [:lua    :basic]              'rt.basic.impl.process-lua
+         [:lua    :interactive]        'rt.basic.impl.process-lua
+         [:lua    :websocket]          'rt.basic.impl.process-lua
+         [:lua    :nginx]              'rt.nginx
+         [:lua    :nginx.instance]     'rt.nginx
+         [:lua    :redis]              'rt.redis
+         [:lua    :remote-port]        'rt.basic.impl.process-lua
+         [:lua    :remote-ws]          'rt.basic.impl.process-lua
+
+         [:js     :oneshot]            'rt.basic.impl.process-js
+         [:js     :basic]              'rt.basic.impl.process-js
+         [:js     :interactive]        'rt.basic.impl.process-js
+         [:js     :websocket]          'rt.basic.impl.process-js
+         [:js     :javafx]             'rt.javafx
+         [:js     :graal]              'rt.graal
+         [:js     :browser]            'rt.browser
+         [:js     :remote-port]        'rt.basic.impl.process-js
+         [:js     :remote-ws]          'rt.basic.impl.process-js
+
+         [:python :oneshot]            'rt.basic.impl.process-python
+         [:python :basic]              'rt.basic.impl.process-python
+         [:python :interactive]        'rt.basic.impl.process-python
+         [:python :websocket]          'rt.basic.impl.process-python
+         [:python :graal]              'rt.graal
+         [:python :jep]                'rt.jep
+         [:python :libpython]          'rt.libpython
+         [:python :remote-port]        'rt.basic.impl.process-python
+         [:python :remote-ws]          'rt.basic.impl.process-python
+
+         [:ruby   :oneshot]            'rt.basic.impl.process-ruby
+         [:ruby   :basic]              'rt.basic.impl.process-ruby
+
+         [:perl   :oneshot]            'rt.basic.impl.process-perl
+         [:perl   :basic]              'rt.basic.impl.process-perl
+
+         [:php    :oneshot]            'rt.basic.impl.process-php
+         [:php    :basic]              'rt.basic.impl.process-php
+
+         [:r      :oneshot]            'rt.basic.impl.process-r
+         [:r      :basic]              'rt.basic.impl.process-r
+
+         [:julia  :oneshot]            'rt.basic.impl.process-julia
+         [:julia  :basic]              'rt.basic.impl.process-julia
+
+         [:erlang :oneshot]            'rt.basic.impl.process-erlang
+         [:erlang :basic]              'rt.basic.impl.process-erlang
+
+         [:rust   :twostep]            'rt.basic.impl.process-rust
+
+         [:c      :jocl]               'rt.jocl
+         [:c      :oneshot]            'rt.basic.impl.process-c
+         [:c      :twostep]            'rt.basic.impl.process-c
+
+         [:xtalk  :oneshot]            'rt.basic.impl.process-xtalk}))

--- a/src/bb/lang/base/runtime.clj
+++ b/src/bb/lang/base/runtime.clj
@@ -1,0 +1,540 @@
+(ns bb.lang.base.runtime
+  (:require [std.protocol.context :as protocol.context]
+            [std.protocol.component :as protocol.component]
+            [bb.lang.base.runtime-proxy :as proxy]
+            [bb.lang.base.pointer :as ptr]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.emit-preprocess :as preprocess]
+            [bb.lang.base.impl :as impl]
+            [bb.lang.base.impl-deps :as deps]
+            [bb.lang.base.impl-lifecycle :as lifecycle]
+            [bb.lang.base.library :as lib]
+            [bb.lang.base.library-snapshot :as snap]
+            [bb.lang.base.util :as ut]
+            [std.json :as json]
+            [bb.lib :as h :refer [defimpl]]
+            [bb.lib.context.registry :as reg]
+            [bb.string :as str]))
+
+;;
+;; Default Runtime
+;;
+
+(defn default-tags-ptr
+  "runtime default args"
+  {:added "4.0"}
+  ([rt ptr]
+   (ptr/ptr-tag ptr (:runtime rt))))
+
+(defn default-deref-ptr
+  "runtime default deref"
+  {:added "4.0"}
+  ([{:keys [library] :as rt} ptr]
+   (ptr/ptr-deref (assoc ptr :library library))))
+
+(defn default-invoke-ptr
+  "runtime default invoke"
+  {:added "4.0"}
+  ([{:keys [id library layout emit] :as rt} ptr args]
+   (ptr/ptr-invoke-string ptr args
+                          {:library library ;; override default library
+                           :layout  layout
+                           :emit    (merge emit
+                                           {:transform (fn [args {:keys [bulk] :as mopts}]
+                                                         (if bulk
+                                                           (apply list 'do args)
+                                                           args))
+                                            :runtime
+                                            (assoc rt
+                                                   :type (:runtime rt)
+                                                   :namespace (h/ns-sym))})})))
+
+(defn default-init-ptr
+  "will init pointer if there is a :rt/init key"
+  {:added "4.0"}
+  [{:keys [id lang library layout module emit] :as rt} entry]
+  (when (and (#{:defglobal :defrun} (:op-key entry))
+             (:rt/init entry))
+    (h/p:rt-invoke-ptr rt
+                       (ut/lang-pointer lang
+                                        {:module module})
+                       [(:form-input entry)])))
+
+(defn default-display-ptr
+  "runtime default display"
+  {:added "4.0"}
+  ([{:keys [lang library module emit] :as rt} ptr]
+   (cond (#{:defglobal} (:op-key @ptr))
+         (let [body (impl/emit-as lang [(ut/sym-full ptr)] {:layout :full
+                                                            :emit emit})]
+           (ptr/ptr-invoke rt
+                           h/p:rt-raw-eval
+                           body
+                           (:main emit)
+                           (or (:json emit) :full)))
+
+         :else
+         (ptr/ptr-display ptr {:library library
+                               :emit emit}))))
+
+(def default-raw-eval
+  (fn [_ string] string))
+
+(def default-transform-in-ptr
+  (fn [_ _ args] args))
+
+(def default-transform-out-ptr
+  (fn [_ _ return] return))
+
+(defn- rt-default-string [{:keys [lang]}]
+  (str "#rt:lang" [lang]))
+
+(defimpl RuntimeDefault [lang redirect]
+  :string rt-default-string
+  :protocols
+  [protocol.context/IContext
+   :body
+   {-raw-eval      (if redirect
+                     (proxy/proxy-raw-eval rt string)
+                     (default-raw-eval rt string))
+    -init-ptr      (if redirect
+                     (proxy/proxy-init-ptr rt ptr)
+                     (default-init-ptr rt ptr))
+    -tags-ptr      (if redirect
+                     (proxy/proxy-tags-ptr rt ptr)
+                     (default-tags-ptr rt ptr))
+    -deref-ptr     (if redirect
+                     (proxy/proxy-deref-ptr rt ptr)
+                     (default-deref-ptr rt ptr))
+    -display-ptr   (if redirect
+                     (proxy/proxy-display-ptr rt ptr)
+                     (default-display-ptr rt ptr))
+    -invoke-ptr    (if redirect
+                     (proxy/proxy-invoke-ptr rt ptr args)
+                     (default-invoke-ptr rt ptr args))
+    -transform-in-ptr   (if redirect
+                          (proxy/proxy-transform-in-ptr rt ptr args)
+                          (default-transform-in-ptr rt ptr args))
+    -transform-out-ptr  (if redirect
+                          (proxy/proxy-transform-out-ptr rt ptr return)
+                          (default-transform-out-ptr rt ptr return))}
+   protocol.component/IComponent
+   :body
+   {-start  (if redirect
+              (let [rt (proxy/proxy-get-rt redirect lang)
+                    _   (doseq [[module shortcut] (:module/internal rt)]
+                          (when (not= module redirect)
+                            (h/suppress (require [module :as shortcut]))))]
+                component)
+              component)
+    -stop    component
+    -kill    component}
+
+   protocol.component/IComponentQuery
+   :body
+   {-started?      (if redirect
+                     (proxy/proxy-started? component)
+                     true)
+    -stopped?      (if redirect
+                     (proxy/proxy-stopped? component)
+                     true)
+    -info          (if redirect
+                     (proxy/proxy-info component level)
+                     {})
+    -remote?       (if redirect
+                     (proxy/proxy-remote? component)
+                     false)
+    -health        (if redirect
+                     (proxy/proxy-health component)
+                     true)}])
+
+(defn rt-default
+  "creates a lang runtime"
+  {:added "4.0"}
+  ([{:keys [lang runtime] :as m}]
+   (map->RuntimeDefault (merge  m {:runtime :default}))))
+
+(defn rt-default?
+  "checks if object is default runtime"
+  {:added "4.0"}
+  ([obj]
+   (instance? RuntimeDefault obj)))
+
+(h/res:spec-add
+ {:type :hara/lang.rt
+  :config {:bootstrap false}
+  :instance {:create rt-default}})
+
+(defn rt-null
+  "creates a default null runtime"
+  {:added "4.0"}
+  ([m]
+   (rt-default (assoc m :lang :null))))
+
+(h/res:spec-add
+ {:type :hara/context.rt.null
+  :instance {:create rt-null}})
+
+(alter-var-root #'reg/+rt-null+
+                (fn [_]
+                  (rt-null reg/+null+)))
+
+;;
+;;
+;;
+
+(defn install-lang!
+  "installs a language within `bb.lib.context`"
+  {:added "4.0"}
+  [lang & [options]]
+  (let [ctx   (ut/lang-context lang)]
+    (h/p:registry-install
+     ctx
+     {:config {:context ctx :lang lang}
+      :scratch (rt-default {:context ctx :lang lang
+                            :options (or options
+                                         {})})
+      :rt  {:default {:resource :hara/lang.rt}}})))
+
+(defn install-type!
+  "installs a specific runtime type given `:lang`"
+  {:added "4.0"}
+  ([lang runtime {:keys [type config] :as spec}]
+   (let [ctx    (ut/lang-context lang)
+         r-spec (h/res:spec-add (dissoc spec :config))
+         r-ctx  (h/p:registry-rt-add ctx {:key runtime
+                                          :config config
+                                          :resource type})]
+     {:spec r-spec
+      :context r-ctx})))
+
+;;
+;;
+;;
+
+(defn return-format-simple
+  "format forms for return"
+  {:added "4.0"}
+  [forms]
+  (concat (butlast forms)
+          [(list 'return (last forms))]))
+
+(defn return-format
+  "standard format for return"
+  {:added "4.0"}
+  [forms & [opts]]
+  (let [v (last forms)
+        v (if (and (h/form? v)
+                   ((h/union '#{:- := var return break throw}
+                             opts)
+                    (first v)))
+            v
+            (list 'return v))]
+    (concat (butlast forms) [v])))
+
+(defn return-wrap-invoke
+  "wraps forms to be invoked"
+  {:added "4.0"}
+  [forms]
+  (h/$ ('((fn [] ~@forms)))))
+
+(defn return-transform
+  "standard return transform"
+  {:added "4.0"}
+  [input {:keys [bulk] :as mopts} & [{:keys [wrap-fn
+                                             format-fn]}]]
+  (let [forms (if bulk input [input])
+        wrap-fn   (or wrap-fn
+                      return-wrap-invoke)
+        format-fn (or format-fn
+                      return-format)]
+    (wrap-fn (format-fn forms))))
+
+(defn default-invoke-script
+  "default invoke script call used by most runtimes"
+  {:added "4.0"}
+  ([{:keys [id lang library layout] :as rt} ptr args f {:keys [json main emit]
+                                                        :or {json :full}
+                                                        :as params}]
+   (let [emit   (h/merge-nested emit (:emit rt))
+         emit   (assoc emit
+                       :input   {:pointer ptr
+                                 :args args}
+                       :runtime (assoc rt
+                                       :type (:runtime rt)
+                                       :namespace (h/ns-sym)))
+         _      (if common/*trace* (h/prn emit params))
+         body   (ptr/ptr-invoke-script ptr args {:emit emit
+                                                 :lang lang
+                                                 :layout (or (:layout params)
+                                                             layout)})]
+     (ptr/ptr-invoke rt
+                     f
+                     body
+                     main
+                     json))))
+
+;;
+;; LIFECYCLE
+;;
+
+(defn default-lifecycle-prep
+  "prepares mopts for lifecycle"
+  {:added "4.0"}
+  [{:keys [id layout lang module library lifecycle emit] :as rt}]
+  (let [library  (or library (impl/runtime-library))
+        snapshot (lib/get-snapshot library)
+        book     (snap/get-book snapshot lang)
+        module   (get-in book [:modules module])]
+    (merge {:layout layout
+            :book book
+            :lang lang
+            :snapshot snapshot
+            :module module
+            :emit (assoc emit
+                         :runtime
+                         {:id id
+                          :lang   (:lang rt)
+                          :type   (:runtime rt)
+                          :module (:module rt)
+                          :namespace (h/ns-sym)})}
+           lifecycle)))
+
+
+;;
+;; SCAFFOLD
+;;
+
+(defn- default-scaffold-array
+  [rt arr]
+  (reduce  (fn [acc [k body]]
+             (try
+               (conj acc [k (ptr/ptr-invoke rt
+                                            h/p:rt-raw-eval
+                                            body
+                                            (:main meta)
+                                            (:json meta))])
+               (catch Throwable t
+                 (reduced (conj acc [k body (.getMessage t)])))))
+           []
+           arr))
+
+(defn default-scaffold-setup-for
+  "setup native modules, defglobals and defruns in the runtime"
+  {:added "4.0"}
+  [rt module-id]
+  (let [meta (default-lifecycle-prep rt)
+        body (impl/emit-scaffold-for module-id meta)]
+    (ptr/ptr-invoke rt
+                    h/p:rt-raw-eval
+                    body
+                    (:main meta)
+                    (:json meta))))
+
+(defn default-scaffold-setup-to
+  "setup scaffold up to but not including the current module in the runtime"
+  {:added "4.0"}
+  [rt module-id]
+  (let [meta (default-lifecycle-prep rt)
+        body (impl/emit-scaffold-to module-id meta)]
+    (ptr/ptr-invoke rt
+                    h/p:rt-raw-eval
+                    body
+                    (:main meta)
+                    (:json meta))))
+
+(defn default-scaffold-imports
+  "embed native imports to be globally accessible"
+  {:added "4.0"}
+  [rt module-id]
+  (let [meta (default-lifecycle-prep rt)
+        body (impl/emit-scaffold-imports module-id meta)]
+    (ptr/ptr-invoke rt
+                    h/p:rt-raw-eval
+                    body
+                    (:main meta)
+                    (:json meta))))
+
+(defn default-lifecycle-fn
+  "constructs a lifecycle fn"
+  {:added "4.0"}
+  [f]
+  (fn [rt & args]
+    (let [{:keys [book] :as meta} (default-lifecycle-prep rt)
+          form (apply f book args)]
+
+      (if form
+        (let [body (impl/emit-str form meta)]
+          (ptr/ptr-invoke rt
+                          h/p:rt-raw-eval
+                          body
+                          (:main meta)
+                          (:json meta)))))))
+
+
+(def ^{:arglists '([rt module-id])}
+  default-has-module?
+  (default-lifecycle-fn deps/has-module-form))
+
+(def ^{:arglists '([rt ptr])}
+  default-has-ptr?
+  (default-lifecycle-fn deps/has-ptr-form))
+
+(def ^{:arglists '([rt ptr])}
+  default-setup-ptr
+  (default-lifecycle-fn deps/setup-ptr-form))
+
+(def ^{:arglists '([rt ptr])}
+  default-teardown-ptr
+  (default-lifecycle-fn deps/teardown-ptr-form))
+
+(defn default-setup-module-emit
+  "emits the string for the module"
+  {:added "4.0"}
+  [rt module-id]
+  (let [{:keys [book] :as meta
+         :rt/keys [setup]} (default-lifecycle-prep rt)]
+    (lifecycle/emit-module-setup module-id (update meta :emit h/merge-nested-new setup))))
+
+(defn default-setup-module-basic
+  "basic setup module action"
+  {:added "4.0"}
+  [rt module-id]
+  (let [{:keys [book] :as meta
+         :rt/keys [setup]} (default-lifecycle-prep rt)
+        body (lifecycle/emit-module-setup module-id (update meta :emit h/merge-nested-new setup))]
+    (ptr/ptr-invoke rt
+                    h/p:rt-raw-eval
+                    body
+                    (:main meta)
+                    (:json meta))))
+
+(defn default-teardown-module-basic
+  "basic teardown module action"
+  {:added "4.0"}
+  [rt module-id]
+  (let [{:keys [teardown] :as meta
+         :rt/keys [teardown]} (default-lifecycle-prep rt)
+        body (lifecycle/emit-module-teardown module-id (update meta :emit h/merge-nested-new teardown))]
+    (ptr/ptr-invoke rt
+                    h/p:rt-raw-eval
+                    body
+                    (:main meta)
+                    (:json meta))))
+
+(defn default-setup-module
+  "default setup module (with error isolation)"
+  {:added "4.0"}
+  [rt module-id & [meta]]
+  (let [{:keys [book] :as meta
+         :rt/keys [setup]} (or meta (default-lifecycle-prep rt))
+        raw  (lifecycle/emit-module-setup-raw module-id (update meta :emit h/merge-nested-new setup))
+        body (lifecycle/emit-module-setup-join raw)]
+    (if (not-empty body)
+      (try (ptr/ptr-invoke rt h/p:rt-raw-eval
+                           body
+                           (:main meta)
+                           (:json meta))
+           (catch Throwable t
+             (let [arr (lifecycle/emit-module-setup-concat raw)]
+               (mapv (fn [part]
+                       (try
+                         (ptr/ptr-invoke rt h/p:rt-raw-eval
+                                         part
+                                         (:main meta)
+                                         (:json meta))
+                         (catch Throwable t
+                           (throw (ex-info "Error at:" {:part (vec (str/split-lines part))
+                                                        :message (loop [t t
+                                                                        c (.getCause ^Throwable t)]
+                                                                   (if c
+                                                                     (recur c (.getCause ^Throwable c))
+                                                                     (.getMessage ^Throwable t)))})))))
+                     arr)))))))
+
+(defn default-teardown-module
+  "default teardown module (with error isolation)"
+  {:added "4.0"}
+  [rt module-id & [meta]]
+  (let [{:keys [book] :as meta
+         :rt/keys [teardown]} (or meta (default-lifecycle-prep rt))
+        raw  (lifecycle/emit-module-teardown-raw module-id (update meta :emit h/merge-nested-new teardown))
+        body (lifecycle/emit-module-teardown-join raw)]
+    (if (not-empty body)
+      (try (ptr/ptr-invoke rt h/p:rt-raw-eval
+                           body
+                           (:main meta)
+                           (:json meta))
+           (catch Throwable t
+             (let [arr (lifecycle/emit-module-teardown-concat raw)]
+               (mapv (fn [part]
+                       (try
+                         (ptr/ptr-invoke rt h/p:rt-raw-eval
+                                         part
+                                         (:main meta)
+                                         (:json meta))
+                         (catch Throwable t
+                           (throw (ex-info "Error at:" {:part (vec (str/split-lines part))
+                                                        :message (loop [t t
+                                                                        c (.getCause ^Throwable t)]
+                                                                   (if c
+                                                                     (recur c (.getCause ^Throwable c))
+                                                                     (.getMessage ^Throwable t)))})))))
+                     arr)))))))
+
+(defn multistage-invoke
+  "invokes a multistage pipeline given deps function"
+  {:added "4.0"}
+  [rt module-id module-fn deps-fn]
+  (let [{:keys [book] :as meta} (default-lifecycle-prep rt)
+        module-ids (deps-fn book module-id)]
+    (mapv (fn [module-id]
+            [module-id (module-fn rt module-id meta)])
+          module-ids)))
+
+(defn multistage-setup-for
+  "setup for a given namespace"
+  {:added "4.0"}
+  [rt module-id]
+  (multistage-invoke rt module-id default-setup-module
+                     (fn [book module-id]
+                       (h/deps:ordered book [module-id]))))
+
+(defn multistage-setup-to
+  "setup to a given namespcase"
+  {:added "4.0"}
+  [rt module-id]
+  (multistage-invoke rt module-id default-setup-module
+                     (fn [book module-id]
+                       (butlast (h/deps:ordered book [module-id])))))
+
+(defn multistage-teardown-for
+  "teardown for a given namespace"
+  {:added "4.0"}
+  [rt module-id]
+  (multistage-invoke rt module-id default-teardown-module
+                     (fn [book module-id]
+                       (reverse (h/deps:ordered book [module-id])))))
+
+(defn multistage-teardown-at
+  "teardown all dependents including this"
+  {:added "4.0"}
+  [rt module-id]
+  (multistage-invoke rt module-id default-teardown-module
+                     (fn [book module-id]
+                       (binding [bb.lang.base.book/*dep-types* :module]
+                         (h/dependents:ordered book module-id)))))
+
+(defn multistage-teardown-to
+  "teardown all dependents upto this"
+  {:added "4.0"}
+  [rt module-id]
+  (multistage-invoke rt module-id default-teardown-module
+                     (fn [book module-id]
+                       (binding [bb.lang.base.book/*dep-types* :module]
+                         (butlast (h/dependents:ordered book module-id))))))
+
+
+(comment
+  (./import)
+  (./create-tests))

--- a/src/bb/lang/base/runtime_proxy.clj
+++ b/src/bb/lang/base/runtime_proxy.clj
@@ -1,0 +1,119 @@
+(ns bb.lang.base.runtime-proxy
+  (:require [std.protocol.context :as protocol.context]
+            [std.protocol.component :as protocol.component]
+            [bb.lib.context.space :as space]
+            [bb.lang.base.util :as ut]
+            [bb.string :as str]))
+
+(defn- rt-proxy-string
+  ([{:keys [namespace redirect lang]}]
+   (str "#rt.proxy" [lang redirect namespace])))
+
+(defn proxy-get-rt
+  "gets the redirected runtime"
+  {:added "4.0"}
+  [redirect lang]
+  (space/space:rt-current redirect (ut/lang-context lang)))
+
+(defn proxy-raw-eval
+  "evaluates the raw string"
+  {:added "4.0"}
+  [{:keys [redirect lang]} string]
+  (protocol.context/-raw-eval
+   (proxy-get-rt redirect lang)
+   string))
+
+(defn proxy-init-ptr
+  "initialises ptr"
+  {:added "4.0"}
+  [{:keys [redirect lang]} ptr]
+  (protocol.context/-init-ptr
+   (proxy-get-rt redirect lang)
+   ptr))
+
+(defn proxy-tags-ptr
+  "gets the ptr tags"
+  {:added "4.0"}
+  [{:keys [redirect lang]} ptr]
+  (protocol.context/-tags-ptr
+   (proxy-get-rt redirect lang)
+   ptr))
+
+(defn proxy-deref-ptr
+  "dereefs the pointer"
+  {:added "4.0"}
+  [{:keys [redirect lang]} ptr]
+  (protocol.context/-deref-ptr
+   (proxy-get-rt redirect lang)
+   ptr))
+
+(defn proxy-display-ptr
+  "displays the pointer"
+  {:added "4.0"}
+  [{:keys [redirect lang]} ptr]
+  (protocol.context/-display-ptr
+   (proxy-get-rt redirect lang)
+   ptr))
+
+(defn proxy-invoke-ptr
+  "invokes the pointer"
+  {:added "4.0"}
+  [{:keys [redirect lang]} ptr args]
+  (protocol.context/-invoke-ptr
+   (proxy-get-rt redirect lang)
+   ptr
+   args))
+
+(defn proxy-transform-in-ptr
+  "transforms the pointer on in"
+  {:added "4.0"}
+  [{:keys [redirect lang]} ptr args]
+  (protocol.context/-transform-in-ptr
+   (proxy-get-rt redirect lang)
+   ptr
+   args))
+
+(defn proxy-transform-out-ptr
+  "transforms the pointer on out"
+  {:added "4.0"}
+  [{:keys [redirect lang]} ptr return]
+  (protocol.context/-transform-out-ptr
+   (proxy-get-rt redirect lang)
+   ptr
+   return))
+
+(defn proxy-started?
+  "checks if proxied has started"
+  {:added "4.0"}
+  [{:keys [redirect lang]}]
+  (protocol.component/-started?
+   (proxy-get-rt redirect lang)))
+
+(defn proxy-stopped?
+  "checks if proxied has stopped"
+  {:added "4.0"}
+  [{:keys [redirect lang]}]
+  (protocol.component/-stopped?
+   (proxy-get-rt redirect lang)))
+
+(defn proxy-remote?
+  "checks if proxied is remote"
+  {:added "4.0"}
+  [{:keys [redirect lang]}]
+  (protocol.component/-remote?
+   (proxy-get-rt redirect lang)))
+
+(defn proxy-info
+  "gets the proxied info"
+  {:added "4.0"}
+  [{:keys [redirect lang]} level]
+  (protocol.component/-info
+   (proxy-get-rt redirect lang)
+   level))
+
+(defn proxy-health
+  "checks the proxied health"
+  {:added "4.0"}
+  [{:keys [redirect lang]}]
+  (protocol.component/-health
+   (proxy-get-rt redirect lang)))

--- a/src/bb/lang/base/script.clj
+++ b/src/bb/lang/base/script.clj
@@ -1,0 +1,357 @@
+(ns bb.lang.base.script
+  (:require [bb.lang.base.emit :as emit]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.impl :as impl]
+            [bb.lang.base.library :as lib]
+            [bb.lang.base.library-snapshot :as snap]
+            [bb.lang.base.runtime :as rt]
+            [bb.lang.base.book-entry :as e]
+            [bb.lang.base.util :as ut]
+            [bb.string :as str]
+            [std.json :as json]
+            [bb.lib :as h]
+            [bb.lang.base.registry :as reg]
+            [bb.lang.base.script-annex :as annex]
+            [bb.lang.base.script-control :as control]
+            [bb.lang.base.script-macro :as macro]))
+
+(defn install
+  "installs a language"
+  {:added "4.0"}
+  [{:keys [lang grammar] :as book}]
+  (let [lib (impl/default-library)]
+    [(lib/install-book! lib book)
+     (rt/install-lang! lang)
+     (macro/intern-grammar lang
+                           grammar)]))
+
+(def +module-keys+
+  [;; builtin
+   :lang
+   :id
+
+   ;; top-level
+   :require
+   :import
+   :macro-only
+   :bundle
+   :file
+   :export
+   :static])
+
+(def +runtime-keys+
+  [:runtime
+   :config
+   :layout
+   :emit
+
+   ;; auto
+   :lang
+   :context
+   :module
+   :namespace
+
+   ;; unique
+   :id])
+
+(defn script-ns-import
+  "imports the namespace and sets a primary flag"
+  {:added "4.0"}
+  ([{:keys [require require-impl] :as config}]
+   (let [current (h/ns-sym)]
+     (alias '- current)
+     (->> require-impl
+          (mapv (fn [ns] (clojure.core/require ns :reload))))
+     (->> require
+          (keep (fn [[ns & {:keys [as with primary]}]]
+                  (clojure.core/require
+                   (cond-> [ns]
+                     as    (conj :as (if (vector? as)
+                                       (last as)
+                                       as))
+                     with  (conj :refer with)))
+                  (if primary ns)))
+          set))))
+
+(defn script-macro-import
+  "import macros into the namespace"
+  {:added "4.0"}
+  ([book]
+   (script-macro-import book identity))
+  ([book restrict]
+   (let [macros (->> (flatten (:macros book))
+                     (filter restrict)
+                     (concat (:highlights book)))
+         syms   (map h/var-sym macros)
+         mns    (ut/sym-module (first syms))
+         ids    (set (map ut/sym-id syms))
+         curr   (h/ns-sym)
+         ignore (h/intersection ids
+                                (set (concat (keys (ns-refers curr))
+                                             (keys (ns-interns curr)))))
+         refers (h/difference ids ignore)]
+     (refer mns :only (vec refers))
+     [refers ids])))
+
+
+;; script-base
+;; - installs a module to the library (book should be installed)
+;;   - most of the work done in lib/install-module
+;;
+;; - initialises the embedded runtime. (checks config and restarts if necessary)
+;;   - most of the work done in script/runtime
+;;
+;;
+;;
+;; script-workflow
+;; - setup clojure namespaces (require and alias)
+;; - aliases current namespace as `-`
+;;
+;; - import language specific macros into current namespace
+;;
+
+(defn script-fn-base
+  "setup for the runtime"
+  {:added "4.0"}
+  ([lang module-id config lib]
+   (let [primary    (script-ns-import config)
+         config     (update config :emit (fnil eval {}))
+         [snapshot] (lib/install-module! lib lang module-id (dissoc config
+                                                                    :runtime
+                                                                    :config
+                                                                    :layout
+                                                                    :emit))
+         book    (snap/get-book-raw snapshot lang)
+         module  (get-in book [:modules module-id])
+         macros  (script-macro-import book)]
+     (merge (:config config)
+            {:module module-id
+             :module/internal (get module :internal)
+             :module/primary primary}
+            (select-keys config [:layout
+                                 :emit])))))
+
+(defn script-fn
+  "calls the regular setup script for the namespace"
+  {:added "4.0"}
+  ([lang]
+   (script-fn lang (h/ns-sym) {}))
+  ([lang module]
+   (if (map? module)
+     (script-fn lang (h/ns-sym) module)
+     (script-fn lang  module {})))
+  ([lang module config]
+   (let [;; loading runtime
+         _ (if-let [ns (get @reg/+registry+ [lang :default])] (require ns))
+         ;; _ (h/prn lang module config)
+         rt-config (script-fn-base lang module config (impl/default-library))]
+     (control/script-rt-get lang
+                            (:runtime config)
+                            rt-config))))
+
+(defmacro ^{:style/indent 1}
+  script
+  "script macro"
+  {:added "4.0"}
+  ([lang]
+   `(script-fn ~lang))
+  ([lang module]
+   `(script-fn ~lang (quote ~module)))
+  ([lang module config]
+   `(script-fn ~lang
+               (quote ~module)
+               (quote ~config))))
+
+(defn script-test-prep
+  "preps the current namespace"
+  {:added "4.0"}
+  ([lang config]
+   (let [module-id (h/ns-sym)
+         book      (annex/get-annex-book module-id lang)
+         lib       (annex/get-annex-library module-id)]
+     (binding [book/*skip-check* true]
+       (script-fn-base lang module-id config lib)))))
+
+(defn script-test
+  "the `script-` function call"
+  {:added "4.0"}
+  ([lang config]
+   (let [rt-config (script-test-prep lang config)]
+     (control/script-rt-get lang
+                            (:runtime config)
+                            rt-config))))
+
+(defmacro ^{:style/indent 1}
+  script-
+  "macro for test setup"
+  {:added "4.0"}
+  ([lang]
+   `(script-test ~lang {}))
+  ([lang config]
+   `(script-test ~lang (quote ~config))))
+
+
+;;
+;; script extend
+;;
+
+(defn script-ext
+  "the `script+` function call"
+  {:added "4.0"}
+  ([[tag lang] config]
+   (let [{:keys [runtime]} config
+         rt-config (script-test-prep lang config)
+         ns (:module rt-config)
+         _  (control/script-rt-get lang
+                                   (:runtime config)
+                                   rt-config)
+         _  (annex/register-annex-tag ns tag lang runtime config)
+         rt (annex/get-annex-runtime ns tag)]
+     (if (or (not rt)
+             (not (annex/same-runtime? rt lang (or runtime :default) rt-config)))
+       (annex/add-annex-runtime ns tag
+                                (annex/start-runtime lang
+                                                     (or runtime :default)
+                                                     rt-config))
+       [rt]))))
+
+(defmacro ^{:style/indent 1}
+  script+
+  "macro for test extension setup"
+  {:added "4.0"}
+  ([[tag lang]]
+   `(script-ext ~[tag lang] {}))
+  ([[tag lang] config]
+   `(script-ext ~[tag lang] (quote ~config))))
+
+;;
+;;
+;;
+
+(defn script-ext-run
+  "function to call with the `!` macro"
+  {:added "4.0"}
+  ([ns tag body meta]
+   (let [{:keys [lang module]
+          :as rt}    (or (annex/get-annex-runtime ns tag)
+                         (h/error "Annex Not found"
+                                  {:available [(keys @(:runtimes (annex/get-annex)))]}))]
+     (macro/call-thunk
+      meta
+      (fn []
+        (h/p:rt-invoke-ptr
+         rt
+         (ut/lang-pointer lang {:module module})
+         [body]))))))
+
+(defmacro ^{:style/indent 1}
+  !
+  "switch between defined annex envs"
+  {:added "4.0"}
+  ([tag body]
+   (if (vector? tag)
+     `(script-ext-run (quote ~(h/ns-sym))
+                      ~(first tag)
+                      (quote ~body)
+                      ~(meta &form)))))
+
+
+(comment
+
+  (defmacro
+    !.async
+    "switch between defined annex envs"
+    {:added "4.0"}
+    ([tag body]
+     `(h/future:run
+       (bound-fn
+         []
+         (script-ext-run (quote ~(h/ns-sym))
+                         ~tag
+                         (quote ~body)
+                         ~(meta &form))))))
+
+  (defmacro
+    !.run
+    "switch between defined annex envs"
+    {:added "4.0"}
+    ([lang body]
+     `(control/script-rt-oneshot-eval
+       :oneshot
+       ~lang
+       [(quote ~body)]))))
+
+(defn annex:start
+  "starts an annex tag"
+  {:added "4.0"}
+  ([tag]
+   (annex:start tag (h/ns-sym)))
+  ([tag ns]
+   (let [{:keys [registry
+                 runtimes]} (annex/get-annex ns)]
+     (if-let [{:keys [lang
+                      runtime
+                      config]} (get @registry tag)]
+       (script-ext [tag lang] config)))))
+
+(defn annex:get
+  "gets the runtime associated with an annex"
+  {:added "4.0"}
+  ([tag]
+   (annex:get tag (h/ns-sym)))
+  ([tag ns]
+   (get @(:runtimes (annex/get-annex ns))
+        tag)))
+
+(defn annex:stop
+  "stops an annex tag"
+  {:added "4.0"}
+  ([tag]
+   (annex:stop tag (h/ns-sym)))
+  ([tag ns]
+   (let [{:keys [runtimes]} (annex/get-annex ns)]
+     (h/swap-return! runtimes
+       (fn [m]
+         (if-let [rt (get m tag)]
+           [(h/stop rt) (dissoc m tag)]))))))
+
+(defn annex:start-all
+  "starts all the annex tags"
+  {:added "4.0"}
+  ([]
+   (annex:start-all (h/ns-sym)))
+  ([ns]
+   (let [{:keys [registry]} (annex/get-annex ns)]
+     (h/map-entries (fn [[tag {:keys [lang
+                                      runtime
+                                      config]}]]
+                      [tag (script-ext [tag lang] config)])
+                    @registry))))
+
+(defn annex:stop-all
+  "stops all annexs"
+  {:added "4.0"}
+  ([]
+   (annex:stop-all (h/ns-sym)))
+  ([ns]
+   (annex/clear-annex ns)))
+
+(defn annex:restart-all
+  "stops and starts all annex runtimes"
+  {:added "4.0"}
+  ([]
+   (annex:restart-all (h/ns-sym)))
+  ([ns]
+   (annex:stop-all ns)
+   (annex:start-all ns)))
+
+(defn annex:list
+  "lists all annexs"
+  {:added "4.0"}
+  ([]
+   (annex:list (h/ns-sym)))
+  ([ns]
+   (let [{:keys [runtimes
+                 registry]} (annex/get-annex ns)]
+     {:registered (set (keys @registry))
+      :active (set (keys @runtimes))})))

--- a/src/bb/lang/base/script_annex.clj
+++ b/src/bb/lang/base/script_annex.clj
@@ -1,0 +1,202 @@
+(ns bb.lang.base.script-annex
+  (:require [bb.lang.base.util :as ut]
+            [bb.lang.base.impl :as impl]
+            [bb.lang.base.library :as lib]
+            [bb.lang.base.library-snapshot :as snap]
+            [bb.lang.base.runtime :as rt]
+            [bb.string :as str]
+            [std.json :as json]
+            [bb.lib :as h :refer [defimpl]]))
+
+(defn- rt-annex-string
+  "returns the annex string"
+  {:added "4.0"}
+  ([{:keys [
+            runtimes]}]
+   (str "#lang.annex " (vec (sort (map (fn [[k rt]]
+                                         [k (:lang rt)])
+                                       @runtimes))))))
+
+(defimpl RuntimeAnnex [id registry runtimes library]
+  :string rt-annex-string)
+
+(defn rt-annex?
+  "checks that object is an annex"
+  {:added "4.0"}
+  ([obj]
+   (instance? RuntimeAnnex obj)))
+
+(defn rt-annex:create
+  "creates an annex object
+
+
+   (annex/rt-annex:create {})
+   => annex/rt-annex?"
+  {:added "4.0"}
+  ([{:keys [id] :as m}]
+   (let [runtimes (atom {})
+         registry (atom {})
+         library  (lib/library {:parent #'impl/default-library})]
+     (map->RuntimeAnnex (merge m {:library library
+                                  :registry registry
+                                  :runtimes runtimes})))))
+
+(def +init-annex+
+  [(h/res:spec-add
+    {:type :hara/lang.rt.annex
+     :config {}
+     :instance {:create rt-annex:create}})
+
+   (h/p:registry-install
+    :lang.annex
+    {:config {}
+     :rt  {:default {:resource :hara/lang.rt.annex}}})])
+
+
+
+(defn annex-current
+  "gets the current annex. May not exist
+
+   (annex/annex-current)
+   => any?"
+  {:added "4.0"}
+  ([]
+   (annex-current (h/ns-sym)))
+  ([ns]
+   (let [{:keys [state] :as sp} (h/p:space ns)
+         rec (:lang.annex @state)]
+     (if rec (:instance rec)))))
+
+(defn annex-reset
+  "resets the current annex"
+  {:added "4.0"}
+  ([]
+   (annex-reset (h/ns-sym)))
+  ([ns]
+   (let [sp (h/p:space ns)]
+     (h/p:space-rt-stop sp :lang.annex))))
+
+(defn get-annex
+  "gets the current annex in the namespace"
+  {:added "4.0"}
+  ([]
+   (get-annex (h/ns-sym)))
+  ([ns]
+   (let [{:keys [state] :as sp} (h/p:space ns)
+         check  (or (:lang.annex @state)
+                    (h/p:space-context-set sp :lang.annex :default {}))]
+
+     (h/p:space-rt-start sp :lang.annex))))
+
+(defn clear-annex
+  "clears all runtimes in the annex"
+  {:added "4.0"}
+  ([]
+   (clear-annex (h/ns-sym)))
+  ([ns]
+   (let [{:keys [runtimes]} (get-annex ns)]
+     (h/swap-return! runtimes
+       (fn [m]
+         [(h/map-vals h/stop m) {}])))))
+
+(defn get-annex-library
+  "gets the current annex library
+
+   (annex/get-annex-library (h/ns-sym))
+   => lib/library?"
+  {:added "4.0"}
+  ([ns]
+   (:library (get-annex ns))))
+
+(defn get-annex-book
+  "gets the current book in the annex
+
+   (annex/get-annex-book (h/ns-sym) :lua)
+   => book/book?"
+  {:added "4.0"}
+  ([ns lang]
+   (let [curr (:library (get-annex ns))]
+     (or (snap/get-book @(:instance curr) lang)
+         (let [book   (or (lib/get-book (impl/default-library) lang)
+                          (h/error "Book not found" {:lang lang}))]
+           (lib/add-book! curr (assoc book :modules {})))))))
+
+(defn add-annex-runtime
+  "adds a runtime to the annex"
+  {:added "4.0"}
+  [ns tag rt]
+  (let [{:keys [registry
+                runtimes]} (get-annex ns)]
+    (h/swap-return! runtimes
+      (fn [m]
+        (let [curr (get m tag)
+              _  (if curr (h/stop curr))]
+          [[curr rt] (assoc m tag rt)])))))
+
+(defn get-annex-runtime
+  "gets the annex rutime"
+  {:added "4.0"}
+  [ns tag]
+  (let [{:keys [runtimes]} (get-annex ns)]
+    (get @runtimes tag)))
+
+(defn remove-annex-runtime
+  "removes the annex runtime"
+  {:added "4.0"}
+  [ns tag]
+  (let [{:keys [runtimes]} (get-annex ns)]
+    (h/swap-return! runtimes
+      (fn [m]
+        (let [curr (get m tag)
+              _  (if curr (h/stop curr))]
+          [curr (dissoc m tag)])))))
+
+(defn register-annex-tag
+  "registers a config for the tag"
+  {:added "4.0"}
+  [ns tag lang runtime config]
+  (let [{:keys [registry]} (get-annex ns)]
+    (h/swap-return! registry
+      (fn [m]
+        [[(get m tag) lang]
+         (assoc m tag {:lang lang
+                       :runtime runtime
+                       :config config})]))))
+
+(defn deregister-annex-tag
+  "removes the config for the tag"
+  {:added "4.0"}
+  [ns tag]
+  (let [{:keys [registry]} (get-annex ns)]
+    (h/swap-return! registry
+      (fn [m]
+        [(get m tag) (dissoc m tag)]))))
+
+(defn start-runtime
+  "starts the runtime in the annex"
+  {:added "4.0"}
+  [lang runtime config]
+  (let [ctx (ut/lang-context lang)
+        {:keys [resource] :as reg} (h/p:registry-rt ctx runtime)
+        spec (h/res:spec-get resource)
+        {:keys [instance]} spec]
+    (-> ((:create instance) (merge (:config reg)
+                                   {:lang lang
+                                    :runtime runtime}
+                                   config))
+        ((:setup instance)))))
+
+(defn same-runtime?
+  "checks that one runtime is the same as another"
+  {:added "4.0"}
+  [rt lang runtime config]
+  (let [ctx (ut/lang-context lang)
+        reg (h/p:registry-rt ctx runtime)
+        ckeys [:lang :runtime :layout :emit]
+        new-conf (-> (merge (:config reg)
+                            {:lang lang
+                             :runtime runtime}
+                            config)
+                     (select-keys ckeys))
+        old-conf (select-keys rt ckeys)]
+    (= new-conf old-conf)))

--- a/src/bb/lang/base/script_control.clj
+++ b/src/bb/lang/base/script_control.clj
@@ -1,0 +1,115 @@
+(ns bb.lang.base.script-control
+  (:require [bb.lang.base.emit :as emit]
+            [bb.lang.base.impl :as impl]
+            [bb.lang.base.library :as lib]
+            [bb.lang.base.registry :as reg]
+            [bb.lang.base.book-entry :as e]
+            [bb.lang.base.util :as ut]
+            [bb.lang.base.runtime :as rt]
+            [bb.string :as str]
+            [std.json :as json]
+            [bb.lib :as h])
+  (:refer-clojure :exclude [test]))
+
+(def +watch-keys+ [:context :lang :module :layout])
+
+;;
+;; Runtime
+;;
+
+(defn script-rt-get
+  "gets the current runtime
+
+   (script-rt-get :lua :default {})
+   => rt/rt-default?
+
+   (h/p:space-context-list)
+   => (contains '[:lang/lua])
+
+   (h/p:registry-rt-list :lang/lua)
+   => (contains '(:default))
+
+
+   (do (script-rt-stop :lua)
+       (h/p:space-rt-active))
+   => []"
+  {:added "4.0"}
+  ([lang key config]
+   #_(h/prn lang key config)
+   (let [_ (if-let [ns (get @reg/+registry+ [lang key])] (require ns))
+         sp          (h/p:space bb.lib.context.space/*namespace*)
+         ctx         (ut/lang-context lang)
+         placement   (get @(:state sp) ctx)
+         started?    (boolean (:instance placement))
+
+         new-config  (merge (:config placement)
+                            (-> (h/p:registry-get ctx)
+                                (get-in [:rt key :config]))
+                            config)
+
+         changed?    (or (not= new-config
+                               (:config placement))
+                         (not= (:key placement) key))
+         _  (when (and started? changed?)
+              (h/p:space-rt-stop sp ctx))
+         _  (if (or (empty? placement) changed?)
+              (h/p:space-context-set sp ctx key config))
+         rt (h/p:space-rt-start sp ctx)]
+     rt)))
+
+(defn script-rt-stop
+  "stops the current runtime"
+  {:added "4.0"}
+  ([]
+   (h/map-juxt [identity script-rt-stop] (ut/lang-rt-list)))
+  ([lang]
+   (script-rt-stop lang nil))
+  ([lang ns]
+   (let [ctx          (ut/lang-context lang)
+         space        (h/p:space-resolve ns)
+         placement    (h/p:space-context-get space ctx)
+         started? (:instance placement)
+         _  (if started?
+              (h/p:space-rt-stop space ctx))]
+     started?)))
+
+(defn script-rt-restart
+  "restarts a given runtime"
+  {:added "4.0"}
+  ([]
+   (h/map-juxt [identity script-rt-restart] (ut/lang-rt-list)))
+  ([lang]
+   (script-rt-restart lang nil))
+  ([lang ns]
+   (let [ctx        (ut/lang-context lang)
+         space      (h/p:space-resolve ns)
+         placement  (h/p:space-context-get space ctx)
+         started?   (:instance placement)
+         _  (if started?
+              (h/p:space-rt-stop space ctx))
+         rt (h/p:space-rt-start space ctx)]
+     rt)))
+
+(defn script-rt-oneshot-eval
+  "oneshot evals a statement"
+  {:added "4.0"}
+  [default lang args]
+  (let [has-rt (get (set (ut/lang-rt-list))
+                    lang)
+        rt  (if has-rt
+              (ut/lang-rt lang)
+              (script-rt-get lang
+                             default
+                             {}))
+        out  (h/p:rt-invoke-ptr rt (ut/lang-pointer lang {:module (:module rt)})
+                                args)
+        _    (when (not has-rt)
+               (script-rt-stop lang)
+               (h/p:space-context-unset (ut/lang-context lang)))]
+    out))
+
+(defn script-rt-oneshot
+  "for use with the defmacro.! function"
+  {:added "4.0"}
+  [default {:keys [lang] :as ptr} args]
+  (script-rt-oneshot-eval default lang [(cons ptr args)]))

--- a/src/bb/lang/base/script_def.clj
+++ b/src/bb/lang/base/script_def.clj
@@ -1,0 +1,99 @@
+(ns bb.lang.base.script-def
+  (:require [bb.lib :as h]
+            [bb.string :as str]
+            [bb.lang.base.util :as ut]))
+
+(defn tmpl-entry
+  "forms for various argument types"
+  {:added "4.0"}
+  [s]
+  (let [{:keys [tag type base prefix shrink]
+         :or {base []}} (h/template-meta)
+        base (if (vector? base) base [base])
+        dsym (case type
+               :fragment (symbol (str "def$." tag))
+               :object (symbol (str "def." tag)))
+        [sym msym] (if (vector? s)
+                     s
+                     [s s])
+        sym  (cond-> (name sym)
+               :then (.replaceAll "\\." (if shrink
+                                          "" "-"))
+               :then ut/sym-default-inverse-str
+               prefix ((fn [s]
+                         (str prefix s))))
+
+        mrep (symbol (str/join "." (conj base msym)))]
+    (list dsym (symbol sym) mrep)))
+
+(defn tmpl-macro
+  "forms for various argument types"
+  {:added "4.0"}
+  [[s args {:keys [property optional vargs empty]}]]
+  (let [{:keys [tag inst prefix subtree]
+         :or {inst "obj"}} (h/template-meta)
+
+        inst (symbol (str inst))
+        [sym msym] (if (vector? s)
+                     s
+                     [s s])
+        sym   (cond-> (ut/sym-default-inverse-str sym)
+                prefix ((fn [s]
+                          (str prefix s)))
+                :then symbol)
+        dargs (cond property []
+
+                    (and optional vargs)
+                    (conj args '& (conj optional '& [:as vargs] :as 'targs))
+
+                    optional
+                    (conj args '& (conj optional :as 'oargs))
+
+                    vargs
+                    (conj args '& [:as vargs])
+
+                    :else
+                    args)
+        aform (cond (and optional vargs)
+                    `(apply
+                      list
+                      (quote ~msym)
+                      ~@args
+                      (vec (concat
+                            (take
+                             (- (count ~'targs)
+                                (count ~vargs))
+                                  ~optional)
+                            ~vargs)))
+
+                    optional
+                    `(apply
+                      list
+                      (quote ~msym)
+                      ~@args (vec (take
+                                   (count ~'oargs) ~optional)))
+
+                    vargs
+                    `(apply list (quote ~msym) ~@args ~vargs)
+
+                    :else
+                    `(list (quote ~msym) ~@args))
+        standalone (let [isym (if empty
+                                (list 'or inst empty)
+                                inst)]
+                     (cond property
+                           `(~'fn:> [~isym] (~'. ~isym ~msym))
+
+                           :else
+                           (let [vargs (if vargs
+                                         [(symbol (str "..." vargs))]
+                                         [])]
+                             `(~'fn:> [~isym ~@args ~@optional ~@vargs]
+                                  (~'. ~isym (~msym ~@args ~@optional ~@vargs))))))
+        subtree-fn (fn [s] (list 'quote (symbol s)))
+        sform (if property
+                `(list ~''. ~inst ~@(map subtree-fn subtree) (quote ~msym))
+                `(list ~''. ~inst ~@(map subtree-fn subtree) ~aform))]
+    `(~(symbol (str "defmacro." tag)) ~(with-meta sym {:standalone (list 'quote standalone)})
+      ([~inst ~@dargs]
+       ~sform))))

--- a/src/bb/lang/base/script_lint.clj
+++ b/src/bb/lang/base/script_lint.clj
@@ -1,0 +1,285 @@
+(ns bb.lang.base.script-lint
+  (:require [bb.lib :as h :refer [definvoke]]
+            [bb.string :as str]
+            [bb.lang.base.library :as lib]
+            [bb.lang.base.impl :as impl]))
+
+;;
+;; dumb linter
+;;
+
+(defn get-reserved-raw
+  "gets all reserved symbols in the grammar"
+  {:added "4.0"}
+  [lang]
+  (set (keys (:reserved (impl/grammar lang)))))
+
+(def get-reserved (memoize get-reserved-raw))
+
+(defn collect-vars
+  "collects all vars"
+  {:added "4.0"}
+  [form]
+  (let [vars (volatile! #{})
+        _ (h/prewalk (fn [form]
+                       (cond (symbol? form)
+                             (do (vswap! vars conj form)
+                                 form)
+
+                             :else form))
+                     form)]
+    @vars))
+
+(definvoke collect-module-globals
+  "collects global symbols from module"
+  {:added "4.0"}
+  [:recent {:key :id
+            :compare h/hash-code}]
+  ([module]
+   (let [{:keys [native static]} module]
+     (disj (h/union
+            (set (mapcat #(mapcat h/seqify (vals %))
+                         (vals native)))
+            (:lang/lint-globals static))
+           '*))))
+
+(defn collect-sym-vars
+  "collect symbols and vars"
+  {:added "4.0"}
+  ([entry module]
+   (collect-sym-vars entry module #{}))
+  ([entry module lang-globals]
+   (let [globals  (or (h/union lang-globals
+                               (collect-module-globals module)
+                               (:static/lint-globals entry))
+                      #{})
+         {:keys [form form-input lang op-key]} entry
+         form (or form form-input)
+         reserved (get-reserved lang)
+         [vars lint-input] (case op-key
+                             (:defn
+                              :defgen) [(volatile! (collect-vars (nth form 2)))
+                                        (drop 3 form)]
+                             (:def
+                              :defglobal)  [(volatile! #{})
+                                            (drop 2 form)])
+         syms (volatile! #{})
+         sym-fn (fn [form]
+                  (let [[ftag] form
+                        form (if (and (= ftag 'fn)
+                                      (symbol? (second form)))
+                               (do (vswap! vars h/union (collect-vars (second form)))
+                                   (cons 'fn (drop 2 form)))
+                               form)]
+                    (cond (#{'var 'const 'fn:> 'fn 'local} ftag)
+                          (do (vswap! vars h/union (collect-vars (second form)))
+                              (drop 2 form))
+
+                          (= '. ftag)
+                          (let [[_ sym & body] form]
+                            [sym (map (fn [form]
+                                        (cond (h/form? form)
+                                              (drop 1 form)
+
+                                              (symbol? form)
+                                              nil
+
+                                              :else form))
+                                      body)])
+
+                          (or (str/starts-with? (str ftag) "for:")
+                              (= (str ftag) "forange"))
+                          (let [[_ bindings & body] form]
+                            (do (vswap! vars h/union (collect-vars (first bindings)))
+                                [(second bindings) body]))
+
+                          (= 'let ftag)
+                          (let [[_ bindings & body] form
+                                all-bindings (take-nth 2 bindings)
+                                all-bound    (take-nth 2 (drop 1 bindings))]
+                            (do (vswap! vars h/union (collect-vars all-bindings))
+                                [all-bound body]))
+
+                          ('#{!:G new} ftag)
+                          (do (vswap! vars conj (second form))
+                              nil)
+
+                          (= 'catch ftag)
+                          (let [[_ bindings & body] form]
+                            (do (vswap! vars h/union (collect-vars bindings))
+                                body))
+
+                          :else form)))
+         _    (h/prewalk
+               (fn [form]
+                 (cond (h/form? form)
+                       (sym-fn form)
+
+                       (symbol? form)
+                       (cond (or (= '_ form)
+                                 (globals form)
+                                 (reserved form)
+                                 (namespace form)
+                                 (str/starts-with? (str form)
+                                                   "x:")
+                                 (str/starts-with? (str form)
+                                                   "..."))
+                             form
+
+                             :else
+                             (let [s  (first (str/split (str form)
+                                                        #"\."))
+                                   s  (if s (symbol s))]
+                               (cond (or (nil? s)
+                                         (globals s)
+                                         (reserved s))
+                                     form
+
+                                     :else
+                                     (do (vswap! syms conj s)
+                                         form))))
+
+                       :else form))
+               lint-input)]
+     {:vars @vars
+      :syms @syms})))
+
+(defn sym-check-linter
+  "checks the linter"
+  {:added "4.0"}
+  ([entry module]
+   (sym-check-linter entry module #{}))
+  ([entry module lang-globals]
+   (sym-check-linter entry module lang-globals {:unknown :print
+                                                :unused  :silent}))
+  ([entry module lang-globals options]
+   (let [{:keys [id op]} entry]
+     (cond ('#{defn def defgen defglobal fn} op)
+           (let [{:keys [vars syms]} (collect-sym-vars entry module lang-globals)
+                 internal (disj (set (vals (:internal module)))
+                                '-)
+                 unused  (h/difference (disj vars '_) syms)
+                 unknown (h/difference syms vars)
+                 unknown (h/difference unknown internal)]
+             (when (not-empty unused)
+               (when (= :print (:unused options))
+                 (h/p (str "UNUSED VAR @ " (:module entry) "/" id)
+                      {:unused unused})))
+             (when (not-empty unknown)
+               (when (= :print (:unknown options))
+                 (h/p (str "UNKNOWN VARIABLES @ " (:module entry) "/" id)
+                      {:unknown unknown}))
+               (when (= :error (:unknown options))
+                 (h/error (str "UNKNOWN VARIABLES @ " (:module entry) "/" id)
+                          {:unknown unknown
+                           :form (or (:form entry)
+                                     (:form-input entry))})))
+             :pass)))))
+
+;;
+;;
+;;
+
+(defonce +registry+
+  (atom {}))
+
+(def +settings+
+  (atom {:lua   {:linters [sym-check-linter]
+                 :globals '#{tonumber
+                             unpack
+                             error
+                             next
+                             type
+                             pcall
+                             table
+                             math
+                             cjson
+                             os
+                             io
+                             string
+                             getmetatable
+                             ngx
+                             require
+                             GLOBAL
+                             CONFIG}}
+         :xtalk {:linters [sym-check-linter]
+                 :globals '#{XT}}
+         :solidity {:linters [sym-check-linter]
+                    :globals '#{msg
+                                require}}
+         :js    {:linters [sym-check-linter]
+                 :globals '#{Worker
+                             Request
+                             Response
+                             Promise
+                             alert
+                             setTimeout
+                             setInterval
+                             clearTimeout
+                             clearInterval
+                             Date
+                             eval
+                             WebSocket
+                             EventSource
+                             self
+                             arguments
+                             fetch
+                             FileReader
+                             globalThis
+                             JSON
+                             BigInt
+                             console
+                             import
+                             document
+                             window
+                             navigator
+                             screen
+                             location
+                             localStorage
+                             sessionStorage
+                             Array
+                             Object
+                             Math
+                             Number
+                             require
+                             process}}}))
+
+(defn lint-set
+  "sets the linter for a namespace"
+  {:added "4.0"}
+  ([ns]
+   (lint-set ns true))
+  ([ns option]
+   (swap! +registry+
+          (fn [m]
+            (if option
+              (assoc m ns true)
+              (dissoc m ns))))))
+
+(defn lint-clear
+  "clears all linted namespaces"
+  {:added "4.0"}
+  []
+  (reset! +registry+ {}))
+
+(defn lint-needed?
+  "checks if lint is needed"
+  {:added "4.0"}
+  [ns]
+  (get @+registry+ ns))
+
+(defn lint-entry
+  "lints a single entry"
+  {:added "4.0"}
+  [entry module]
+  (let [{:keys [lang]} entry
+        {:keys [linters globals]} (get @+settings+ lang)]
+    (when (not (-> module :static :lang/no-lint))
+      (doseq [linter linters]
+        (linter entry module globals {:unknown :error
+                                      :unused  :silent})))))
+
+
+(comment
+  (keys *module*)
+  )

--- a/src/bb/lang/base/script_macro.clj
+++ b/src/bb/lang/base/script_macro.clj
@@ -1,0 +1,372 @@
+(ns bb.lang.base.script-macro
+  (:require [bb.lang.base.util :as ut]
+            [bb.lang.base.library :as lib]
+            [bb.lang.base.emit-preprocess :as preprocess]
+            [bb.lang.base.emit :as emit]
+            [bb.lang.base.grammar-spec :as grammar]
+            [bb.lang.base.impl :as impl]
+            [bb.lang.base.impl-entry :as entry]
+            [bb.lang.base.script-annex :as annex]
+            [bb.lang.base.script-control :as control]
+            [bb.lang.base.script-lint :as lint]
+            [bb.lang.base.pointer :as ptr]
+            [bb.lang.base.runtime :as rt]
+            [std.protocol.context :as protocol.context]
+            [bb.lib :as h]))
+
+(def +form-allow+ [:line :column :file :name :ns])
+
+(defn body-arglists
+  "makes arglists from body"
+  {:added "4.0"}
+  [body]
+  (let [args-fn (fn [body]
+                  (vec (remove (fn [x]
+                                 (or (keyword? x)
+                                     (number? x)
+                                     (and (vector? x)
+                                          (not (some symbol? x)))
+                                     (string? x)))
+                               (first body))))]
+    (if (vector? (first body))
+      (list (args-fn body))
+      (map args-fn body))))
+
+(defn intern-in
+  "interns a macro"
+  {:added "4.0"}
+  ([prefix tag val & [namespace]]
+   (intern (or namespace (h/ns-sym))
+           (with-meta (symbol (str prefix (name tag)))
+             {:macro true
+              :arglists '([& body])})
+           val)))
+
+(defn intern-prep
+  "outputs the module and form meta"
+  {:added "4.0"}
+  [lang form]
+  (let [fmeta  (meta form)
+        module (or (:module fmeta)
+                   (let [rt (ut/lang-rt lang)]
+                     (:module rt)))
+        _      (assert (boolean module) "Module required for insertion.")]
+    [module fmeta]))
+
+(defn intern-def$-fn
+  "interns a fragment macro"
+  {:added "4.0"}
+  ([lang [op sym body :as form] smeta]
+   (let [[module fmeta] (intern-prep lang form)
+         entry  (entry/create-fragment form
+                                       (merge smeta
+                                              fmeta
+                                              {:lang lang
+                                               :module module}))
+         lib    (impl/runtime-library)
+         _      (lib/add-entry-single! lib entry)]
+     (ptr/ptr-intern (:namespace entry)
+                     (with-meta sym (merge (select-keys fmeta +form-allow+)
+                                           smeta))
+                     entry))))
+
+(defn intern-def$
+  "intern a def fragment macro"
+  {:added "4.0"}
+  ([lang tag]
+   (intern-in
+    "def$." tag
+    (fn [&form &env sym body]
+      `(intern-def$-fn ~lang
+                       (quote ~&form)
+                       (merge ~(meta sym)
+                              {:time (h/time-ns)}))))))
+
+(defn intern-defmacro-fn
+  "function to intern a macro"
+  {:added "4.0"}
+  ([lang [op sym & body :as form] smeta]
+   (let [[doc attr body] (grammar/format-fargs body)
+         [module fmeta]  (intern-prep lang form)
+         entry  (entry/create-macro (apply list 'defmacro sym body)
+                                    (merge smeta
+                                           fmeta
+                                           {:lang lang
+                                            :module module}))
+         lib    (impl/runtime-library)
+         _      (lib/add-entry-single! lib entry)]
+     (ptr/ptr-intern (:namespace entry)
+                     (with-meta sym (merge attr
+                                           {:doc doc
+                                            :arglists (body-arglists body)}
+                                           (select-keys fmeta +form-allow+)
+                                           smeta))
+                     entry))))
+
+(defn intern-defmacro
+  "the intern macro function"
+  {:added "4.0"}
+  ([lang tag]
+   (intern-in
+    "defmacro." tag
+    (fn [&form &env sym & body]
+      `(intern-defmacro-fn ~lang
+                           (quote ~&form)
+                           (merge ~(meta sym)
+                                  {:time (h/time-ns)}))))))
+
+(defn call-thunk
+  "calls the thunk given meta to control pointer output
+
+   (macro/call-thunk {:debug true}
+                     (fn [] ptr/*print*))
+   => #{:input}"
+  {:added "4.0"}
+  [{:keys [input raw debug clip] :as meta}
+   thunk]
+  (binding [ptr/*print* (if (= (:tag meta) *)
+                          #{:input-form :raw-input :raw-output}
+                          (cond-> ptr/*print* debug (conj :input)))
+            ptr/*output* (cond-> ptr/*output*
+                           raw (conj :raw))
+            ptr/*input* (if (= (:tag meta) -)
+                          #{:input}
+                          (cond-> ptr/*input*
+                            input (conj :input)))
+            ptr/*clip* (boolean clip)]
+    (thunk)))
+
+(defn intern-!-fn
+  "interns a free pointer macro"
+  {:added "4.0"}
+  [lang args {:keys [input raw debug clip] :as meta}]
+  (let [rt (ut/lang-rt lang)
+        {:keys [module] :as rt} (if (satisfies? protocol.context/IContext rt)
+                                  rt
+                                  (rt/rt-default rt))]
+    (call-thunk meta
+                (fn []
+                  (h/p:rt-invoke-ptr
+                   rt
+                   (ut/lang-pointer lang {:module module}) args)))))
+
+(defn intern-!
+  "interns a macro for free evalutation"
+  {:added "4.0"}
+  ([lang tag]
+   (intern-in
+    "!." tag
+    (fn [&form _ & body]
+      `(intern-!-fn ~lang
+                    (quote ~(vec body))
+                    ~(meta &form))))))
+
+(defn intern-free-fn
+  "interns a free pointer in the namespace
+
+   (macro/intern-free-fn :lua '(defptr.lua hello 1)
+                         {})
+   => #'bb.lang.base.script-macro-test/hello"
+  {:added "4.0"}
+  [lang [_ sym body] smeta]
+  (let [rt (ut/lang-rt lang)
+        module (or (:module smeta)
+                   (:module rt))
+        ptr (ut/lang-pointer lang {:module module
+                                   :form body})]
+    (intern (h/ns-sym) sym ptr)))
+
+(defn intern-free
+  "creates a defptr macro
+
+   (macro/intern-free :lua \"hello\")
+   => #'bb.lang.base.script-macro-test/defptr.hello"
+  {:added "4.0"}
+  ([lang tag]
+   (intern-in
+    "defptr." tag
+    (fn [&form _ & body]
+      `(intern-free-fn ~lang (quote ~&form)
+                       ~(meta &form))))))
+
+(defn intern-top-level-fn
+  "interns a top level function"
+  {:added "4.0"}
+  ([lang [op reserved] [_ sym & body :as form-raw] smeta]
+   (let [{:keys [format section priority]} reserved
+         [module fmeta] (intern-prep lang form-raw)
+         form          (apply list op sym body)
+
+         [tmeta entry] (binding [preprocess/*macro-splice* (:static/template smeta)]
+                         (entry/create-code-raw form
+                                                reserved
+                                                (merge smeta
+                                                       fmeta
+                                                       {:lang lang
+                                                        :module module})))
+         lib    (impl/runtime-library)
+         sym    (cond (vector? sym)
+                      (first (filter symbol? sym))
+
+                      :else sym)
+         var    (ptr/ptr-intern (:namespace entry)
+                                (with-meta sym (merge tmeta
+                                                      (if (:fn reserved)
+                                                        {:arglists (body-arglists
+                                                                    (drop 2 (:form-input entry)))})
+                                                      (select-keys fmeta +form-allow+)
+                                                      smeta))
+                                entry)
+         rt     (ut/lang-rt-default @var)
+         rt     (if (satisfies? protocol.context/IContext rt)
+                  rt
+                  (rt/rt-default rt))
+         _      (lib/add-entry-single! lib entry)
+         _      (comment "TODO: USE BULK ENTRY ADD"
+                  (if (= :single (:lang/add-entry rt))
+                    (lib/add-entry-single! lib entry)
+                    (lib/add-entry! lib entry)))
+         init   (h/p:rt-init-ptr rt entry)
+         module (lib/get-module lib
+                                (:lang entry)
+                                (:module entry))
+
+         ;;
+         ;;     LINT HACK FOR JS
+         ;;
+         #_#_
+         _      (when (and (#{:js :xtalk :lua} (:lang entry))
+                           (not (:static/no-lint smeta)))
+                  (lint/lint-entry (lib/get-entry lib entry)
+                                   module))]
+     (if init
+       init
+       var))))
+
+(defn intern-top-level
+  "interns a top level macro
+
+   (impl/with:library [+library+]
+     (macro/intern-top-level :lua \"hello\" 'def))
+   => #'bb.lang.base.script-macro-test/def.hello
+
+   (impl/with:library [+library+]
+     ^{:module L.core}
+     (def.hello abc 1))
+   => #'bb.lang.base.script-macro-test/abc
+
+   (impl/with:library [+library+]
+     (ptr/ptr-deref abc))
+
+   (impl/with:library [+library+]
+     (ptr/ptr-display abc {}))
+   => \"def abc = 1;\""
+  {:added "4.0"}
+  ([lang tag op]
+   (let [lib  (impl/runtime-library)
+         {:keys [grammar]} (lib/get-book lib lang)]
+     (intern-top-level lang tag op grammar)))
+  ([lang tag op grammar]
+   (let [reserved (or (get-in grammar [:reserved op])
+                      (h/error "Not found" {:op op
+                                            :tag tag
+                                            :lang lang}))]
+     (intern-in
+      (str op ".") tag
+      (fn [&form &env sym & body]
+        `(intern-top-level-fn ~lang
+                              (quote [~op ~reserved])
+                              (quote ~&form)
+                              (merge (quote ~(meta sym))
+                                     {:time (h/time-ns)})))))))
+
+(defn intern-macros
+  "interns the top-level macros in the grammar"
+  {:added "4.0"}
+  ([lang grammar]
+   (let [{:keys [macros reserved tag]} grammar
+         fvar   (intern-def$ lang tag)
+         mvar   (intern-defmacro lang tag)
+         evar   (intern-! lang tag)
+         pvar   (intern-free lang tag)
+         tvars  (mapv (fn [op] (intern-top-level lang tag op grammar))
+                      macros)]
+     [[fvar mvar evar pvar] tvars])))
+
+(defn intern-highlights
+  "interns the highlight macros in the grammar"
+  {:added "4.0"}
+  ([lang grammar]
+   (let [{:keys [highlight reserved]} grammar]
+     (vec (keep (fn [sym]
+                  (let [op (get reserved sym)]
+                    (intern (h/ns-sym)
+                            (with-meta sym (merge {:macro true}
+                                                  (select-keys op [:arglists :style/indent])))
+                            (fn [_ _ & args]))))
+                highlight)))))
+
+(defn intern-grammar
+  "interns a bunch of macros in the namespace
+
+   (:macros (:grammar (lib/get-book +library+ :lua)))
+   => '#{defrun defn defglobal defgen defn- deftemp defclass defabstract def}
+
+   (impl/with:library [+library+]
+     (macro/intern-grammar :lua (:grammar (lib/get-book +library+ :lua))))
+   => map?"
+  {:added "4.0"}
+  [lang grammar]
+  (let [lib  (impl/runtime-library)
+        {:keys [grammar]} (lib/get-book lib lang)
+        m  {:macros     (intern-macros lang grammar)
+            :highlights (intern-highlights lang grammar)}]
+    (lib/wait-mutate!
+     lib
+     (fn [snapshot]
+       [m (update-in snapshot [lang :book] merge m)]))))
+
+
+(defn intern-defmacro-rt-fn
+  "defines both a library entry as well as a runtime macro"
+  {:added "4.0"}
+  [lang form smeta]
+  (let [{:static/keys [wrap]
+         :rt/keys [default]
+         :or {default :oneshot}} smeta
+        v (intern-defmacro-fn lang
+                              form
+                              smeta)
+
+        vptr (intern *ns* (with-meta (symbol (str  (.sym ^clojure.lang.Var v)
+                                                   ":ptr"))
+                            (meta v))
+                     @v)
+        vmacro (fn [_ _ & args]
+                 (let [form (list `control/script-rt-oneshot
+                                  default
+                                  (h/var-sym vptr)
+                                  (mapv (fn [x]
+                                          (list 'quote x))
+                                        args))]
+                   (cond->> form
+                     wrap (list wrap))))
+        _  (alter-meta! v merge {:macro true})
+        _  (alter-var-root v (fn [_] vmacro))]
+    [v vptr]))
+
+(defmacro defmacro.!
+  "macro for runtime lang macros"
+  {:added "4.0"}
+  [sym args & body]
+  (let [{:static/keys [lang]} (meta sym)]
+    `(intern-defmacro-rt-fn ~lang
+                            (quote ~&form)
+                            (merge ~(meta sym)
+                                   {:time (h/time-ns)}))))
+
+(comment
+  (h/p:space-context-unset (ut/lang-context :bash))
+  (bb.lang/with-trace
+    (bb.lang/with:input
+        (rt.shell/man:ptr :man))))

--- a/src/bb/lang/base/util.clj
+++ b/src/bb/lang/base/util.clj
@@ -1,0 +1,132 @@
+(ns bb.lang.base.util
+  (:require [bb.lib :as h]
+            [bb.string :as str]))
+
+;;
+;; SYMBOL
+;;
+
+(defn sym-id
+  "gets the symbol id"
+  {:added "3.0"}
+  ([id]
+   (symbol (name id))))
+
+(defn sym-module
+  "gets the symbol namespace"
+  {:added "3.0"}
+  ([id]
+   (if-let [s (namespace id)]
+     (symbol s))))
+
+(defn sym-pair
+  "gets the symbol pair
+
+   (sym-pair 'L.core/identity)
+   => '[L.core identity]"
+  {:added "3.0"}
+  ([id]
+   [(sym-module id)
+    (symbol (name id))]))
+
+(defn sym-full
+  "creates a full symbol"
+  {:added "3.0"}
+  ([{:keys [module id]}]
+   (if (and module id)
+     (sym-full module id)))
+  ([module id]
+   (symbol (name module) (name id))))
+
+(defn sym-default-str
+  "default fast symbol conversion"
+  {:added "4.0"}
+  [sym]
+  (str/replace (h/strn sym) "-" "_"))
+
+(defn sym-default-inverse-str
+  "inverses the symbol string"
+  {:added "4.0"}
+  [sym]
+  (str/replace (h/strn sym) "_" "-"))
+
+(defn hashvec?
+  "checks for hash vec"
+  {:added "4.0"}
+  ([x]
+   (and (set? x)
+        (= 1 (count x))
+        (vector? (first x)))))
+
+(defn doublevec?
+  "checks for double vec"
+  {:added "4.0"}
+  ([x]
+   (and (vector? x)
+        (= 1 (count x))
+        (vector? (first x)))))
+
+
+;;
+;; Context
+;;
+
+(defn lang-context
+  "creates the lang context"
+  {:added "4.0"}
+  ([lang]
+   (if lang
+     (keyword "lang" (name lang))
+     (h/error "No Lang Input" {:input lang}))))
+
+(defn lang-rt-list
+  "lists rt in a namespace"
+  {:added "4.0"}
+  ([]
+   (lang-rt-list (h/ns-sym)))
+  ([ns]
+   (let [space (h/p:space ns)]
+     (keep (fn [k]
+
+             (if (= 'lang (sym-module k))
+               (keyword (name k))))
+           (h/p:space-context-list space)))))
+
+(defn lang-rt
+  "getn the runtime contexts in a map"
+  {:added "4.0"}
+  ([]
+   (h/map-juxt [identity
+                lang-rt]
+               (lang-rt-list)))
+  ([lang]
+   (h/p:space-rt-current (lang-context lang)))
+  ([ns lang]
+   (h/p:space-rt-current ns (lang-context lang))))
+
+(defn lang-rt-default
+  "gets the default runtime function"
+  {:added "4.0"}
+  [ptr]
+  (let [ns (h/ns-sym)
+        active (set (lang-rt-list ns))
+        {:keys [module lang]} ptr]
+    (or (if (active lang) (lang-rt lang))
+        (let [rts (map (fn [lang] (lang-rt ns lang)) active)]
+          (or (first (filter (fn [rt] (get-in rt [:module/primary module]))
+                             rts))
+              (first (filter (fn [rt] (get-in rt [:module/internal module]))
+                             rts))))
+        (h/p:space-rt-current ns (:context ptr)))))
+
+(defn lang-pointer
+  "creates a lang pointer"
+  {:added "4.0"}
+  ([lang]
+   (lang-pointer lang {}))
+  ([lang {:keys [module id] :as m}]
+   (let [ctx (lang-context lang)]
+     (h/pointer (assoc m
+                       :module module :lang lang
+                       :context ctx
+                       :context/fn #'lang-rt-default)))))

--- a/src/bb/lang/base/workspace.clj
+++ b/src/bb/lang/base/workspace.clj
@@ -1,0 +1,268 @@
+(ns bb.lang.base.workspace
+  (:require [std.protocol.context :as protocol.context]
+            [bb.lang.base.library :as lib]
+            [bb.lang.base.library-snapshot :as snap]
+            [bb.lang.base.impl :as impl]
+            [bb.lang.base.impl-entry :as impl-entry]
+            [bb.lang.base.impl-lifecycle :as lifecycle]
+            [bb.lang.base.runtime :as rt]
+            [bb.lang.base.pointer :as ptr]
+            [bb.lang.base.util :as ut]
+            [bb.lang.interface.type-shared :as shared]
+            [bb.lang.base.script-control :as script-control]
+            [std.task.process :as process]
+            [bb.lib :as h]))
+
+(defn rt-resolve
+  "resolves an rt given keyword"
+  {:added "4.0"}
+  [lang-or-rt]
+  (if (keyword? lang-or-rt)
+    (ut/lang-rt lang-or-rt)
+    lang-or-rt))
+
+(defn sym-entry
+  "gets the entry using a symbol"
+  {:added "4.0"}
+  [lang sym]
+  (let [[sym-module sym-id] (ut/sym-pair sym)]
+    (lib/get-entry (impl/runtime-library)
+                   {:lang lang
+                    :module sym-module
+                    :section :code
+                    :id sym-id})))
+
+(defn sym-pointer
+  "converts to a pointer map"
+  {:added "4.0"}
+  [lang sym]
+  (let [[sym-module sym-id] (ut/sym-pair sym)]
+    {:lang lang
+     :module sym-module
+     :section :code
+     :id sym-id}))
+
+(defn module-entries
+  "gets all module entries
+
+   (w/module-entries :xtalk 'xt.lang.base-lib identity)
+   => coll?"
+  {:added "4.0"}
+  [lang ns pred]
+  (->> (lib/get-module (impl/runtime-library)
+                       lang
+                       ns)
+       :code
+       vals
+       (filter pred)
+       (sort-by (fn [e]
+                  (mapv #(get e %) [:line :time])))))
+
+(defn emit-ptr
+  "emits the poiner as a string"
+  {:added "4.0"}
+  ([ptr & [opts]]
+   (impl-entry/with:cache-force
+    (ptr/ptr-display ptr (or opts
+                             (ut/lang-rt-default ptr))))))
+
+(defn ptr-display-str
+  "copies pointer text to clipboard"
+  {:added "4.0"}
+  [ptr]
+  (impl-entry/with:cache-force
+   (ptr/ptr-display ptr (ut/lang-rt-default ptr))))
+
+(defn ptr-clip
+  "copies pointer text to clipboard"
+  {:added "4.0"}
+  [ptr]
+  (h/clip:nil (ptr-display-str ptr)))
+
+(defn ptr-print
+  "copies pointer text to clipboard"
+  {:added "4.0"}
+  [ptr]
+  (impl-entry/with:cache-force
+   (h/p)
+   (h/p (h/pl-add-lines (ptr-display-str ptr)))))
+
+(defn ptr-setup
+  "calls setup on a pointer"
+  {:added "4.0"}
+  [ptr]
+  (h/p:rt-setup-ptr (ut/lang-rt-default ptr)
+                    ptr))
+
+(defn ptr-setup
+  "calls setup on a pointer"
+  {:added "4.0"}
+  [ptr]
+  (h/p:rt-setup-ptr (ut/lang-rt-default ptr)
+                    ptr))
+
+(defn ptr-teardown
+  "calls teardown on a pointer"
+  {:added "4.0"}
+  [ptr]
+  (h/p:rt-teardown-ptr (ut/lang-rt-default ptr)
+                       ptr))
+
+(defn ptr-setup-deps
+  "calls setup on a pointer and all dependencies"
+  {:added "4.0"}
+  [ptr]
+  (let [deps (->> (h/deps:ordered (lib/get-book (impl/runtime-library)
+                                                (:lang ptr))
+                                  [(ut/sym-full ptr)])
+                  (map #(sym-entry (:lang ptr) %))
+                  (filter #(-> % :op (= 'defn))))]
+    (doseq [p deps]
+      (ptr-setup p))))
+
+(defn ptr-teardown-deps
+  "calls teardown on pointer all dependencies"
+  {:added "4.0"}
+  [ptr]
+  (let [deps (->> (h/deps:ordered (lib/get-book (impl/runtime-library)
+                                                (:lang ptr))
+                                  [(ut/sym-full ptr)])
+                  (map #(sym-entry (:lang ptr) %))
+                  (filter #(-> % :op-key (= 'defn))))]
+    (doseq [p deps]
+      (ptr-teardown p))))
+
+(defn emit-module
+  "emits the entire module"
+  {:added "4.0"}
+  ([]
+   (h/map-juxt [identity emit-module] (ut/lang-rt-list)))
+  ([lang-or-rt]
+   (emit-module lang-or-rt nil))
+  ([lang-or-rt module-id]
+   (let [rt (rt-resolve lang-or-rt)]
+     (rt/default-setup-module-emit rt
+                                   (or module-id (:module rt))))))
+
+(defn print-module
+  "emits and prints out the module
+
+   (std.print/with-out-str
+     (w/print-module (l/rt 'xt.lang.base-lib :xtalk)))
+   => string?"
+  {:added "4.0"}
+  ([]
+   (h/map-juxt [identity print-module] (ut/lang-rt-list)))
+  ([lang-or-rt]
+   (h/pl (emit-module lang-or-rt))))
+
+(defn rt:module
+  "gets the book module for a runtime"
+  {:added "4.0"}
+  ([lang-or-rt]
+   (let [rt (rt-resolve lang-or-rt)]
+     (lib/get-module (impl/runtime-library)
+                     (:lang rt)
+                     (:module rt)))))
+
+(defn rt:module-meta
+  "gets the book module for a runtime"
+  {:added "4.0"}
+  ([lang-or-rt]
+   (let [rt (rt-resolve lang-or-rt)]
+     (dissoc (lib/get-module (impl/runtime-library)
+                             (:lang rt)
+                             (:module rt))
+             :fragment
+             :code))))
+
+(defn rt:module-purge
+  "purges the current workspace"
+  {:added "4.0"}
+  ([]
+   (h/map-juxt [identity rt:module-purge] (ut/lang-rt-list)))
+  ([lang-or-rt]
+   (let [{:keys [lang module]
+          :as rt} (rt-resolve lang-or-rt)]
+     (lib/delete-module! (impl/runtime-library)
+                         lang
+                         module))))
+
+;;
+;;
+;;
+
+(defn rt:inner
+  "gets the inner client for a shared runtime"
+  {:added "4.0"}
+  ([]
+   (h/map-juxt [identity rt:inner] (ut/lang-rt-list)))
+  ([lang & [ns]]
+   (shared/rt-get-inner (ut/lang-rt ns lang))))
+
+(defn rt:restart
+  "restarts the shared runtime"
+  {:added "4.0"}
+  ([]
+   (h/map-juxt [identity
+                rt:restart]
+               (ut/lang-rt-list)))
+  ([lang & [ns]]
+   (let [rt (ut/lang-rt ns lang)]
+     (if (shared/rt-is-shared? rt)
+       (shared/restart-group-instance (-> rt :client :type)
+                                      (-> rt :id))
+       (script-control/script-rt-restart lang ns)))))
+
+(defn- multistage-tmpl
+  [[sym f]]
+  (h/$ (defn ~sym
+         ([lang]
+          (let [rt (ut/lang-rt lang)]
+            (~sym rt (:module rt))))
+         ([rt module-id]
+          (~f rt module-id)))))
+
+(h/template-entries [multistage-tmpl]
+  [[rt:setup-single    h/p:rt-setup-module]
+   [rt:teardown-single h/p:rt-teardown-module]
+   [rt:setup-to  rt/multistage-setup-to]
+   [rt:setup rt/multistage-setup-for]
+   [rt:teardown  rt/multistage-teardown-for]
+   [rt:teardown-to  rt/multistage-teardown-to]
+   [rt:teardown-at  rt/multistage-teardown-at]
+   [rt:scaffold-to rt/default-scaffold-setup-to]
+   [rt:scaffold rt/default-scaffold-setup-for]
+   [rt:scaffold-imports rt/default-scaffold-imports]])
+
+(defn intern-macros
+  "interns all macros from one namespace to another"
+  {:added "4.0"}
+  [lang ns & [module-id library merge-op]]
+  (let [library (or library (impl/default-library))
+        [to from] (if (vector? ns)
+                    ns
+                    [(h/ns-sym) ns])
+        imports (lib/wait-mutate!
+                 library
+                 (fn [snap]
+                   (let [book (snap/get-book-raw snap lang)
+                         imports (->> (get-in book [:modules from :fragment])
+                                      (h/map-vals (fn [e]
+                                                    (assoc e :module (or module-id to)))))
+                         new-book (update-in book [:modules (or module-id to) :fragment]
+                                             (fn [m]
+                                               ((or merge-op (fn [_ new] new))
+                                                m imports)))]
+                     [imports (snap/add-book snap new-book)])))]
+    (h/map-vals
+     (fn [e]
+       (let [src-var  (resolve (symbol (str ns) (str (:id e))))]
+         (intern to
+                 (with-meta (:id e)
+                   (merge (meta src-var)
+                          (select-keys e [:namespace :line]))
+                   #_(assoc
+                      #_#_:arglists (list (second (:form e)))))
+                 (ut/lang-pointer lang (select-keys e [:lang :id :module :section])))))
+     imports)))

--- a/src/bb/lang/dev.clj
+++ b/src/bb/lang/dev.clj
@@ -1,0 +1,27 @@
+(ns bb.lang.dev
+  (:require [bb.lib.link :as l]))
+
+(defn reload-specs
+  "reloads the specs"
+  {:added "4.0"}
+  []
+  (require 'bb.lang.base.grammar-spec :reload)
+  (require 'bb.lang.base.grammar-xtalk :reload)
+  (require 'bb.lang.base.grammar :reload)
+  (require 'bb.lang.model.spec-xtalk.com-js :reload)
+  (require 'bb.lang.model.spec-xtalk.com-lua :reload)
+  (require 'bb.lang.model.spec-xtalk.com-python :reload)
+  (require 'bb.lang.model.spec-xtalk.com-r :reload)
+  (require 'bb.lang.model.spec-xtalk.fn-js :reload)
+  (require 'bb.lang.model.spec-xtalk.fn-lua :reload)
+  (require 'bb.lang.model.spec-xtalk.fn-python :reload)
+  (require 'bb.lang.model.spec-xtalk.fn-r :reload)
+  (require 'bb.lang.model.spec-js :reload)
+  (require 'bb.lang.model.spec-lua :reload)
+  (require 'bb.lang.model.spec-python :reload)
+  (require 'bb.lang.model.spec-r :reload)
+  (require 'xt.lang.base-lib :reload))
+
+(comment
+  (s/reload-specs)
+  )

--- a/src/bb/lang/interface/type_notify.clj
+++ b/src/bb/lang/interface/type_notify.clj
@@ -1,0 +1,316 @@
+(ns bb.lang.interface.type-notify
+  (:require [std.protocol.component :as component]
+            [std.json :as json]
+            [std.concurrent :as cc]
+            [bb.string :as str]
+            [bb.lang.base.impl :as impl]
+            [bb.lib :as h :refer [defimpl]])
+  (:import (java.net ServerSocket
+                     Socket
+                     InetSocketAddress)
+           (com.sun.net.httpserver HttpExchange
+                                   HttpHandler
+                                   HttpServer)))
+
+(def ^:dynamic *notify-capture*
+  (atom []))
+
+(def ^:dynamic *notify-override* nil)
+
+(defn has-sink?
+  "checks that sink exists"
+  {:added "4.0"}
+  [{:keys [sinks]} id]
+  (contains? @sinks id))
+
+(defn get-sink
+  "gets a sink from the notification app server"
+  {:added "4.0"}
+  [{:keys [sinks]} id]
+  (h/swap-return! sinks
+    (fn [m]
+      (let [q (get m id)
+            curr (or q (atom nil))]
+        [curr (if q m (assoc m id curr))]))))
+
+(defn clear-sink
+  "clears a sink"
+  {:added "4.0"}
+  [{:keys [sinks]} id]
+  (h/swap-return! sinks
+    (fn [m]
+      [(get m id) (dissoc m id)])))
+
+(defn add-listener
+  "adds a listener to the sink"
+  {:added "4.0"}
+  [notify id sink-key f]
+  (let [sink (get-sink notify id)]
+    (add-watch sink sink-key
+               (fn [_ _ _ v]
+                 (f (h/map-keys keyword v))))))
+
+(defn remove-listener
+  "removes a listener from the sink"
+  {:added "4.0"}
+  [notify id sink-key]
+  (let [sink (get-sink notify id)]
+    (remove-watch sink sink-key)))
+
+;;
+;;
+;;
+
+(defn get-oneshot-id
+  "registers a oneshot id for the app server"
+  {:added "4.0"}
+  [{:keys [oneshots]}]
+  (h/swap-return! oneshots
+    (fn [set]
+      (loop [id (str "oneshot/" (h/sid))]
+        (if (get set id)
+          (recur (str "oneshot/" (h/sid)))
+          [id (conj set id)])))))
+
+(defn remove-oneshot-id
+  "removes a oneshot id"
+  {:added "4.0"}
+  [{:keys [oneshots]} id]
+  (h/swap-return! oneshots
+    (fn [set]
+      [(get set id) (disj set id)])))
+
+(defn clear-oneshot-sinks
+  "clear all registered oneshot sinks"
+  {:added "4.0"}
+  [{:keys [oneshots sinks]}]
+  (let [ids @oneshots]
+    (swap! sinks (fn [m] (apply dissoc m ids)))
+    (reset! oneshots #{})
+    ids))
+
+(defn process-print
+  "processes `print` id option"
+  {:added "4.0"}
+  [msg]
+  (let [{:strs [value key]} msg
+        {:strs [line column namespace id data]} (second key)]
+    (h/p (str "\n" namespace (if id (str "/" id))
+              (if (or line column)
+                (str " (" line ":" column ")"))
+              (if data (str " " data))))
+    (h/prf value true)))
+
+(defn process-capture
+  "processes `capture` id option"
+  {:added "4.0"}
+  [msg]
+  (swap! *notify-capture* conj msg))
+
+(defn process-message
+  "processes a message recieved by the notification server"
+  {:added "4.0"}
+  [app input]
+  (let [{:strs [id] :as msg} (json/read input)]
+    (cond (= id "print")
+          (process-print msg)
+
+          (= id "capture")
+          (process-capture msg)
+
+          (and id
+                 (or (not (str/starts-with? id  "oneshot/"))
+                     (has-sink? app id)))
+          (reset! (get-sink app id) msg))))
+
+;;
+;;
+;;
+
+(defn handle-notify-http
+  "handler for http request"
+  {:added "4.0"}
+  [^HttpExchange tx app]
+  (let [bytes (.readAllBytes (.getRequestBody tx))]
+    (process-message app (String. bytes))))
+
+(defn start-notify-http
+  "starts http server"
+  {:added "4.0"}
+  ([{:keys [http-port
+            sinks
+            http-instance] :as app}]
+   (when (not @http-instance)
+     (let [server (doto (HttpServer/create
+                         (InetSocketAddress. http-port)
+                         0)
+                    (.createContext
+                     "/" (reify HttpHandler
+                           (^void handle [_ ^HttpExchange tx]
+                            (let [_ (#'handle-notify-http tx app)
+                                  headers (.getResponseHeaders tx)
+                                  _ (.set headers "Access-Control-Allow-Origin" "*")
+                                  _ (.sendResponseHeaders tx 200 2)]
+                              (doto (.getResponseBody tx)
+                                (.write (.getBytes "OK"))
+                                (.close))))))
+                    (.setExecutor nil)
+                    (.start))]
+       (reset! http-instance server)))
+   app))
+
+
+(defn stop-notify-http
+  "stops http server"
+  {:added "4.0"}
+  ([{:keys [http-instance] :as app}]
+   (when-let [^HttpServer server @http-instance]
+     (.stop server 0)
+     (reset! http-instance nil ))
+   app))
+
+(defn handle-notify-socket
+  "handler for socket request"
+  {:added "4.0"}
+  [^java.net.Socket socket app]
+  #_(h/prn :CONNECTED)
+  (let [is  (.getInputStream socket)
+        bytes (.readAllBytes is)
+        _   (.close socket)]
+    (process-message app (String. bytes))))
+
+(defn start-notify-socket
+  "starts socket server"
+  {:added "4.0"}
+  ([{:keys [socket-port
+            socket-instance
+            sinks] :as app}]
+   (when (not @socket-instance)
+     (let [server    (ServerSocket. socket-port)
+           loop-fn   (fn []
+                       (loop []
+                         (when (not (.isClosed server))
+                           (try
+                             (let [socket   (.accept server)
+                                   _  (h/future
+                                        (#'handle-notify-socket socket app))])
+                             (catch java.net.SocketException e))
+                           (recur))))
+           thread   (cc/thread {:start true
+                                :handler loop-fn})]
+       (reset! socket-instance {:server server
+                                :thread thread})))
+   app))
+
+(defn stop-notify-socket
+  "stops socket server"
+  {:added "4.0"}
+  ([{:keys [socket-instance] :as app}]
+   (when-let [{:keys [server thread]} @socket-instance]
+     (if server (.close ^ServerSocket server))
+     (.interrupt ^Thread thread)
+     (reset! socket-instance nil ))
+   app))
+
+(defn start-notify
+  "starts both servers
+
+   (notify/start-notify +server+)
+   => map?"
+  {:added "4.0"}
+  [app]
+  (start-notify-http app)
+  (start-notify-socket app))
+
+(defn stop-notify
+  "stops both servers"
+  {:added "4.0"}
+  [app]
+  (stop-notify-http app)
+  (stop-notify-socket app))
+
+(defn- notify-server-string [{:keys [http-port
+                                     http-instance
+                                     socket-port
+                                     socket-instance
+                                     oneshots
+                                     sinks] :as notify}]
+  (str "#notify.server" {:http   [http-port   (boolean @http-instance)]
+                         :socket [socket-port (boolean @socket-instance)]
+                         :sinks (h/difference (set (keys @sinks))
+                                               @oneshots)
+                         :oneshots (count @oneshots)}))
+
+(defimpl NotifyServer [port sinks oneshots]
+  :string notify-server-string
+  :protocols [std.protocol.component/IComponent
+              :suffix "-notify"
+              :method {-kill stop-notify}])
+
+(defn notify-server:create
+  "creates notify serve"
+  {:added "4.0"}
+  [{:keys [http-port
+           socket-port]}]
+  (let [http-port   (or (h/port:check-available (or http-port   18130))
+                        (h/port:check-available 0))
+        socket-port (or (h/port:check-available (or socket-port 18131))
+                        (h/port:check-available 0))]
+    (map->NotifyServer {:http-port http-port
+                        :http-instance (atom nil)
+                        :socket-port socket-port
+                        :socket-instance (atom nil)
+                        :sinks   (atom {})
+                        :oneshots (atom #{})})))
+
+(defn notify-server
+  "create and start notify server"
+  {:added "4.0"}
+  [{:keys [port] :as m}]
+  (-> (notify-server:create m)
+      (h/start)))
+
+(h/res:spec-add
+ {:type :hara/lang.notify
+  :mode {:allow #{:global}
+         :default :global}
+  :instance {:create #'notify-server:create
+             :start h/start
+             :stop h/stop}})
+
+(defn default-notify
+  "gets the default notify server
+
+   (notify/default-notify)"
+  {:added "4.0"}
+  []
+  (or *notify-override*
+      (h/res :hara/lang.notify)))
+
+(defn default-notify:reset
+  "resets the default notify server"
+  {:added "4.0"}
+  []
+  (h/res:stop :hara/lang.notify))
+
+(defn watch-oneshot
+  "returns a completable future
+
+   (notify/watch-oneshot +server+
+                         10)
+   => (contains [string? h/future?])"
+  {:added "4.0"}
+  [app timeout & [id]]
+  (let [id (or id (get-oneshot-id app))
+        q   (get-sink app id)
+        pi  (h/incomplete)
+        p   (-> pi
+                (h/future:timeout timeout)
+                (h/on:complete (fn [ret _]
+                                 (remove-watch q id)
+                                 (remove-oneshot-id app id)
+                                 (clear-sink app id)
+                                 ret)))
+        _  (add-watch q id (fn [_ _ _ v]
+                             (h/future:force pi v)))]
+    [id p]))

--- a/src/bb/lang/interface/type_shared.clj
+++ b/src/bb/lang/interface/type_shared.clj
@@ -1,0 +1,210 @@
+(ns bb.lang.interface.type-shared
+  (:require [std.protocol.component :as protocol.component]
+            [std.protocol.context :as protocol.context]
+            [bb.lib :as h :refer [defimpl]]))
+
+(defonce ^:dynamic *groups*
+  (atom {}))
+
+(defn get-groups
+  "gets all shared groups
+
+   (shared/get-groups)
+   ;; (:hara/rt.postgres :hara/rt.redis :hara/rt.nginx :hara/rt.cpython.shared :hara/rt.luajit.shared)
+   => vector?"
+  {:added "4.0"}
+  []
+  (vec (keys @*groups*)))
+
+(defn get-group-count
+  "gets the group count for a type and id
+
+   (shared/get-group-count :hara/rt.redis)
+   ;; {:default 21, :test 2}
+   => map?"
+  {:added "4.0"}
+  ([]
+   (h/map-juxt [identity
+                get-group-count]
+               (get-groups)))
+  ([type & [id]]
+   (if id
+     (or (get-in @*groups*
+                 [type id :count])
+         0)
+     (h/map-vals :count
+                 (get @*groups* type)))))
+
+;(:hara/rt.postgres :hara/rt.redis :hara/rt.nginx :hara/rt.cpython.shared :hara/rt.luajit.shared)
+
+(defn update-group-count
+  "updates the group counte"
+  {:added "4.0"}
+  [type id f]
+  (swap! *groups*
+         (fn [m]
+           (update-in m [type id :count] f))))
+
+(defn get-group-instance
+  "gets the group instance"
+  {:added "4.0"}
+  [type id]
+  (get-in @*groups*
+          [type id :instance]))
+
+(defn set-group-instance
+  "sets the group instance"
+  {:added "4.0"}
+  [type id instance & [count config client]]
+  (swap! *groups*
+         (fn [m]
+           (cond-> m
+             :then  (assoc-in [type id :instance]
+                              instance)
+             count  (assoc-in [type id :count]
+                              count)
+             config (assoc-in [type id :config]
+                              config)
+             client (assoc-in [type id :client]
+                              client)))))
+
+(defn update-group-instance
+  "updates the group instance"
+  {:added "4.0"}
+  [type id f]
+  (swap! *groups*
+         (fn [m]
+           (update-in m [type id :instance] f))))
+
+(defn restart-group-instance
+  "restarts the group instance"
+  {:added "4.0"}
+  [type id]
+  (-> (swap! *groups*
+             (fn [m]
+               (let [{:keys [config client instance]} (get-in m [type id])]
+                 (if instance
+                   (h/stop instance))
+                 (assoc-in m [type id :instance]
+                           (h/start ((:constructor client)
+                                     config))))))
+      (get-in [type id :instance])))
+
+
+(defn remove-group-instance
+  "removes the group instance"
+  {:added "4.0"}
+  [type id]
+  (swap! *groups*
+         (fn [m]
+           (update-in m [type] dissoc id))))
+
+(defn start-shared
+  "starts a shared runtime client"
+  {:added "4.0"}
+  [{:keys [id client temp config] :as rt}]
+  (let [{:keys [type constructor]} client
+        instance (get-group-instance type id)]
+    (cond (not instance)
+          (set-group-instance type id (h/start (constructor config))
+                              1
+                              config
+                              client)
+
+          :else
+          (update-group-count type id (fnil inc 0))))
+  rt)
+
+(defn stop-shared
+  "stops a shared runtime client"
+  {:added "4.0"}
+  [{:keys [id client temp config] :as rt}]
+  (let [{:keys [type constructor]} client
+        cnt      (get-group-count type id)
+        instance (get-group-instance type id)]
+    (cond (not instance) nil
+
+          (and (or temp
+                   (= id :default))
+               (<= cnt 1))
+          (do (h/stop instance)
+              (remove-group-instance type id))
+
+          :else
+          (update-group-count type id (fnil dec 0))))
+  rt)
+
+(def kill-shared stop-shared)
+
+(def wrap-shared
+  (fn [f client id config]
+    (fn [shared & args]
+      (apply f
+             (merge
+              (get-in @*groups*
+                      [(:type client) id :instance])
+              config)
+             args))))
+
+(defn- rt-shared-string [{:keys [tag lang] :as rt}]
+  (str "#rt.shared" (:tag (get-group-instance (-> rt :client :type)
+                                              (-> rt :id)))
+       [lang]))
+
+(defimpl SharedRuntime
+  [id client temp config]
+  :suffix "-shared"
+  :string rt-shared-string
+  :protocols [protocol.component/IComponent
+              protocol.context/IContext
+              :method
+              {-raw-eval    (wrap-shared protocol.context/-raw-eval client id config),
+               -init-ptr    (wrap-shared protocol.context/-init-ptr client id config),
+               -tags-ptr    (wrap-shared protocol.context/-tags-ptr client id config),
+               -deref-ptr   (wrap-shared protocol.context/-deref-ptr client id config),
+               -display-ptr (wrap-shared protocol.context/-display-ptr client id config),
+               -invoke-ptr  (wrap-shared protocol.context/-invoke-ptr client id config),
+               -transform-in-ptr (wrap-shared protocol.context/-transform-in-ptr client id config),
+               -transform-out-ptr (wrap-shared protocol.context/-transform-out-ptr client id config)}
+              protocol.context/IContextLifeCycle
+              :method
+              {-has-module?  (wrap-shared protocol.context/-has-module? client id config),
+               -setup-module (wrap-shared protocol.context/-setup-module client id config),
+               -teardown-module (wrap-shared protocol.context/-teardown-module client id config),
+               -has-ptr?  (wrap-shared protocol.context/-has-ptr? client id config),
+               -setup-ptr (wrap-shared protocol.context/-setup-module client id config)
+               -teardown-ptr (wrap-shared protocol.context/-teardown-ptr client id config)}])
+
+(defn rt-shared:create
+  "creates a shared runtime client"
+  {:added "4.0"}
+  [{:rt/keys [id client temp] :as m}]
+  (let [rtks   (h/qualified-keys m :rt)
+        config (apply dissoc m (keys rtks))]
+    (map->SharedRuntime (merge m
+                                {:id (or id :default)
+                                 :config config}
+                                (h/unqualify-keys rtks)))))
+
+(defn rt-shared
+  "creates and starts and shared runtime client"
+  {:added "4.0"}
+  ([m]
+   (-> (rt-shared:create m)
+       (h/start))))
+
+(defn rt-is-shared?
+  "checks if a runtime is shared"
+  {:added "4.0"}
+  [obj]
+  (= "bb.lang.interface.type_shared.SharedRuntime"
+     (.getName ^Class (type obj))))
+
+(defn rt-get-inner
+  "gets the inner runtime"
+  {:added "4.0"}
+  [rt]
+  (if (rt-is-shared? rt)
+    (get-group-instance (-> rt :client :type)
+                        (-> rt :id))
+    rt))

--- a/src/bb/lang/model/spec_bash.clj
+++ b/src/bb/lang/model/spec_bash.clj
@@ -1,0 +1,276 @@
+(ns bb.lang.model.spec-bash
+  (:require [bb.lang.base.emit :as emit]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.emit-data :as data]
+            [bb.lang.base.emit-fn :as fn]
+            [bb.lang.base.emit-top-level :as top]
+            [bb.lang.base.grammar :as grammar]
+            [bb.lang.base.util :as ut]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.script :as script]
+            [bb.string :as str]
+            [bb.lib :as h]
+            [bb.lang.model.spec-xtalk]))
+
+(defn bash-quote-item
+  "quotes an item"
+  {:added "4.0"}
+  [v grammar mopts]
+  (if (vector? v)
+    (data/emit-data :free v grammar mopts)
+    (str "\"" (.replaceAll ^String (common/*emit-fn* v grammar mopts)
+                           "\"" "\\\\\"") "\"")))
+
+(defn bash-set
+  "quotes a string value"
+  {:added "4.0"}
+  [set grammar mopts]
+  (bash-quote-item (first set) grammar mopts))
+
+(defn bash-quote
+  "quotes a string value"
+  {:added "4.0"}
+  [[_ item] grammar mopts]
+  (bash-quote-item item grammar mopts))
+
+(defn bash-dash-param
+  "if keyword, replace `:` with `-`"
+  {:added "4.0"}
+  [k]
+  (conj (if (keyword? k)
+          (str "-" (name k))
+          k)))
+
+(defn bash-map
+  "outputs a map"
+  {:added "4.0"}
+  [form grammar mopts]
+  (let [arr (reduce-kv (fn [acc k v]
+                         (cond-> acc
+                           (not (false? v))  (conj (bash-dash-param k))
+                           (not (boolean? v)) (conj v)))
+                        []
+                        form)]
+    (str/join " " (common/emit-array arr grammar mopts))))
+
+(defn bash-invoke
+  "outputs an invocation (same as vector)"
+  {:added "4.0"}
+  [[f & args] grammar mopts]
+  (let [args (map (fn [x]
+                    (if (and (h/form? x)
+                             (not (get-in grammar [:reserved (first x)])))
+                      (list '$ x)
+                      x))
+                  args)]
+    (str/join " " (common/emit-array (cons f args) grammar mopts))))
+
+(defn- bash-vector
+  [arr grammar mopts]
+  (str/join " " (common/emit-array arr grammar mopts)))
+
+(defn bash-assign
+  "outputs an assignment"
+  {:added "4.0"}
+  [[_ & args :as form] grammar mopts]
+  (common/emit-assign "=" args (assoc-in grammar [:default :common :space] "") mopts))
+
+(defn bash-var
+  "transforms to var"
+  {:added "4.0"}
+  [[_ sym & args]]
+  (let [val (last args)]
+    (list :- :local (list := sym val))))
+
+(defn bash-defn
+  "transforms a function to allow for inputs"
+  {:added "4.0"}
+  [[_ sym args & body]]
+  (let [vs (map-indexed (fn [i v]
+                          (list 'var v (list :$ (inc i))))
+                        args)]
+    (apply list 'defn- sym []
+           (concat vs body))))
+
+(defn bash-defn-
+  "emits a non paramerised version"
+  {:added "4.0"}
+  [[_ sym args & body] grammar mopts]
+  (top/emit-top-level :defn (apply list nil sym [] body) grammar mopts))
+
+(defn bash-expand
+  "brace expansion syntax"
+  {:added "4.0"}
+  [[_ inner]]
+  (list :% "${" (list '% inner) "}"))
+
+(defn bash-subshell
+  "brace subshell syntax"
+  {:added "4.0"}
+  [[_ inner]]
+  (list :% "$(" (list '% inner) ")"))
+
+(defn bash-test
+  "constructs test syntax"
+  {:added "4.0"}
+  [[_ inner]]
+  (list :% "[[ " (list '% (mapv bash-dash-param inner)) " ]]"))
+
+(defn bash-pipeleft
+  "constructs pipeleft syntax"
+  {:added "4.0"}
+  [[_ inner]]
+  (list :% "<(" (list '% inner) ")"))
+
+(defn bash-piperight
+  "constructs pipeleft syntax"
+  {:added "4.0"}
+  [[_ inner]]
+  (list :% ">(" (list '% inner) ")"))
+
+(defn bash-here
+  "construct here block and here string"
+  {:added "4.0"}
+  [[_ term lines]]
+  (if (and (string? term) (empty? lines))
+    (list :% "<<<" #{term})
+    (list :% "<<" term
+          (list \\ \\ (apply list 'do lines))
+          (list \\ \\ term))))
+
+(defn bash-check-fn
+  "custom check for vectors"
+  {:added "4.0"}
+  [check]
+  (if (vector? check)
+    (list :test (apply vector check))
+    check))
+
+(defn bash-when
+  "when support for custom vectors"
+  {:added "4.0"}
+  ([[_ check & body]]
+   `(~'br* (~'if ~(bash-check-fn check) ~@body))))
+
+(defn bash-if
+  "if support for custom vectors"
+  {:added "4.0"}
+  ([[_ check then & [else]]]
+   `(~'br*
+     (~'if ~(bash-check-fn check) ~then)
+     ~@(if else
+         `[(~'else ~else)]))))
+
+(defn bash-cond
+  "cond support for custom vectors"
+  {:added "4.0"}
+  ([[_ check then & more]]
+   (let [args (partition 2 more)
+         [ei el] (if (= :else (first (last args)))
+                   [(butlast args) (last args)]
+                   [args nil])]
+     `(~'br*
+       (~'if ~(bash-check-fn check) ~then)
+       ~@(map (fn [[check then]]
+                `(~'elseif ~(bash-check-fn check) ~then))
+              ei)
+       ~@(if el
+           `[(~'else ~(second el))])))))
+
+(def +features+
+  (-> (grammar/build :include [:builtin
+                               :builtin-helper
+                               :free-control
+                               :free-literal
+                               :math
+                               :compare
+                               :return
+                               :vars
+                               :control-base
+                               :control-general
+                               :block
+                               :top-base
+                               [:macro :include [:if :cond :when]]
+                               :macro-case])
+      (grammar/build:override
+       {:mul       {:value true}
+        :add       {:value true}
+        :sub       {:value true}
+        :div       {:value true}
+        :eq        {:raw "=" :value true}
+        :gt        {:value true}
+        :lt        {:value true}
+        :var       {:macro  #'bash-var  :emit :macro}
+        :seteq     {:emit   #'bash-assign}
+        :defn      {:symbol #{'defn} :macro #'bash-defn :emit :macro}
+        :block     {:symbol #{:block}}
+        :if        {:macro  #'bash-if}
+        :when      {:macro  #'bash-when}
+        :cond      {:macro  #'bash-cond}
+        :quote     {:op :quote     :symbol '#{quote}  :emit #'bash-quote}})
+      (grammar/build:extend
+       {:defn-     {:op :defn-     :symbol #{'defn-}  :type :block :emit #'bash-defn-}
+        :andflow   {:op :andflow   :symbol '#{&&}   :raw "&&" :value true  :emit :infix}
+        :orflow    {:op :orflow    :symbol '#{||}   :raw "||" :value true  :emit :infix}
+        :pipe      {:op :pipe      :symbol '#{>>}   :raw "|"  :emit :infix}
+        :to        {:op :to        :symbol #{:..}   :emit :between      :raw ".."}
+        :expand    {:op :expand    :symbol #{:$}    :emit :macro  :macro #'bash-expand :raw "$"}
+        :test      {:op :test      :symbol #{:test} :emit :macro  :macro #'bash-test}
+        :subshell  {:op :subshell  :symbol #{'$}    :raw "$" :emit :macro  :value true  :macro #'bash-subshell}
+        :here      {:op :here      :symbol #{'<<}   :emit :macro  :macro #'bash-here}
+        :toleft    {:op :toleft    :symbol #{'<$}   :raw "<" :value true :emit :macro  :macro #'bash-pipeleft}
+        :toright   {:op :toright   :symbol #{'$>}   :raw ">" :value true :emit :macro  :macro #'bash-piperight}})))
+
+(def +template+
+  (->> {:banned #{:regex}
+        :highlight '#{return break}
+        :default {:common    {:statement ""
+                              :start  "" :end ""
+                              :sep ""
+                              :namespace-full "_"
+                              :space " "}
+                  :invoke    {:custom #'bash-invoke}
+                  :define    {:space ""}
+                  :symbol    {:full {:replace {\. "_"
+                                               \- "_"}
+                                     :sep "_"}
+                              :global identity}
+                  :block     {:statement ""
+                              :parameter {:start " " :end ""}
+                              :body      {:start "; do" :end "done"}}}
+        :token   {:nil       {:as "''"}
+                  :string    {:custom #'identity}
+                  :keyword   {:custom #'h/strn}}
+        :data    {:map       {:custom #'bash-map}
+                  :set       {:custom #'bash-set}
+                  :vector    {:custom #'bash-vector}
+                  :free      {:start "{" :end "}" :sep ","}}
+        :block  {:branch     {:control   {:default   {:parameter {:start " " :end "; then"}
+	                                              :body      {:start "" :end "" :append true}}
+	                                  :elseif    {:raw "elif"}}
+	                      :wrap      {:end "fi"}}
+                 :switch     {:raw "case"
+                              :body      {:start " in" :end "esac"}
+                              :control {:default {:raw ""
+                                                  :parameter {:start "" :end ""}
+                                                  :body      {:start ")" :end ";;"}}}}}}
+       (h/merge-nested (update-in (emit/default-grammar)
+                                  [:token :symbol]
+                                  dissoc :replace))))
+
+(def +grammar+
+  (grammar/grammar :sh
+    (grammar/to-reserved +features+)
+    +template+))
+
+(def +book+
+  (book/book {:lang :bash
+              :parent :xtalk
+              :meta (book/book-meta {})
+              :grammar +grammar+}))
+
+(def +init+
+  (script/install +book+))
+
+(comment
+  (./create-tests))

--- a/src/bb/lang/model/spec_c.clj
+++ b/src/bb/lang/model/spec_c.clj
@@ -1,0 +1,179 @@
+(ns bb.lang.model.spec-c
+  (:require [bb.lang.base.emit :as emit]
+            [bb.lang.base.emit-fn :as emit-fn]
+            [bb.lang.base.emit-helper :as helper]
+            [bb.lang.base.grammar :as grammar]
+            [bb.lang.base.util :as ut]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.script :as script]
+            [bb.string :as str]
+            [bb.lib :as h]))
+
+(defn tf-define
+  "not sure if this is needed (due to defmacro) but may be good for source to source"
+  {:added "4.0"}
+  [[_ sym & more :as form]]
+  (let [[args body] (if (= 1 (count more))
+                      [nil (first more)]
+                      more)]
+    (if args
+      (list :- "#define" (list :% sym (list 'quote
+                                            (apply list args)))
+            body)
+      (list :- "#define" sym body))))
+
+(defn tf-struct
+  "transforms struct definition"
+  {:added "4.0"}
+  [[_ sym fields]]
+  (let [fields (partition 2 fields)
+        out (map (fn [[type name]]
+                   (list :- type (str name ";")))
+                 fields)]
+    (list :- "struct" sym
+          (list :- "{"
+                (list \\
+                      \\ (list \| (apply list 'do out)))
+                (list :- "\n};")))))
+
+(defn tf-enum
+  "transforms enum definition"
+  {:added "4.0"}
+  [[_ sym fields]]
+  (list :- "enum" sym
+        (list :- "{")
+        (list 'quote fields)
+        (list :- "};")))
+
+(defn tf-typedef
+  "transforms typedef"
+  {:added "4.0"}
+  [[_ type alias]]
+  (let [alias-str (ut/sym-default-str alias)]
+    (list :- "typedef" type (str alias-str ";"))))
+
+(defn to-c-type
+  "converts to c type"
+  {:added "4.0"}
+  [t]
+  (cond (keyword? t) (name t)
+        (symbol? t) (name t)
+        (vector? t) (str/join " " (map to-c-type t))
+        :else (str t)))
+
+(defn c-sanitize
+  "sanitizes a symbol for c"
+  {:added "4.0"}
+  [s]
+  (-> (str s)
+      (str/replace "-" "_")
+      (str/replace "." "_")
+      (str/replace "/" "____")))
+
+(defn c-fn-args
+  "custom C function arguments emission"
+  {:added "4.0"}
+  [[_ args] grammar mopts]
+  (let [args (if (and (list? args) (= 'quote (first args)))
+               (second args)
+               args)
+        args (if (vector? args)
+               (if (vector? (first args))
+                 args
+                 (partition 2 args))
+               [args])]
+    (str "("
+         (str/join ", "
+                   (map (fn [arg]
+                          (if (sequential? arg)
+                            (let [[type name] arg]
+                              (str (c-sanitize (to-c-type type))
+                                   " "
+                                   (emit/emit-main name grammar mopts)))
+                            (emit/emit-main arg grammar mopts)))
+                        args))
+         ")")))
+
+
+
+(defn emit-defn
+  "custom defn for C"
+  {:added "4.0"}
+  [[_ sym args & body] grammar mopts]
+  (let [ret-type (or (-> sym meta :tag) (-> sym meta :-) "void")
+        ret-type (to-c-type ret-type)
+
+        module (:module mopts)
+        sym-str (if (and module (symbol? sym) (not (namespace sym)))
+                  (c-sanitize (symbol (name (:id module)) (name sym)))
+                  (c-sanitize sym))
+
+        args-str (c-fn-args [:c-args args] grammar mopts)
+
+        body-str (emit/emit-main (list \\ \\ (list \| (apply list 'do body))) grammar mopts)]
+
+    (str ret-type " " sym-str " " args-str " "
+         "{\n"
+         body-str
+         "\n}")))
+
+(defn tf-arrow
+  "transforms arrow ->"
+  {:added "4.0"}
+  [[_ left right]]
+  (list :% left (list :- "->" right)))
+
+(defn tf-sizeof
+  "transforms sizeof"
+  {:added "4.0"}
+  [[_ val]]
+  (list :- "sizeof" val))
+
+(def +features+
+  (-> (grammar/build :exclude [:data-shortcuts
+                               :control-try-catch
+                               :class
+                               :macro-arrow])
+      (grammar/build:override
+       {:defn    {:emit #'emit-defn}})
+      (grammar/build:extend
+       {:c-args  {:op :c-args :symbol #{:c-args} :emit #'c-fn-args}
+        :define  {:op :define  :symbol '#{define}  :macro #'tf-define
+                  :type :def :emit :macro
+                  :section :code :priority 1}
+        :arrow   {:op :arrow :symbol #{'-> 'arrow} :emit :infix :raw "->"}
+        :sizeof  {:op :sizeof :symbol #{'sizeof} :emit :prefix :raw "sizeof" :type :free}
+        :struct  {:op :struct :symbol #{'struct} :emit :macro :macro #'tf-struct :section :code :type :def}
+        :enum    {:op :enum   :symbol #{'enum}   :emit :macro :macro #'tf-enum :section :code :type :def}
+        :typedef {:op :typedef :symbol #{'typedef} :emit :macro :macro #'tf-typedef :section :code :type :def}})))
+
+(def +template+
+  (->> {:banned #{:set :map :regex}
+        :highlight '#{return break}
+        :default {:function  {:raw ""}}
+        :data    {:vector    {:start "{" :end "}" :space ""}
+                  :tuple     {:start "(" :end ")" :space ""}}
+        :block  {:for       {:parameter {:sep ","}}
+                 :script    {:start "" :end ""}}
+        :define {:def       {:raw ""}}}
+       (h/merge-nested (emit/default-grammar))))
+
+(def +grammar+
+  (grammar/grammar :c
+    (grammar/to-reserved +features+)
+    +template+))
+
+(def +meta+
+  (book/book-meta
+   {:module-current   (fn [])
+    :module-import    (fn [name _ opts]
+                        (h/$ (:- "#include" ~name)))
+    :module-export    (fn [{:keys [as refer]} opts])}))
+
+(def +book+
+  (book/book {:lang :c
+              :meta +meta+
+              :grammar +grammar+}))
+
+(def +init+
+  (script/install +book+))

--- a/src/bb/lang/model/spec_erlang.clj
+++ b/src/bb/lang/model/spec_erlang.clj
@@ -1,0 +1,162 @@
+(ns bb.lang.model.spec-erlang
+  (:require [bb.lang.base.emit :as emit]
+            [bb.lang.base.grammar :as grammar]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.emit-preprocess :as preprocess]
+            [bb.lang.base.util :as ut]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.script :as script]
+            [bb.lang.model.spec-xtalk]
+            [bb.lang.model.spec-xtalk.fn-erlang :as fn]
+            [bb.lib :as h]
+            [bb.string :as str]))
+
+;;
+;; UTILS
+;;
+
+(defn to-erlang-var [sym]
+  (if (symbol? sym)
+    (let [s (name sym)]
+      (if (re-find #"^[a-z]" s)
+        (symbol (str (str/upper-case (subs s 0 1)) (subs s 1)))
+        sym))
+    sym))
+
+(defn capitalize-locals [form locals]
+  (if (empty? locals)
+    form
+    (h/postwalk (fn [x]
+                  (if (and (symbol? x) (locals x))
+                    (to-erlang-var x)
+                    x))
+                form)))
+
+(defn emit-ast [form]
+  (common/emit-common form
+                      preprocess/*macro-grammar*
+                      preprocess/*macro-opts*))
+
+(defn wrap-raw [s]
+  (list 'erl-raw s))
+
+;;
+;; LANG
+;;
+
+(defn tf-erlang-defn
+  "transforms defn to erlang function definition"
+  [[_ sym args & body]]
+  (let [name (ut/sym-default-str sym)
+        locals (set (filter symbol? args))
+        erl-args (map to-erlang-var args)
+        erl-body (map #(capitalize-locals % locals) body)]
+    (list 'defn- sym (vec erl-args) erl-body)))
+
+(defn emit-erlang-defn
+  "emits erlang function"
+  [[_ sym params body]]
+  (wrap-raw
+   (str (ut/sym-default-str sym)
+        "("
+        (str/join ", " (map emit-ast params))
+        ") -> "
+        (str/join ", " (map emit-ast body))
+        ".")))
+
+(defn tf-erlang-case
+  "transforms case"
+  [[_ expr & clauses]]
+  (let [pairs (partition 2 clauses)]
+    (list 'case* expr pairs)))
+
+(defn emit-erlang-case
+  "emits erlang case"
+  [[_ expr clauses]]
+  (wrap-raw
+   (str "case " (emit-ast expr) " of "
+        (str/join "; "
+                  (map (fn [[pat body]]
+                         (str (emit-ast pat) " -> " (emit-ast body)))
+                       clauses))
+        " end")))
+
+(defn tf-erlang-tuple
+  "transforms tuple"
+  [[_ & elements]]
+  (cons 'tuple* elements))
+
+(defn emit-erlang-tuple
+  "emits erlang tuple"
+  [[_ & elements]]
+  (wrap-raw
+   (str "{" (str/join ", " (map emit-ast elements)) "}")))
+
+(defn emit-erlang-var
+  "emits var assignment"
+  [[_ sym _ val]]
+  (wrap-raw
+   (str (emit-ast (to-erlang-var sym)) " = " (emit-ast val))))
+
+(def +features+
+  (-> (grammar/build :include [:builtin :math :compare :logic :control-base])
+      (merge (grammar/build-xtalk))
+      (grammar/build:extend
+       {:erl-raw {:op :erl-raw :symbol #{'erl-raw} :type :token}
+        :defn   {:macro #'tf-erlang-defn :emit :macro :type :macro :symbol #{'defn}}
+        :case   {:macro #'tf-erlang-case :emit :macro :type :macro :symbol #{'case}}
+        :tuple  {:macro #'tf-erlang-tuple :emit :macro :type :macro :symbol #{'tuple}}
+        :var    {:symbol #{'var} :emit :macro :macro #'emit-erlang-var :type :macro}
+        :eq-exact {:raw "=:="}
+        :defn- {:op :defn- :symbol #{'defn-} :emit :macro :macro #'emit-erlang-defn :type :macro}
+        :case* {:op :case* :symbol #{'case*} :emit :macro :macro #'emit-erlang-case :type :macro}
+        :tuple* {:op :tuple* :symbol #{'tuple*} :emit :macro :macro #'emit-erlang-tuple :type :macro}
+        :send  {:op :send :symbol #{'send '!} :raw "!" :emit :infix}})
+      (grammar/build:override fn/+erlang+)
+      (grammar/build:override
+       {:and    {:raw "and"}
+        :or     {:raw "or"}
+        :not    {:raw "not"}
+        :eq     {:raw "=="}
+        :neq    {:raw "/="}
+        :mod    {:raw "rem"}})))
+
+(defn erlang-map-key
+  "custom erlang map key"
+  [key grammar mopts]
+  (cond (keyword? key) (name key)
+        (string? key) (str "\"" key "\"")
+        :else (common/emit-common key grammar mopts)))
+
+(def +template+
+  (->> {:default {:comment   {:prefix "%"}
+                  :common    {:statement "" :apply "(" :sep ", "}
+                  :block     {:body {:start "" :end "" :sep ", "}}}
+        :token   {:nil       {:as "undefined"}
+                  :boolean   {:as identity}
+                  :string    {:quote :double}
+                  :symbol    {}
+                  :erl-raw   {:as second}}
+        :data    {:vector    {:start "[" :end "]" :space ""}
+                  :map       {:start "#{" :end "}" :space "" :assign " => " :key-fn #'erlang-map-key}
+                  :map-entry {:start "" :end "" :space "" :assign " => " :key-fn #'erlang-map-key}
+                  :set       {:start "#{" :end "}" :space "" :assign " => "}}
+        :function {:defn     {:raw ""}}}
+       (h/merge-nested (emit/default-grammar))))
+
+(def +grammar+
+  (grammar/grammar :erlang
+    (grammar/to-reserved +features+)
+    +template+))
+
+(def +meta+
+  (book/book-meta {}))
+
+(def +book+
+  (book/book {:lang :erlang
+              :parent :xtalk
+              :meta +meta+
+              :grammar +grammar+}))
+
+(def +init+
+  (script/install +book+))

--- a/src/bb/lang/model/spec_glsl.clj
+++ b/src/bb/lang/model/spec_glsl.clj
@@ -1,0 +1,88 @@
+(ns bb.lang.model.spec-glsl
+  (:require [bb.lang.base.emit :as emit]
+            [bb.lang.base.grammar :as grammar]
+            [bb.lang.base.util :as ut]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.script :as script]
+            [bb.string :as str]
+            [bb.lib :as h]))
+
+(def +types+
+  [:bool :int :float :double :uint
+   :vec2 :vec3 :vec4
+   :dvec2 :dvec3 :dvec4
+   :ivec2 :ivec3 :ivec4
+   :uvec2 :uvec3 :uvec4
+   :bvec2 :bvec3 :bvec4
+   :mat2 :mat3 :mat4
+   :mat2x3 :mat2x4
+   :mat3x2 :mat3x4
+   :mat4x2 :mat4x3
+   :dmat2 :dmat3 :dmat4
+   :dmat2x3 :dmat2x4
+   :dmat3x2 :dmat3x4
+   :dmat4x2 :dmat4x3])
+
+(def +typeops+
+  (h/map-juxt [identity
+               (fn [k]
+                 {:op k    :symbol #{k}  :raw (name k) :emit :invoke})]
+              +types+))
+
+(def +features+
+  (-> (grammar/build :exclude [:data-shortcuts
+                               :control-try-catch
+                               :class])
+      (grammar/build:extend +typeops+)))
+
+(def +template+
+  (->> {:banned #{:set :map :regex}
+        :highlight '#{return break}
+        :default {:function  {:raw ""}}
+        :data    {:vector    {:start "{" :end "}" :space ""}
+                  :tuple     {:start "(" :end ")" :space ""}}
+        :block  {:for       {:parameter {:sep ","}}}
+        :define {:def       {:raw ""}}}
+       (h/merge-nested (emit/default-grammar))))
+
+(def +grammar+
+  (grammar/grammar :gl
+    (grammar/to-reserved +features+)
+    +template+))
+
+(def +meta+
+  (book/book-meta
+   {:module-import    (fn [name _ opts]
+                        (h/$ (:- "#include" ~name)))}))
+
+(def +book+
+  (book/book {:lang :glsl
+              :meta +meta+
+              :grammar +grammar+}))
+
+(def +init+
+  (script/install +book+))
+
+
+
+
+
+
+
+
+
+
+
+
+
+(comment
+  {:defrun
+        {:op :def  :symbol '#{def} :spec :def  :type :def  :section :code
+         :emit gl-def
+         :arglists '([sym & body])}
+        :def     {:op :def :raw ""}
+        :vec2    {:op :vec2    :symbol '#{:vec2}  :raw "vec2" :emit :invoke}
+        :vec3    {:op :vec3    :symbol '#{:vec3}  :raw "vec3" :emit :invoke}
+        :addr    {:op :addr    :symbol '#{:&}  :raw "&" :emit :pre}
+        :ptr     {:op :ptr     :symbol '#{:*}  :raw "*" :emit :pre}}
+  )

--- a/src/bb/lang/model/spec_go.clj
+++ b/src/bb/lang/model/spec_go.clj
@@ -1,0 +1,137 @@
+(ns bb.lang.model.spec-go
+  (:require [bb.lang.base.emit :as emit]
+            [bb.lang.base.emit-fn :as fn]
+            [bb.lang.base.emit-data :as data]
+            [bb.lang.base.emit-helper :as helper]
+            [bb.lang.base.grammar :as grammar]
+            [bb.lang.base.util :as ut]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.script :as script]
+            [bb.lang.model.spec-xtalk]
+            [bb.lang.model.spec-xtalk.fn-go :as fn-go]
+            [bb.string :as str]
+            [bb.lib :as h]))
+
+(defn go-typesystem
+  "handle generic types"
+  {:added "4.0"}
+  [arr grammar mopts]
+  (let [[_ type & args] arr]
+     (cond (= 'slice type)
+           (str "[]" (emit/emit-main (first args) grammar mopts))
+
+           (= 'map type)
+           (str "map[" (emit/emit-main (first args) grammar mopts) "]"
+                (emit/emit-main (second args) grammar mopts))
+
+           :else
+           (str (emit/emit-main type grammar mopts)
+                "[" (str/join ", " (map #(emit/emit-main % grammar mopts) args)) "]"))))
+
+(defn go-vector
+  "emit vector or slice"
+  {:added "4.0"}
+  ([arr grammar mopts]
+   (let [sym (first arr)]
+     (cond (= :> sym)
+           (go-typesystem arr grammar mopts)
+
+           :else
+           (str "[]interface{}{"
+                (str/join ", " (map #(emit/emit-main % grammar mopts) arr))
+                "}")))))
+
+(defn tf-go-arrow
+  "macro for channel op"
+  {:added "4.0"}
+  [[_ & args]]
+  (if (= 1 (count args))
+    (list :% (list :- "<-") (first args))
+    (list :% (first args) (list :- " <- ") (second args))))
+
+(defn go-defstruct
+  "defstruct implementation"
+  {:added "4.0"}
+  [[_ sym fields] grammar mopts]
+  (str "type " (emit/emit-main sym grammar mopts) " struct {\n"
+       (str/join "\n"
+                 (map (fn [field]
+                        (if (vector? field)
+                          (let [[n t & tags] field
+                                tag-str (if (seq tags)
+                                          (str " `" (str/join " " tags) "`")
+                                          "")]
+                            (str "  " (emit/emit-main n grammar mopts) " "
+                                 (emit/emit-main t grammar mopts)
+                                 tag-str))
+                          (str "  " (emit/emit-main field grammar mopts))))
+                      fields))
+       "\n}"))
+
+(defn go-definterface
+  "definterface implementation"
+  {:added "4.0"}
+  [[_ sym methods] grammar mopts]
+  (str "type " (emit/emit-main sym grammar mopts) " interface {\n"
+       (str/join "\n"
+                 (map (fn [method]
+                         (str "  " (emit/emit-main method grammar mopts)))
+                      methods))
+       "\n}"))
+
+(def +features+
+  (-> (grammar/build)
+      (grammar/build:override
+       {:var        {:symbol '#{var} :raw "var"}
+        :new        {:symbol '#{new} :raw "new" :emit :call}})
+      (grammar/build:override fn-go/+go+)
+      (grammar/build:extend
+       {:go-chan    {:op :go-chan    :symbol '#{chan} :raw "chan " :emit :pre}
+        :go-arrow   {:op :go-arrow   :symbol '#{<-}   :macro #'tf-go-arrow :emit :macro :type :macro}
+        :go         {:op :go         :symbol '#{go}   :raw "go " :emit :pre}
+        :defer      {:op :defer      :symbol '#{defer} :raw "defer " :emit :pre}
+        :make       {:op :make       :symbol '#{make} :raw "make" :emit :invoke}
+
+        :defstruct  {:op :defstruct :symbol '#{defstruct}
+                     :type :def :section :code
+                     :emit #'go-defstruct}
+        :definterface {:op :definterface :symbol '#{definterface}
+                       :type :def :section :code
+                       :emit #'go-definterface}})))
+
+(def +template+
+  (-> (emit/default-grammar)
+      (h/merge-nested
+       {:banned #{:set :regex}
+        :highlight '#{return break continue fallthrough}
+        :default {:common    {:statement ""}
+                  :function  {:prefix "func"
+                              :raw ""
+                              :args {:sep ", "}}
+                  :typehint  {:enabled true :assign "" :space " " :after true}
+                  :invoke    {:reversed true :hint ""}
+                  :block     {:start " {" :end "}"}}
+        :token   {:symbol {:replace {\- "_"}}}
+        :data    {:vector {:custom #'go-vector}
+                  :map    {:start "map[string]interface{}{" :end "}" :space ""}}
+        :xtalk   {:notify {:custom true}}})))
+
+(def +grammar+
+  (grammar/grammar :go
+    (grammar/to-reserved +features+)
+    +template+))
+
+(def +meta+
+  (book/book-meta
+   {:module-current   (fn [])
+    :module-import    (fn [name _ opts]
+                        (list :- "import" (str "\"" name "\"")))}))
+
+(def +book+
+  (book/book {:lang :go
+              :parent :xtalk
+              :meta +meta+
+              :grammar +grammar+}))
+
+(def +init+
+  (script/install +book+))

--- a/src/bb/lang/model/spec_haskell.clj
+++ b/src/bb/lang/model/spec_haskell.clj
@@ -1,0 +1,207 @@
+(ns bb.lang.model.spec-haskell
+  (:require [bb.lang.base.emit :as emit]
+            [bb.lang.base.emit-fn :as emit-fn]
+            [bb.lang.base.emit-data :as data]
+            [bb.lang.base.emit-helper :as helper]
+            [bb.lang.base.grammar :as grammar]
+            [bb.lang.base.util :as ut]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.script :as script]
+            [bb.string :as str]
+            [bb.lib :as h]))
+
+(defn haskell-typesystem
+  "emit haskell types"
+  {:added "4.0"}
+  [arr grammar mopts]
+  (let [[sym & more] (rest arr)]
+    (str sym " " (str/join " "
+                           (map (fn [input]
+                                  (cond (string? input)
+                                        input
+
+                                        :else
+                                        (emit/emit-main input grammar mopts)))
+                                more)))))
+
+(defn haskell-vector
+  "emit haskell vectors and types"
+  {:added "4.0"}
+  ([arr grammar mopts]
+   (let [sym (first arr)]
+     (cond (= :> sym)
+           (haskell-typesystem arr grammar mopts)
+
+           :else
+           (data/emit-coll :vector arr grammar mopts)))))
+
+(defn emit-raw-str
+  "emits a raw string"
+  {:added "4.0"}
+  [[_ s] grammar mopts]
+  s)
+
+(defn emit-indent-body
+  "indents the body"
+  {:added "4.0"}
+  [[_ form] grammar mopts]
+  (let [s (emit/emit-main form grammar mopts)]
+    (str/indent s 2)))
+
+(defn tf-defn
+  "custom defn for Haskell"
+  {:added "4.0"}
+  [[_ sym args & body]]
+  (let [ret-type (-> sym meta :tag)
+        sym      (if (string? sym) (symbol sym) sym)
+        args-emit (map (fn [arg]
+                        (cond (vector? arg)
+                              (let [[t n] arg] n)
+                              :else arg))
+                       args)
+        body-emit (if (> (count body) 1)
+                    (cons 'do body)
+                    (first body))
+        sig (if ret-type
+              (let [arg-types (map (fn [arg]
+                                     (if (vector? arg)
+                                       (first arg)
+                                       (or (-> arg meta :tag) "Object")))
+                                   args)]
+                (str (ut/sym-default-str sym) " :: " (str/join " -> " (map str arg-types)) " -> " ret-type))
+              nil)]
+    (if sig
+        (list :lines (list :- sig) (list :- sym (list :h-args args-emit) "=" body-emit))
+        (list :- sym (list :h-args args-emit) "=" body-emit))))
+
+(defn tf-case
+  "transforms case"
+  {:added "4.0"}
+  [[_ val & clauses]]
+  (let [clauses (partition 2 clauses)
+        out (map (fn [[pattern result]]
+                   (list :% pattern (list :raw-str " -> ") (list :% result)))
+                 clauses)]
+    (list :%
+          (list :% (list :raw-str "case ") val (list :raw-str " of\n"))
+          (list :indent-body (apply list :lines out)))))
+
+(defn tf-if
+  "transforms if"
+  {:added "4.0"}
+  [[_ cond then else]]
+  (list :% (list :raw-str "if ") cond (list :raw-str " then ") then (list :raw-str " else ") else))
+
+(defn tf-let
+  "transforms let"
+  {:added "4.0"}
+  [[_ bindings body]]
+  (let [bindings (partition 2 bindings)
+        out (map (fn [[sym val]]
+                   (list :% sym (list :raw-str " = ") val))
+                 bindings)]
+    (list :%
+          (list :raw-str "let\n")
+          (list :indent-body (apply list :lines out))
+          (list :raw-str "\nin ") body)))
+
+(defn tf-lambda
+  "transforms fn/lambda"
+  {:added "4.0"}
+  [[_ args body]]
+  (list :% (list :raw-str "\\ ") (list :h-args args) (list :raw-str " -> ") body))
+
+(defn tf-do
+  "transforms do"
+  {:added "4.0"}
+  [[_ & body]]
+  (list :% (list :raw-str "do\n")
+        (list :indent-body (apply list :lines body))))
+
+(defn haskell-args
+  "custom haskell arguments emission (space separated)"
+  {:added "4.0"}
+  [[_ args] grammar mopts]
+  (let [args (cond (and (list? args) (= 'quote (first args)))
+                   (second args)
+
+                   (coll? args) args
+
+                   :else [args])]
+    (str/join " "
+              (map (fn [arg]
+                     (emit/emit-main arg grammar mopts))
+                   args))))
+
+(def +features+
+  (-> (grammar/build :exclude [:control-try-catch
+                               :class
+                               :macro-arrow
+                               :control-base
+                               :control-general])
+      (grammar/build:override
+       {:defn    {:macro #'tf-defn :emit :macro}
+        :fn      {:macro #'tf-lambda :emit :macro}
+        :if      {:op :if :symbol #{'if} :emit :macro :macro #'tf-if :type :macro}
+        :case    {:op :case :symbol #{'case} :emit :macro :macro #'tf-case :type :macro}})
+      (grammar/build:extend
+       {:let:h   {:op :let:h :symbol #{'let:h 'let} :emit :macro :macro #'tf-let :type :macro}
+        :do      {:op :do :symbol #{'do} :emit :macro :macro #'tf-do :type :macro}
+        :cons    {:op :cons :symbol #{'cons} :emit :infix :raw ":"}
+        :concat  {:op :concat :symbol #{'concat} :emit :infix :raw "++"}
+        :h-args  {:op :h-args :symbol #{:h-args} :emit #'haskell-args}
+        :raw-str {:op :raw-str :symbol #{:raw-str} :emit #'emit-raw-str}
+        :indent-body {:op :indent-body :symbol #{:indent-body} :emit #'emit-indent-body}
+        :%       {:op :% :symbol #{:%} :emit :squash}
+        :lines   {:op :lines :symbol #{:lines} :emit :free :sep "\n"}})))
+
+(def +sym-replace+
+  {\- "_"
+   \> ">"
+   \< "<"})
+
+(def +template+
+  (->> {:banned #{:set :map :regex}
+        :highlight '#{in module where qualified as data newtype instance deriving return}
+        :default {:comment   {:prefix "--"}
+                  :common    {:statement ""
+                              :namespace-full "."
+                              :namespace-sep  "."}
+                  :index     {:offset 0 :end-inclusive false}
+                  :block     {:parameter {:start " " :end " "}
+                              :body      {:start "" :end ""}}
+                  :function  {:raw ""
+                              :args {:sep " "}}
+                  :invoke    {:sep " " :start " " :end ""}}
+        :data    {:vector    {:start "[" :end "]" :space "" :custom #'haskell-vector}
+                  :tuple     {:start "(" :end ")" :space ""}}
+        :token   {:symbol    {:replace +sym-replace+}}
+        :block  {:list       {:start "[" :end "]" :space ""}}
+        :function {:defn      {:raw ""}
+                   :lambda    {:raw "\\" :args {:start "" :end " -> "}}}
+        :define   {:def       {:raw ""}}}
+       (h/merge-nested (emit/default-grammar))))
+
+(def +grammar+
+  (grammar/grammar :hs
+    (grammar/to-reserved +features+)
+    +template+))
+
+(def +meta+
+  (book/book-meta
+   {:module-current   (fn [])
+    :module-import    (fn [name {:keys [as qualified]} opts]
+                        (let [parts ["import"]
+                              parts (if qualified (conj parts "qualified") parts)
+                              parts (conj parts (str name))
+                              parts (if as (conj parts "as" (str as)) parts)]
+                          (h/$ (:- ~@parts))))
+    :module-export    (fn [{:keys [as refer]} opts])}))
+
+(def +book+
+  (book/book {:lang :haskell
+              :meta +meta+
+              :grammar +grammar+}))
+
+(def +init+
+  (script/install +book+))

--- a/src/bb/lang/model/spec_jq.clj
+++ b/src/bb/lang/model/spec_jq.clj
@@ -1,0 +1,220 @@
+(ns bb.lang.model.spec-jq
+  (:require [bb.lang.base.emit :as emit]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.grammar :as grammar]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.script :as script]
+            [bb.lib :as h]
+            [bb.string :as str]
+            [bb.lang.model.spec-xtalk]))
+
+;;
+;; JQ
+;;
+
+(defn jq-args
+  "custom args for jq"
+  {:added "4.0"}
+  [args grammar mopts]
+  (let [arg-strings (map #(common/*emit-fn* % grammar mopts) args)]
+    (if (empty? arg-strings)
+      ""
+      (str "(" (str/join "; " arg-strings) ")"))))
+
+(defn jq-invoke
+  "outputs an invocation (same as vector)"
+  {:added "4.0"}
+  [[f & args] grammar mopts]
+  (let [fstr (common/*emit-fn* f grammar mopts)]
+    (if (= fstr ".")
+      (if (seq args)
+        (let [k (first args)
+              kstr (common/*emit-fn* k grammar mopts)]
+           (if (or (keyword? k)
+                   (re-find #"^[a-zA-Z_][a-zA-Z0-9_]*$" kstr))
+             (str "." (if (keyword? k) (subs kstr 1) kstr))
+             (str ".[" kstr "]")))
+        ".")
+      (str fstr (jq-args args grammar mopts)))))
+
+(defn jq-args-ast
+  "ast for args"
+  {:added "4.0"}
+  [args]
+  (if (empty? args)
+    ""
+    (apply list :% (list 'k:lparen) (concat (interpose (list 'k:semi) args) [(list 'k:rparen)]))))
+
+(defn jq-defn
+  "transforms a function to allow for inputs"
+  {:added "4.0"}
+  [[_ sym args & body]]
+  (list :% (list 'k:def) (list 'k:space) sym (jq-args-ast args) (list 'k:colon) (list 'k:space) (apply list 'do body) (list 'k:semi)))
+
+(defn jq-as
+  "jq variable binding"
+  {:added "4.0"}
+  [[_ sym]]
+  (list :% (list 'k:as) (list 'k:space) (list :$ sym)))
+
+(defn jq-label
+  "jq label"
+  {:added "4.0"}
+  [[_ sym]]
+  (list :% (list 'k:label) (list 'k:space) (list :$ sym)))
+
+(defn jq-break
+  "jq break"
+  {:added "4.0"}
+  [[_ sym]]
+  (if sym
+    (list :% (list 'k:break) (list 'k:space) (list :$ sym))
+    (list 'k:break)))
+
+(defn jq-dot
+  "jq dot access"
+  {:added "4.0"}
+  ([[_ & [k]] _ _]
+   (cond (nil? k)
+         (list 'identity)
+
+         (symbol? k)
+         (symbol (str "." (name k)))
+
+         (keyword? k)
+         (symbol (str "." (name k)))
+
+         :else
+         (list :% "." "[" k "]"))))
+
+(defn jq-try
+  "jq try/catch"
+  {:added "4.0"}
+  [[_ body handler]]
+  (list :% (list 'k:try) (list 'k:space) body (list 'k:space) (list 'k:catch) (list 'k:space) handler))
+
+(defn jq-if
+  "jq if/then/else"
+  {:added "4.0"}
+  [[_ test then else]]
+  (list :% (list 'k:if) (list 'k:space) test (list 'k:space) (list 'k:then) (list 'k:space) then (list 'k:space) (list 'k:else) (list 'k:space) else (list 'k:space) (list 'k:end)))
+
+(defn jq-reduce
+  "jq reduce"
+  {:added "4.0"}
+  [[_ inputs as init update]]
+  (list :% (list 'k:reduce) (list 'k:space) inputs (list 'k:space) (list 'k:as) (list 'k:space) (list :$ as) (list 'k:space)
+        (list :% (list 'k:lparen) (list '% init) (list 'k:semi) (list 'k:space) (list '% update) (list 'k:rparen))))
+
+(defn jq-foreach
+  "jq foreach"
+  {:added "4.0"}
+  [[_ inputs as init update & [extract]]]
+  (if extract
+    (list :% (list 'k:foreach) (list 'k:space) inputs (list 'k:space) (list 'k:as) (list 'k:space) (list :$ as) (list 'k:space)
+          (list :% (list 'k:lparen) (list '% init) (list 'k:semi) (list 'k:space) (list '% update) (list 'k:semi) (list 'k:space) (list '% extract) (list 'k:rparen)))
+    (list :% (list 'k:foreach) (list 'k:space) inputs (list 'k:space) (list 'k:as) (list 'k:space) (list :$ as) (list 'k:space)
+          (list :% (list 'k:lparen) (list '% init) (list 'k:semi) (list 'k:space) (list '% update) (list 'k:rparen)))))
+
+(def +features+
+  (-> (grammar/build :include [:builtin
+                               :builtin-helper
+                               :free-control
+                               :free-literal
+                               :math
+                               :compare
+                               :logic
+                               :return
+                               :vars
+                               :fn
+                               :control-base
+                               :control-general
+                               :top-base
+                               :block])
+      (grammar/build:override
+       {:defn      {:macro #'jq-defn :emit :macro}
+        :def       {:macro #'jq-defn :emit :macro}
+        :quote     {:emit :json}
+        :break     {:op :break     :symbol #{'break} :macro #'jq-break :emit :macro}
+        :index     {:symbol #{}}})
+      (grammar/build:extend
+       {:pipe      {:op :pipe      :symbol '#{>> |}   :raw "|"  :emit :infix}
+        :comma     {:op :comma     :symbol '#{,,}   :raw ","  :emit :infix}
+        :assign    {:op :assign    :symbol '#{:=}   :raw "="  :emit :infix}
+        :update    {:op :update    :symbol '#{|=}   :raw "|=" :emit :infix}
+        :plus-up   {:op :plus-up   :symbol '#{+=}   :raw "+=" :emit :infix}
+        :sub-up    {:op :sub-up    :symbol '#{-=}   :raw "-=" :emit :infix}
+        :mul-up    {:op :mul-up    :symbol '#{*=}   :raw "*=" :emit :infix}
+        :div-up    {:op :div-up    :symbol '#{div=}   :raw "/=" :emit :infix}
+        :mod-up    {:op :mod-up    :symbol '#{%=}   :raw "%=" :emit :infix}
+        :alt       {:op :alt       :symbol '#{alt}   :raw "//" :emit :infix}
+        :try-opt   {:op :try-opt   :symbol '#{?}    :raw "?"  :emit :post}
+        :rec       {:op :rec       :symbol '#{..}   :raw ".." :emit :token}
+        :dot       {:op :dot       :symbol #{'get}  :macro #'jq-dot :emit :macro}
+        :as        {:op :as        :symbol #{'as}   :macro #'jq-as :emit :macro}
+        :label     {:op :label     :symbol #{'label} :macro #'jq-label :emit :macro}
+        :try       {:op :try       :symbol #{'try}  :macro #'jq-try :emit :macro}
+        :if        {:op :if        :symbol #{'if}   :macro #'jq-if :emit :macro}
+        :reduce    {:op :reduce    :symbol #{'reduce} :macro #'jq-reduce :emit :macro}
+        :foreach   {:op :foreach   :symbol #{'foreach} :macro #'jq-foreach :emit :macro}
+        :identity  {:op :identity  :symbol #{'identity '.} :raw "." :emit :token :value true}
+
+        :k:space   {:op :k:space   :symbol #{'k:space} :raw " " :emit :token :value true}
+        :k:def     {:op :k:def     :symbol #{'k:def} :raw "def" :emit :token :value true}
+        :k:as      {:op :k:as      :symbol #{'k:as} :raw "as" :emit :token :value true}
+        :k:label   {:op :k:label   :symbol #{'k:label} :raw "label" :emit :token :value true}
+        :k:break   {:op :k:break   :symbol #{'k:break} :raw "break" :emit :token :value true}
+        :k:try     {:op :k:try     :symbol #{'k:try} :raw "try" :emit :token :value true}
+        :k:catch   {:op :k:catch   :symbol #{'k:catch} :raw "catch" :emit :token :value true}
+        :k:if      {:op :k:if      :symbol #{'k:if} :raw "if" :emit :token :value true}
+        :k:then    {:op :k:then    :symbol #{'k:then} :raw "then" :emit :token :value true}
+        :k:else    {:op :k:else    :symbol #{'k:else} :raw "else" :emit :token :value true}
+        :k:end     {:op :k:end     :symbol #{'k:end} :raw "end" :emit :token :value true}
+        :k:reduce  {:op :k:reduce  :symbol #{'k:reduce} :raw "reduce" :emit :token :value true}
+        :k:foreach {:op :k:foreach :symbol #{'k:foreach} :raw "foreach" :emit :token :value true}
+        :k:lparen  {:op :k:lparen  :symbol #{'k:lparen} :raw "(" :emit :token :value true}
+        :k:rparen  {:op :k:rparen  :symbol #{'k:rparen} :raw ")" :emit :token :value true}
+        :k:colon   {:op :k:colon   :symbol #{'k:colon} :raw ":" :emit :token :value true}
+        :k:semi    {:op :k:semi    :symbol #{'k:semi} :raw ";" :emit :token :value true}
+        :var-ref   {:op :var-ref   :symbol #{:$}       :raw "$" :emit :pre}})))
+
+(def +template+
+  (->> {:banned #{:regex :set}
+        :highlight '#{def if then else end reduce foreach as try catch label break}
+        :default {:common    {:statement ""
+                              :start  "" :end ""
+                              :sep ""
+                              :namespace-full "_"
+                              :space " "}
+                  :invoke    {:custom #'jq-invoke}
+                  :define    {:space " "}
+                  :symbol    {:full {:replace {\. "_"
+                                               \- "_"}
+                                     :sep "_"}
+                              :global identity}
+                  :block     {:statement ""
+                              :parameter {:start "(" :end ")"}
+                              :body      {:start ":" :end ";"}}}
+        :token   {:nil       {:as "null"}
+                  :string    {:quote :double}}
+        :data    {:map       {:start "{" :end "}" :sep "," :assign ":"}
+                  :vector    {:start "[" :end "]" :sep ","}
+                  :free      {:start "(" :end ")" :sep "; "}}
+        :block   {:function  {:defn      {:raw "def" :sep "; "}}}}
+       (h/merge-nested (update-in (emit/default-grammar)
+                                  [:token :symbol]
+                                  dissoc :replace))))
+
+(def +grammar+
+  (grammar/grammar :jq
+    (grammar/to-reserved +features+)
+    +template+))
+
+(def +book+
+  (book/book {:lang :jq
+              :parent :xtalk
+              :meta (book/book-meta {})
+              :grammar +grammar+}))
+
+(def +init+
+  (script/install +book+))

--- a/src/bb/lang/model/spec_js.clj
+++ b/src/bb/lang/model/spec_js.clj
@@ -1,0 +1,303 @@
+(ns bb.lang.model.spec-js
+  (:require [bb.lang.model.spec-js.meta :as meta]
+            [bb.lang.model.spec-js.jsx :as jsx]
+            [bb.lang.model.spec-js.qml :as qml]
+            [bb.lang.base.emit :as emit]
+            [bb.lang.base.emit-data :as data]
+            [bb.lang.base.emit-top-level :as top]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.emit-helper :as helper]
+            [bb.lang.base.emit-preprocess :as preprocess]
+            [bb.lang.base.grammar :as grammar]
+            [bb.lang.base.grammar-spec :as spec]
+            [bb.lang.base.util :as ut]
+	    [bb.lang.base.book :as book]
+            [bb.lang.base.script :as script]
+            [bb.lang.model.spec-xtalk]
+            [bb.lang.model.spec-xtalk.fn-js :as fn]
+            [std.html :as html]
+            [bb.string :as str]
+            [bb.lib :as h]))
+
+(def ^:dynamic *template-fn* #'jsx/emit-jsx)
+
+(defn emit-html
+  "emits html"
+  {:added "4.0"}
+  ([arr _ mopts]
+   (data/emit-maybe-multibody ["\n" ""] (html/html arr))))
+
+(defn js-regex
+  "outputs the js regex"
+  {:added "4.0"}
+  ([^java.util.regex.Pattern re]
+   (str "/" (.pattern re) "/")))
+
+(defn js-map-key
+  "emits a map key"
+  {:added "4.0"}
+  ([key grammar mopts]
+   (cond (or (keyword? key)
+             (string? key))
+         (data/default-map-key key grammar mopts)
+
+         :else
+         (str "[" (common/*emit-fn* key grammar mopts) "]"))))
+
+(defn js-vector
+  "emits a js vector"
+  {:added "4.0"}
+  ([arr grammar mopts]
+   (let [o (first arr)]
+     (cond (empty? arr) "[]"
+
+           (keyword? o)
+           (*template-fn* arr grammar mopts)
+
+           :else
+           (data/emit-coll :vector arr grammar mopts)))))
+
+(defn js-map
+  [m grammar mopts]
+  (let [rest (get m ':..)
+        syms (get m ':#)
+        out-syms  (map #(common/*emit-fn* % grammar mopts)
+                       syms)
+        out-keys  (map (fn [pair]
+                         (data/emit-map-entry pair grammar mopts))
+                       (dissoc m :# :..))
+        out-rest  (if rest
+                    (map #(str "..."
+                               (common/*emit-fn* %
+                                                 grammar
+                                                 mopts))
+                         (if (vector?  rest)
+                           rest
+                           [rest])))]
+    (data/emit-coll-layout :map common/*indent*
+                           (concat out-syms out-keys out-rest)
+                           grammar mopts)))
+
+(defn js-set
+  "emits a js set"
+  {:added "4.0"}
+  ([arr grammar mopts]
+   (cond (vector? (first arr))
+         (common/*emit-fn* (apply list 'tab (first arr))
+                           grammar
+                           mopts)
+
+         :else
+         (h/->> arr
+                (sort-by (fn [e]
+                           (if (map? e)
+                             [1 (h/strn e)]
+                             [0 (h/strn e)])))
+                (map (fn [e]
+                       (cond (map? e)
+                             (->> e
+                                  (map (fn [pair]
+                                         (data/emit-map-entry pair grammar mopts)))
+                                  (str/join ","))
+
+                             (or (symbol? e)
+                                 (string? e)
+                                 (and (h/form? e)
+                                      (#{:..} (first e))))
+                             (common/*emit-fn* e grammar mopts)
+
+                             :else
+                             (h/error "Not allowed" {:entry e}))))
+                (str/join ",")
+                (str "{" % "}")))))
+
+(defn- js-symbol-global
+  [fsym grammar mopts]
+  (list '. 'globalThis [(helper/emit-symbol-full
+                         fsym
+                         (namespace fsym)
+                         grammar)]))
+
+(defn js-defclass
+  "creates a defclass function"
+  {:added "4.0"}
+  ([[_ sym inherit & body]]
+   (let [{:keys [module] :as mopts}  (preprocess/macro-opts)
+         body      (top/transform-defclass-inner body)
+         sym-name  (symbol (if module (name (:id module)))
+                           (name sym))
+         supers (list 'quote (vec (remove keyword? inherit)))]
+     `(:- :class ~sym-name :extends ~supers \{
+          (\\
+           \\ (\| (do ~@body))
+           \\)
+          \}))))
+
+(defn tf-var-let
+  "outputs the let keyword"
+  {:added "4.0"}
+  [[_ decl & args]]
+  (list 'var* :let decl := (last args)))
+
+(defn tf-var-const
+  "outputs the const keyword"
+  {:added "4.0"}
+  [[_ decl & args]]
+  (list 'var* :const decl := (last args)))
+
+(defn tf-for-object
+  "custom for:object code
+
+   (tf-for-object '(for:object [[k v] {:a 1}]
+                               [k v]))
+   => '(for [(var* :let [k v]) :of (Object.entries {:a 1})] [k v])"
+  {:added "4.0"}
+  [[_ [[k v] m] & body]]
+  (let [[binding method] (cond (= k '_) [v  'Object.values]
+                               (= v '_) [k  'Object.keys]
+                               :else [[k v] 'Object.entries])]
+    (apply list 'for [(list 'var* :let binding) :of (list method m)]
+           body)))
+
+(defn tf-for-array
+  "custom for:array code
+
+   (tf-for-array '(for:array [e [1 2 3 4 5]]
+                              [k v]))
+   => '(for [(var* :let e) :of (% [1 2 3 4 5])] [k v])
+
+   (tf-for-array '(for:array [[i e] arr]
+                             [k v]))
+   => '(for [(var* :let i := 0) (< i (. arr length))
+             (:++ i)] (var* :let e (. arr [i])) [k v])"
+  {:added "4.0"}
+  [[_ [e arr] & body]]
+  (if (vector? e)
+    (let [[i v] e]
+      (h/$ (for [(var* :let ~i := 0) (< ~i (. ~arr length)) (:++ ~i)]
+             (var* :let ~v (. ~arr [~i]))
+             ~@body)))
+    (h/$ (for [(var* :let ~e) :of (% ~arr)]
+           ~@body))))
+
+(defn tf-for-iter
+  "custom for:iter code
+
+   (tf-for-iter '(for:iter [e iter]
+                           e))
+   => '(for [(var* :let e) :of (% iter)] e)"
+  {:added "4.0"}
+  [[_ [e it] & body]]
+  (apply list 'for [(list 'var* :let e) :of (list '% it)]
+         body))
+
+(defn tf-for-return
+  "for return transform"
+  {:added "4.0"}
+  [[_ [[res err] statement] {:keys [success error final]}]]
+  (let [cb (list 'fn [err res]
+                 (list 'if err
+                       error
+                       success))
+        out (h/prewalk (fn [x]
+                         (if (= x '(x:callback))
+                           cb
+                           x))
+                       statement)]
+    (cond->> out
+      final (list 'return))))
+
+(defn tf-for-try
+  "for try transform"
+  {:added "4.0"}
+  [[_ [[res err] statement] {:keys [success error]}]]
+  (h/$ (try
+         (var ~res := ~statement)
+         ~success
+         (catch ~err ~error))))
+
+(defn tf-for-async
+  "for async transform"
+  {:added "4.0"}
+  [[_ [[res err] statement] {:keys [success error finally]}]]
+  (h/$ (. (new Promise (fn [resolve reject]
+                         (resolve ~statement)))
+          ~@(if success
+              [(list 'then
+                     (list 'fn [res]
+                           success))])
+          ~@(if error
+              [(list 'catch
+                     (list 'fn [err]
+                           error))])
+          ~@(if finally
+              [(list 'finally
+                     (list 'fn '[]
+                           finally))]))))
+
+(def +features+
+  (-> (grammar/build :exclude [:pointer
+                               :block
+                               :data-range])
+      (grammar/build:override
+       {:var        {:symbol '#{var*}}
+        :mul        {:value true}
+        :defn       {:symbol '#{defn defn- defelem}}
+        :with-global {:value true :raw "globalThis"}
+        :defclass   {:macro  #'js-defclass    :emit :macro}
+        :for-object {:macro  #'tf-for-object  :emit :macro}
+        :for-array  {:macro  #'tf-for-array   :emit :macro}
+        :for-iter   {:macro  #'tf-for-iter    :emit :macro}
+        :for-return {:macro  #'tf-for-return  :emit :macro}
+        :for-try    {:macro  #'tf-for-try     :emit :macro}
+        :for-async  {:macro  #'tf-for-async :emit :macro}})
+      (grammar/build:override fn/+js+)
+      (grammar/build:extend
+       {:property   {:op :property  :symbol  '#{property}   :assign ":" :raw "property" :value true :emit :def-assign}
+        :teq        {:op :teq       :symbol  '#{===}        :raw "===" :emit :bi}
+        :tneq       {:op :tneq      :symbol  '#{not==}      :raw "!==" :emit :bi}
+        :delete     {:op :delete    :symbol  '#{del}        :raw "delete" :value true :emit :prefix}
+        :typeof     {:op :typeof    :symbol  '#{typeof}     :raw "typeof" :emit :prefix}
+        :instanceof {:op :instof    :symbol  '#{instanceof} :raw "instanceof" :emit :bi}
+        :undef      {:op :undef     :symbol  '#{undefined}  :raw "undefined" :value true :emit :throw}
+        :nan        {:op :nan       :symbol  '#{NaN} :raw "NaN" :value true :emit :throw}
+        :vargs      {:op :vargs     :symbol  '#{...} :raw "...vargs" :value true :emit :throw}
+        :var-let    {:op :var-let   :symbol  '#{var}     :macro  #'tf-var-let :type :macro}
+        :var-const  {:op :var-const :symbol  '#{const}   :macro  #'tf-var-const :type :macro}})))
+
+(def +template+
+  (->> {:banned #{:keyword}
+        :allow   {:assign  #{:symbol :vector :set :map}}
+        :highlight '#{return break del tab reject}
+        :default  {:common    {:namespace-full "$$"}
+                   :function  {:raw "function" :space ""}}
+        :token    {:nil       {:as "null"}
+                   :regex     {:custom #'js-regex}
+                   :string    {}
+                   :symbol    {:global #'js-symbol-global}}
+        :block    {:for       {:parameter {:sep ";"}}}
+        :data     {:vector    {:custom #'js-vector}
+                   :set       {:custom #'js-set}
+                   :map       {:custom #'js-map}
+                   :map-entry {:key-fn #'js-map-key}}
+        :function {:defgen    {:raw "function*"}
+                   :fn.inner  {:raw ""}}
+        :define   {:defglobal {:raw ""}
+                   :def       {:raw "var"}
+                   :declare   {:raw "var"}}
+        :xtalk    {:notify    {:custom true}}}
+       (h/merge-nested (emit/default-grammar))))
+
+(def +grammar+
+  (grammar/grammar :js
+    (grammar/to-reserved +features+)
+    +template+))
+
+(def +book+
+  (book/book {:lang :js
+              :parent :xtalk
+              :meta meta/+meta+
+              :grammar +grammar+}))
+
+(def +init+
+  (script/install +book+))

--- a/src/bb/lang/model/spec_js/html.clj
+++ b/src/bb/lang/model/spec_js/html.clj
@@ -1,0 +1,64 @@
+(ns bb.lang.model.spec-js.html
+  (:require [bb.lang.base.emit :as emit]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.util :as ut]
+            [std.html :as html]
+            [bb.string :as str]
+            [bb.lib :as h]))
+
+(defn wrap-indent-inner
+  "increase indentation in walk inner"
+  {:added "4.0"}
+  ([f]
+   (fn [form]
+     (if (and (vector? form)
+              (keyword? (first form)))
+       (binding [common/*indent* (+ common/*indent* 2)]
+         (f form))
+       (f form)))))
+
+(defn wrap-indent-outer
+  "decrese indentation in walk outer"
+  {:added "4.0"}
+  ([f]
+   (fn [form]
+     (if (and (vector? form)
+              (keyword? (first form)))
+       (binding [common/*indent* (- common/*indent* 2)]
+         (f form))
+       (f form)))))
+
+(defn prewalk-indent
+  "preserves indentations"
+  {:added "4.0"}
+  ([f form]
+   (h/walk (wrap-indent-inner (partial prewalk-indent f))
+           (wrap-indent-outer identity) (f form))))
+
+(defn prepare-html
+  "prepares the html, embedding any new scripts"
+  {:added "4.0"}
+  ([tree nsp]
+   tree
+   #_(prewalk-indent
+    (fn [form]
+      (if (and (vector? form)
+               (symbol? (first form))
+               (str/starts-with? (first form) "%"))
+        (let [ptr @(resolve (second form))
+              {:keys [module id lang]} ptr]
+          (str (common/with-indent [2]
+                 (str (common/newline-indent)
+                      (common/emit-main (:form (lib/lib:get-entry lang (ut/sym-full module id)))
+                                        (lib/lib:get-grammar lang)
+                                        nsp)))
+               (common/newline-indent)))
+        form))
+    tree)))
+
+(defn emit-html
+  "emits the html"
+  {:added "4.0"}
+  ([arr _ nsp]
+   (let [tree (prepare-html arr nsp)]
+     (html/html tree))))

--- a/src/bb/lang/model/spec_js/jsx.clj
+++ b/src/bb/lang/model/spec_js/jsx.clj
@@ -1,0 +1,348 @@
+(ns bb.lang.model.spec-js.jsx
+  (:require [bb.lang.base.emit :as emit]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.emit-data :as data]
+            [bb.lib :as h]
+            [bb.string :as str]))
+
+(declare emit-jsx)
+(declare emit-jsx-set-params)
+
+(defn jsx-key-fn
+  "converts jsx key"
+  {:added "4.0"}
+  ([k]
+   (if (keyword? k)
+     (keyword (str/camel-case (name k)))
+     k)))
+
+(defn jsx-arr-prep
+  "prepares jsx array
+
+   (jsx-arr-prep [:div {:className 'a}
+                  [:p '(hello 1 2 3)]]
+                 js/+grammar+
+                 {})
+   => '[:div {:className a} [:p (hello 1 2 3)]]"
+  {:added "4.0"}
+  ([arr grammar mopts]
+   (cond (= :% (first arr))
+         (if (second arr)
+           (let [tag (keyword (emit/emit-main (second arr)
+                                              grammar
+                                              mopts))]
+             (cons tag (drop 2 arr)))
+           (h/error "MISSING TAG"))
+
+         (= :<> (first arr))
+         (cons :React.Fragment (rest arr))
+
+         :else
+         arr)))
+
+(defn jsx-standardise-params
+  [params]
+  (let [{:keys [class className]} params
+        className (or class
+                      className)
+        value  (if (vector? className)
+                 (str/join " " (map h/strn className))
+                 className)
+        params (if value
+                 (assoc params :className value)
+                 params)]
+    (dissoc params :class)))
+
+(defn jsx-arr-norm
+  "normalises the jsx array
+
+   (jsx-arr-norm [:div])
+   => [:div {} nil]"
+  {:added "4.0"}
+  ([arr]
+   (let [[tag & children] arr
+         params? (first children)
+         [tag params children] (cond (map? params?)
+                                     (let [params (->>  params?
+                                                        (h/map-keys jsx-key-fn)
+                                                        (jsx-standardise-params))]
+                                       [tag params (rest children)])
+
+                                     (set? params?)
+                                     [tag params? (rest children)]
+
+                                     :else
+                                     [tag {} children])]
+     [tag params children])))
+
+(defn emit-jsx-map-params
+  "emits jsx map params
+
+   (emit-jsx-map-params '{:a (+ 1 2 3) :b \"abc\"}
+                        js/+grammar+
+                        {})
+   => '(\"a={1 + 2 + 3}\" \"b=\\\"abc\\\"\")"
+  {:added "4.0"}
+  ([params grammar mopts]
+   (binding [common/*indent* (+ common/*indent* 2)]
+     (cond-> (mapv (fn [[k v]]
+                     (let [vstr (cond (string? v)
+                                      (emit/emit-main v grammar mopts)
+
+                                      :else
+                                      (let [body (emit/emit-main v grammar mopts)
+                                            body (if (str/multi-line? body)
+                                                   (str/indent-rest body 2)
+                                                   body)]
+                                        (str "{" body "}")))]
+                       (str (name k) "=" vstr)))
+                   (dissoc params :.. :#))
+       (:# params) (into (flatten (emit-jsx-set-params #{(:# params)} grammar mopts)))
+
+       (:.. params) (conj (str "{..." (emit/emit-main (if (vector?  (:.. params))
+                                                        (first (:.. params))
+                                                        (:.. params))
+                                                      grammar
+                                                      mopts)
+                               "}"))))))
+
+(defn emit-jsx-set-params
+  "emits jsx set params
+
+   (emit-jsx-set-params '#{a b c}
+                        js/+grammar+
+                        {})
+   => '((\"a={a}\" \"c={c}\" \"b={b}\"))
+
+   (emit-jsx-set-params '#{[a b (:.. c)]}
+                        js/+grammar+
+                        {})
+   => '((\"a={a}\" \"b={b}\") \"{...c}\")"
+  {:added "4.0"}
+  ([params grammar mopts]
+   (let [emit-fn (fn [svar mvar fvar]
+                   (let [mvar (merge mvar (zipmap svar svar))
+                         mstr (if (not-empty mvar)
+                                (emit-jsx-map-params mvar grammar mopts))
+                         fstr (if (not-empty fvar)
+                                (emit/emit-main (set fvar) grammar mopts))]
+                     (filter identity [mstr fstr])))
+         is-sym (fn [x]
+                  (and (symbol? x)
+                       (not (str/starts-with? (name x)
+                                              "..."))))]
+     (cond (and (= 1 (count params))
+                (vector? (first params)))
+           (let [groups (data/emit-table-group (first params))
+                 groups (map (fn [x]
+                               (if (and (seq? x) (= := (first x)))
+                                 [(second x) (nth x 2)]
+                                 x))
+                             groups)
+                 svar   (filter is-sym groups)
+                 mvar   (->> (filter vector? groups)
+                             (into {})
+                             (jsx-standardise-params))
+                 fvar   (remove (fn [x]
+                                  (or (vector? x)
+                                      (is-sym x)))
+                                groups)]
+             (emit-fn svar mvar fvar))
+
+           :else
+           (let [svar (filter is-sym params)
+                 mvar (apply merge (filter map? params))
+                 fvar (remove (fn [x]
+                                (or (map? x)
+                                    (is-sym x)))
+                              params)]
+             (emit-fn svar mvar fvar))))))
+
+(defn emit-jsx-params
+  "emits jsx params
+
+   (emit-jsx-params {:a 1 :b 2}
+                    js/+grammar+
+                    {})
+   => [\" \" \"a={1} b={2}\"]
+
+   (emit-jsx-params '#{[a b (:.. c)]}
+                    js/+grammar+
+                    {})
+   => [\" \" \"a={a} b={b} {...c}\"]"
+  {:added "4.0"}
+  ([params grammar mopts]
+   (let [body-arr (cond (empty? params) []
+
+                        (set? params)
+                        (flatten (emit-jsx-set-params params grammar mopts))
+
+                        (map? params)
+                        (emit-jsx-map-params params grammar mopts)
+
+                        :else (h/error "Not valid input." {:input params}))]
+     (cond (empty? body-arr)
+           ["" ""]
+
+           (data/emit-singleline-array? body-arr)
+           [" "  (str/join " " body-arr)]
+
+           :else
+           (let [spc (str (common/newline-indent) "  ")]
+             [spc (str/join spc body-arr)])))))
+
+(defn emit-jsx-inner
+  "emits the inner blocks for a jsx form"
+  {:added "4.0"}
+  ([arr grammar mopts]
+   (let [[tag params children] (-> arr
+                                   (jsx-arr-prep grammar mopts)
+                                   (jsx-arr-norm))
+
+         ntag   (name tag)
+         ntag   (cond-> ntag
+                  (.startsWith ntag "<") (subs 1)
+                  (.endsWith ntag ">") (h/lsubs 1))
+
+         [prefix params] (emit-jsx-params params grammar mopts)]
+     (if (empty? children)
+       (str "<" ntag prefix params "/>")
+       (let [end    (str  "</" ntag ">")
+             start  (str  "<" ntag prefix params
+                          ">")
+             indent   common/*indent*
+             body-arr (binding [common/*indent* 0]
+                        (->> children
+                             (mapv (fn [form]
+                                     (cond (and (vector? form)
+                                                (keyword? (first form)))
+                                           (emit-jsx-inner form grammar mopts)
+
+                                           :else (str "{" (emit/emit-main form grammar mopts) "}"))))))
+             single?  (data/emit-singleline-array? body-arr)
+             body     (if single?
+                        (str/join "" body-arr)
+                        (str/indent  (str/join "\n" body-arr) (+ 2 indent)))]
+         (str start
+              (if single? "" "\n")
+              body
+              (if (or (not single?)
+                      (str/multi-line? start))
+                (common/newline-indent))
+              end))))))
+
+(defn emit-jsx-raw
+  "emits the jsx transform
+
+   (emit-jsx-raw [:div {:className 'a}
+                  [:p '(hello 1 2 3)]]
+                 js/+grammar+
+                 {})
+   => \"(\\n  <div className={a}><p>{hello(1,2,3)}</p></div>)\""
+  {:added "4.0"}
+  ([arr grammar mopts]
+   (binding [common/*indent* (+ common/*indent* 2)]
+     (str "("
+          (common/newline-indent)
+          (emit-jsx-inner arr grammar mopts) ")"))))
+
+(defn emit-jsx
+  "can perform addition transformation if [:grammar :jsx] is false
+
+   (emit-jsx [:div {:className 'a}
+              [:p '(hello 1 2 3)]]
+             js/+grammar+
+             {:emit {:lang/jsx false}})
+   => (bb.string/|
+       \"React.createElement(\"
+       \"  \\\"div\\\",\"
+       \"  {\\\"className\\\":a},\"
+      \"  React.createElement(\\\"p\\\",{},hello(1,2,3))\"
+       \")\")"
+  {:added "4.0"}
+  ([arr grammar mopts]
+   (if (= false (-> mopts :emit :lang/jsx))
+     (let [child-fn (fn [children]
+                      (cond (or (empty? children)
+                                (map? (first children))
+                                (set? (first children)))
+                            children
+
+                            :else (cons {} children)))
+           tf-fn (fn tf-fn
+                   [form]
+                   (let [tag (first form)]
+                     (cond (= :<> tag)
+                           (tf-fn (cons 'React.Fragment (rest form)))
+
+                           (= :% tag)
+                           (apply list 'React.createElement (second form)
+                                  (child-fn (drop 2 form)))
+
+                           (re-find #"^[a-z]" (name tag))
+                           (apply list 'React.createElement (name tag)
+                                  (child-fn (rest form)))
+
+                           :else
+                           (apply list 'React.createElement (symbol (name tag))
+                                  (child-fn (rest form))))))
+           arr (->> arr
+                    (clojure.walk/prewalk
+                     (fn walk-fn [form]
+                       (try
+                         (cond (and (vector? form)
+                                    (keyword? (first form)))
+                               (tf-fn form)
+
+                               (and (set? form)
+                                    (vector? (first form)))
+                               (volatile! form)
+
+                               (map? form)
+                               (->> form
+                                    (jsx-standardise-params)
+                                    (h/map-keys (fn [k]
+                                                  (h/strn (jsx-key-fn k)))))
+
+                               :else
+                               form)
+                         (catch Throwable t
+                           (h/pl form)))))
+                    (clojure.walk/prewalk
+                     (fn [form]
+                       (if (volatile? form)
+                         @form
+                         form))))]
+       (emit/emit-main arr grammar mopts))
+     (emit-jsx-raw arr grammar mopts))))
+
+
+(comment
+  (./create-tests)
+
+  (emit/emit-main (:form (bb.lang/ptr-entry js.ext.react/createStoreProvider))
+                  (bb.lang/grammar:js))
+
+  (emit-jsx [:h1 "hello"]
+            (bb.lang/grammar:js)
+            {:grammar {:jsx false}})
+
+
+  (emit-jsx
+   '[:div
+     (js/write [(S.group {"test/FooHello" {:a 10 :b 20}})])]
+   (bb.lang/grammar:js)
+   {:grammar {:jsx false}})
+
+
+  (emit-jsx
+   '[:div
+     [:h1 (+ "HELLO " val)]
+     [:button {test (fn []
+                      (setVal (Math.random {rt.javafx.test/BarHello 1})))}]]
+   (bb.lang/grammar:js)
+   {:grammar {:jsx false}})
+
+  (emit/emit-main '(React.createElement "h1" {} "hello")
+                  (bb.lang/grammar:js)
+                  {:grammar {:jsx false}}))

--- a/src/bb/lang/model/spec_js/meta.clj
+++ b/src/bb/lang/model/spec_js/meta.clj
@@ -1,0 +1,152 @@
+(ns bb.lang.model.spec-js.meta
+  (:require [bb.string :as str]
+            [bb.lib :as h]
+            [std.fs :as fs]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.book-module :as module]
+            [bb.lang.base.util :as ut]))
+
+;;
+;; MODULE
+;;
+
+(defn js-module-import-async
+  [name link]
+  (let [{:keys [ns as refer]} link]
+    (list 'const as
+          (list 'new
+                'Proxy
+                (list 'import name)
+                '{:get (fn [esm key]
+                         (return (. esm
+                                    (then (fn [m]
+                                            (return {"__esMODULE" true
+                                                     :default (. m default [key])}))))))}))))
+
+(defn js-module-import
+  "outputs the js module import from"
+  {:added "4.0"}
+  ([name link mopts]
+   (let [{:keys [emit]} mopts
+         async-ns (set (-> emit :static :import/async))
+         {:keys [ns as refer]} link
+         {:lang/keys [format]} emit]
+     (case format
+       :none nil
+       (:global)   (let [sym (if (vector? as)
+                               (last as)
+                               as)]
+                     (list 'Object.defineProperty '!:G (str sym)
+                           {:value (list 'require (str name))}))
+       (:commonjs) (let [sym (if (vector? as)
+                               (last as)
+                               as)]
+                     (list 'const sym := (list 'require (str name))))
+       (let [as (if (= :link (:import emit))
+                  ['* as]
+                  as)
+             imports (cond-> []
+                       as    (conj (if (vector? as)
+                                     (list :- (first as)
+                                           :as (last as))
+                                     as))
+                       refer (conj (set refer)))]
+         (cond (async-ns ns)
+               (js-module-import-async name link)
+
+               :else
+               (if (empty? imports)
+                 (list :- :import (str "'" name "'"))
+                 (list :- :import
+                       (list 'quote imports)
+                       :from (str "'" name "'")))))))))
+
+(defn js-module-export
+  "outputs the js module export form"
+  {:added "4.0"}
+  ([module mopts]
+   (let [{:keys [emit]} mopts
+         {:lang/keys [format
+                      export]} emit
+         static-export (-> module :static :export)
+         table  (if static-export
+                  (->> static-export
+                       (map (fn [sym]
+                              [(list :% (name sym)) sym]))
+                       (cons 'tab))
+                  (->> (module/module-entries module
+                                              #{:defn
+                                                :def
+                                                :defclass})
+                       (cons 'tab)))]
+     (case format
+       (:none
+        :global)  nil
+       :commonjs  (list := 'module.exports table)
+       (if static-export
+         (if (and (vector? static-export)
+                  (= 1 (count static-export)))
+           (list :- :export :default (first static-export))
+           (list :- :export :default table)))))))
+
+(defn js-module-link
+  "gets the relative js based module"
+  {:added "4.0"}
+  ([ns graph]
+   (let [parent-rel (fn [path]
+                      (let [idx (.lastIndexOf (str path) ".")
+                            idx (if (neg? idx)
+                                  (count path)
+                                  idx)]
+                        (subs (str path) 0 idx)))
+         {:keys [base root-ns]} graph
+         root-rel     (parent-rel (str root-ns))
+         is-ext       (not (str/starts-with? (name ns) root-rel))
+         is-ext-base  (not (str/starts-with? (name base) root-rel))
+         base-path    (-> (str/replace (name base) #"\." "/")
+                          (fs/parent))
+         interim (cond (or (not is-ext)
+                           is-ext-base)
+                       (let [ns-path   (str/replace (name ns) #"\." "/")]
+                         (str (fs/relativize base-path ns-path)))
+
+                       :else
+                       (let [ns-path   (str/replace (name root-ns) #"\." "/")
+                             ns-path   (subs ns-path 0 (.lastIndexOf ns-path "/"))
+                             interim   (str (fs/relativize base-path ns-path))]
+                         (str interim "/" (str/replace (name ns) #"\." "/"))))]
+     (cond (str/starts-with? interim ".")
+           interim
+
+           (str/starts-with? interim "/")
+           (str "." interim)
+
+           (empty? interim)
+           (str "../" (fs/file-name base-path))
+
+           :else
+           (str "./" interim)))))
+
+(defn js-transform-entry
+  "outputs the js module export form"
+  {:added "4.0"}
+  ([body {:keys [entry mopts]}]
+   (let [{:keys [emit]} mopts
+         {:lang/keys [format]} emit]
+     (cond (= :script (:type emit))
+           body
+
+           :else
+           (case format
+             (:none :global :commonjs) body
+             (case (:op-key entry)
+               (:defclass :def :defn) (str "export " body)
+               body))))))
+
+(def +meta+
+  (book/book-meta
+   {:module-current (fn [])
+    :module-import  #'js-module-import
+    :module-export  #'js-module-export
+    :module-link    #'js-module-link
+    :transforms {:entry [#'js-transform-entry]}}))

--- a/src/bb/lang/model/spec_js/qml.clj
+++ b/src/bb/lang/model/spec_js/qml.clj
@@ -1,0 +1,155 @@
+(ns bb.lang.model.spec-js.qml
+  (:require [bb.lang.base.emit-common :as common]
+            [bb.lang.base.util :as ut]
+            [bb.string :as str]
+            [bb.lib :as h]))
+
+;;
+;; nodes start with :qml/<NAME>, else will be inlined as a statement
+;; - var gets compiled to `property`
+;; - fn gets compiled to `function`
+;; - do block on properties is a js block
+;; - array on properties is an array
+;;
+
+(defn qml-props?
+  "checks if data is a qml prop"
+  {:added "4.0"}
+  [item]
+  (or (map? item)
+      (and (set? item)
+           (= 1 (count item))
+           (vector? (first item)))))
+
+(defn qml-container?
+  "checks if item is a qml container"
+  {:added "4.0"}
+  [item]
+  (and (vector? item)
+       (keyword? (first item))
+       (= "qml" (namespace (first item)))))
+
+(defn classify-props
+  "classifies props"
+  {:added "4.0"}
+  [props classify-fn]
+  (let [pairs (cond (map? props)
+                    props
+
+                    (set? props)
+                    (->> (first props)
+                         (partition 2))
+
+                    :else (h/error "Not Allowed" {:input props}))]
+    (mapv (fn [[k prop]]
+            [k (classify-fn prop)])
+          pairs)))
+
+(defn classify-container
+  "classifies a container"
+  {:added "4.0"}
+  [[tag props & children] classify-fn]
+  (let [title (if (= "qml" (namespace tag))
+                (name tag)
+                (h/error "Not a valid qml tag: " tag))
+        [props children] (if (qml-props? props)
+                           [props children]
+                           [{} children])]
+    {:type  :qml/container
+     :title title
+     :props (classify-props props classify-fn)
+     :children (mapv classify-fn children)}))
+
+(defn classify
+  "classifies the data structure"
+  {:added "4.0"}
+  [val]
+  (if (qml-container? val)
+    (classify-container val classify)
+    {:type :qml/value
+     :value val}))
+
+
+;;
+;; emit script
+;;
+
+(declare emit-node)
+
+(defn emit-value
+  "emits a value string"
+  {:added "4.0"}
+  [{:keys [value]} grammar mopts]
+  (cond (h/form? value)
+        (case (first value)
+          %  (str " {"
+                  (common/with-indent [2]
+                    (str (common/newline-indent)
+                         (common/*emit-fn* (cons 'do (rest value))
+                                           grammar
+                                           mopts)))
+                  (common/newline-indent)
+                  "}")
+          var (common/*emit-fn* (cons 'property (rest value))
+                                (assoc-in grammar [:default :common :assign] ":")
+                                mopts)
+          fn  (common/*emit-fn* (cons 'fn.inner (rest value))
+                                grammar
+                                mopts)
+          (common/*emit-fn* value
+                            grammar
+                            mopts))
+
+        :else
+        (common/*emit-fn* value
+                          grammar
+                          mopts)))
+
+(defn emit-container
+  "emits a container string"
+  {:added "4.0"}
+  [{:keys [title props children]} grammar mopts]
+  (str title " {"
+       (common/with-indent [2]
+         (str (common/newline-indent)
+              (->> (concat (mapv (fn [[k node]]
+                                   (str (h/strn k) ": " (emit-node node grammar mopts)))
+                                 props)
+                           (mapv #(emit-node %  grammar mopts) children))
+                   (str/join (common/newline-indent)))))
+       (common/newline-indent)
+       "}"))
+
+(defn emit-node
+  "emits either container or value string"
+  {:added "4.0"}
+  [{:keys [type value] :as node} grammar mopts]
+  (case type
+    :qml/container (emit-container node grammar mopts)
+    :qml/value (emit-value node grammar mopts)))
+
+(defn emit-qml
+  "emits a qml string
+
+   (l/with:emit
+    (qml/emit-qml [:qml/Window #{[:a 1 :b [:qml/Item]]}
+                   '(fn hello [] (+ 1 2))]
+                  js/+grammar+
+                  {}))
+   (bb.string/|
+   \"Window {\"
+    \"  a: 1\"
+    \"  b: Item {\"
+    \"    \"
+    \"  }\"
+    \"  hello(){\"
+    \"    1 + 2;\"
+    \"  }\"
+    \"}\")"
+  {:added "4.0"}
+  [form grammar mopts]
+  (let [tree (classify form)]
+    (emit-node tree grammar mopts)))
+
+(comment
+  (./import))

--- a/src/bb/lang/model/spec_julia.clj
+++ b/src/bb/lang/model/spec_julia.clj
@@ -1,0 +1,220 @@
+(ns bb.lang.model.spec-julia
+  (:require [bb.lang.base.emit-common :as common]
+            [bb.lang.base.emit :as emit]
+            [bb.lang.base.grammar :as grammar]
+            [bb.lang.base.impl :as impl]
+            [bb.lang.base.util :as ut]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.book-module :as module]
+            [bb.lang.base.script :as script]
+            [bb.lang.model.spec-xtalk]
+            [bb.lang.model.spec-xtalk.fn-julia :as fn]
+            [bb.string :as str]
+            [bb.lib :as h]
+            [std.fs :as fs]))
+
+;;
+;; LANG
+;;
+
+(defn tf-local
+  "a more flexible `var` replacement"
+  {:added "4.0"}
+  [[op decl & args]]
+  (if (empty? args)
+    (if (= op 'local)
+      (list 'var* :local decl)
+      (list 'var* :local decl)) ;; default declaration
+    (let [bound (last args)]
+      (cond (and (h/form? bound)
+                 (= 'fn (first bound)))
+            (apply list 'defn (with-meta decl {:inner true})
+                   (rest bound))
+
+            :else
+            (if (= op 'local)
+              (list 'var* :local decl := bound)
+              (list ':= decl bound))))))
+
+(defn julia-map-key
+  "custom julia map key"
+  {:added "3.0"}
+  ([key grammar mopts]
+   (cond (keyword? key)
+         (str "\"" (name key) "\"")
+
+         :else
+         (common/*emit-fn* key grammar mopts))))
+
+(defn tf-for-iter
+  "for iter transform"
+  {:added "4.0"}
+  [[_ [e it] & body]]
+  (apply list 'for [e :in it]
+         body))
+
+(defn tf-for-index
+  "for index transform"
+  {:added "4.0"}
+  [[_ [i [start end step :as range]] & body]]
+  (apply list 'for [i :in (list 'to start (or step 1) end)]
+           body))
+
+(defn tf-dict
+  "dict transform"
+  {:added "4.0"}
+  [[_ & args]]
+  (let [pairs (partition 2 args)
+        args  (map (fn [[k v]]
+                     (list '=> (if (keyword? k) (name k) k) v))
+                   pairs)]
+    (apply list 'Dict args)))
+
+(defn tf-push!
+  "push! transform to avoid sanitization"
+  {:added "4.0"}
+  [[_ arr item]]
+  (list :% "push!(" arr ", " item ")"))
+
+(defn emit-to
+  "emits the range"
+  {:added "4.0"}
+  [[_ start step end] grammar mopts]
+  (if (= step 1)
+    (str start ":" end)
+    (str start ":" step ":" end)))
+
+(def +features+
+  (-> (grammar/build :include [:builtin
+                               :builtin-global
+                               :builtin-module
+                               :builtin-helper
+                               :free-control
+                               :free-literal
+                               :math
+                               :compare
+                               :logic
+                               :return
+                               :data-table
+                               :data-shortcuts
+                               :vars
+                               :fn
+                               :control-base
+                               :control-general
+                               :top-base
+                               :top-global
+                               :top-declare
+                               :for
+                               :macro
+                               :macro-arrow
+                               :macro-let
+                               :macro-xor])
+      (merge (grammar/build-xtalk))
+      (grammar/build:override
+       {:var    {:symbol '#{var*}}
+        :not    {:raw "!"}
+        :and    {:raw "&&"}
+        :or     {:raw "||"}
+        :neq    {:raw "!="}
+        :mod    {:raw "%"}
+        :pow    {:raw "^"}
+        :for-iter   {:macro #'tf-for-iter   :emit :macro}
+        :for-index  {:macro #'tf-for-index  :emit :macro}})
+      (grammar/build:override fn/+julia+)
+      (grammar/build:extend
+       {:cat    {:op :cat    :symbol '#{cat}       :raw "*"   :emit :infix}
+        :len    {:op :len    :symbol '#{len}       :raw "length"    :emit  :pre}
+        :local  {:op :local  :symbol '#{local var} :macro  #'tf-local :type :macro}
+        :pair   {:op :pair   :symbol '#{=>}        :raw "=>"        :emit :infix}
+        :dict   {:op :dict   :symbol '#{dict}      :macro #'tf-dict :emit :macro}
+        :push!  {:op :push!  :symbol '#{push!}     :macro #'tf-push! :emit :macro}
+        :%      {:op :%      :symbol #{:%}         :emit :squash}
+        :to     {:op :to     :symbol #{'to}        :emit #'emit-to}})))
+
+(def +template+
+  (->> {:banned #{:set :regex}
+        :allow   {:assign  #{:symbol :quote}}
+        :highlight '#{return break local end for if elseif else function module using import}
+        :default {:comment   {:prefix "#"}
+                  :common    {:apply "(" :statement ""
+                              :namespace-full "."
+                              :namespace-sep  "."}
+                  :index     {:offset 1  :end-inclusive true}
+                  :return    {:multi true}
+                  :block     {:parameter {:start "(" :end ")" :space ", "}
+                              :body      {:start "" :end "end"}}
+                  :function  {:raw "function"
+                              :body      {:start "" :end "end"}}
+                  :infix     {:if  {:check "&&" :then "||"}}
+                  :global    {:reference nil}}
+        :token  {:nil       {:as "nothing"}
+                 :string    {:quote :double}}
+        :data   {:map-entry {:start ""  :end ""  :space "" :assign " => " :keyword :string
+                             :key-fn #'julia-map-key}
+                 :map       {:start "Dict(" :end ")"}
+                 :vector    {:start "[" :end "]" :space ", "}}
+        :block  {:for       {:body    {:start "" :end "end"}
+                             :parameter {:start " " :end "" :space " "}}
+                 :while     {:body    {:start "" :end "end"}}
+                 :branch    {:wrap    {:start "" :end "end"}
+                             :control {:default {:parameter  {:start " " :end ""}
+                                                 :body {:append true :start "" :end " end"}}
+                                       :if      {:raw "if"}
+                                       :elseif  {:raw "elseif"}
+                                       :else    {:raw "else"}}}}
+        :function {:defn      {:raw "function"}}
+        :define   {:def       {:raw ""}
+                   :defglobal {:raw ""}
+                   :declare   {:raw ""}}}
+       (h/merge-nested (emit/default-grammar))))
+
+(defn julia-module-link
+  "gets the absolute julia based module"
+  {:added "4.0"}
+  ([ns graph]
+   (let [{:keys [target root-ns]} graph
+         root-path (->> (str/split (name root-ns) #"\.")
+                        (butlast)
+                        (str/join "/"))
+
+         ns-path   (str/replace (name ns) #"\." "/")]
+     (if (str/starts-with? ns-path (str root-path))
+       (h/->> (fs/relativize root-path ns-path)
+              (str)
+              (str "./"))
+       (str "./" ns-path)))))
+
+(defn julia-module-export
+  "outputs the julia module export form"
+  {:added "4.0"}
+  ([module mopts]
+   (let [exports (module/module-entries module #{:defn :def})]
+     (if (seq exports)
+       (list 'export (apply list exports))
+       nil))))
+
+(def +meta+
+  (book/book-meta
+   {:module-current h/NIL
+    :module-link    #'julia-module-link
+    :module-export  #'julia-module-export
+    :module-import  (fn [name {:keys [as]} opts]
+                      (if as
+                        (list 'import name :as as)
+                        (list 'using name)))
+    :has-ptr        (fn [ptr] (list '!= (ut/sym-full ptr) nil))
+    :teardown-ptr   (fn [ptr] (list := (ut/sym-full ptr) nil))}))
+
+(def +grammar+
+  (grammar/grammar :julia
+    (grammar/to-reserved +features+)
+    +template+))
+
+(def +book+
+  (book/book {:lang :julia
+              :parent :xtalk
+              :meta +meta+
+              :grammar +grammar+}))
+
+(def +init+
+  (script/install +book+))

--- a/src/bb/lang/model/spec_lua.clj
+++ b/src/bb/lang/model/spec_lua.clj
@@ -1,0 +1,334 @@
+(ns bb.lang.model.spec-lua
+  (:require [bb.lang.model.spec-xtalk]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.emit :as emit]
+            [bb.lang.base.grammar :as grammar]
+            [bb.lang.base.grammar-spec :as spec]
+            [bb.lang.base.impl :as impl]
+            [bb.lang.base.util :as ut]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.book-module :as module]
+            [bb.lang.base.script :as script]
+            [bb.lang.model.spec-xtalk]
+            [bb.lang.model.spec-xtalk.fn-lua :as fn]
+            [bb.string :as str]
+            [bb.lib :as h]
+            [std.fs :as fs]))
+
+;;
+;; LANG
+;;
+
+(defn tf-local
+  "a more flexible `var` replacement"
+  {:added "4.0"}
+  [[_ decl & args]]
+  (if (empty? args)
+    (list 'var* :local decl)
+    (let [bound (last args)]
+      (cond (and (h/form? bound)
+                 (= 'fn (first bound)))
+            (apply list 'defn (with-meta decl {:inner true})
+                   (rest bound))
+
+            (vector? decl)
+            (apply list 'var* :local (list 'quote decl)
+                   [:= (list 'unpack bound)])
+
+            (set? decl)
+            (cons 'do
+                  (map (fn [sym]
+                         (let [sym-index (ut/sym-default-str sym)]
+                           (list 'var* :local sym := (list '. bound [sym-index]))))
+                       decl))
+
+            :else (list 'var* :local decl := bound)))))
+
+(defn tf-c-ffi
+  "transforms a c ffi block"
+  {:added "4.0"}
+  [[_ & forms]]
+  `(\\ "[["
+    ^{:indent 2}
+    (\\ \\ (~'!:lang {:lang :c} (~'do ~@forms)))
+    \\ "]]"))
+
+(defn lua-map-key
+  "custom lua map key"
+  {:added "3.0"}
+  ([key grammar mopts]
+   (cond (not (or (h/form? key)
+                  (symbol? key)
+                  (number? key)))
+         (let [key-str (cond (string? key)
+                             key
+
+                             :else
+                             (ut/sym-default-str key))
+               key-str (cond (and (not (#{"function"
+                                          "return"
+                                          "end"
+                                          "for"
+                                          "in"
+                                          "var"} key-str))
+                                  (re-find #"^[A-Za-z][\w\d]*$" key-str))
+                             key-str
+
+                             :else
+                             (str "['" key-str "']"))]
+           key-str)
+
+         :else
+         (str  "[" (common/*emit-fn* key grammar mopts) "]"))))
+
+(defn tf-for-object
+  "for object transform"
+  {:added "4.0"}
+  [[_ [[k v] m] & body]]
+  (apply list 'for [[k v] :in (list 'pairs m)]
+         body))
+
+(defn tf-for-array
+  "for array transform"
+  {:added "4.0"}
+  [[_ [e arr] & body]]
+  (if (vector? e)
+    (apply list 'for [e :in (list 'ipairs arr)]
+           body)
+    (apply list 'for [['_ e] :in (list 'ipairs arr)]
+           body)))
+
+(defn tf-for-iter
+  "for iter transform"
+  {:added "4.0"}
+  [[_ [e it] & body]]
+  (apply list 'for [e :in it]
+         body))
+
+(defn tf-for-index
+  "for index transform"
+  {:added "4.0"}
+  [[_ [i [start end step :as range]] & body]]
+  (apply list 'for [i := (list 'quote [start end (or step 1)])]
+           body))
+
+(defn tf-for-return
+  "for return transform"
+  {:added "4.0"}
+  [[_ [[res err] statement] {:keys [success error]}]]
+  (h/$ (do (var '[~res ~err] ~statement)
+           (if (not ~err)
+             ~success
+             ~error))))
+
+(defn tf-for-try
+  "for try transform"
+  {:added "4.0"}
+  [[_ [[res err] statement] {:keys [success error]}]]
+  (h/$ (do (var '[ok out] (pcall (fn []
+                                   (return ~statement))))
+           (if ok
+             (do* (var ~res := out)
+                  ~@(if success [success]))
+             (do* (var ~err := out)
+                  ~@(if error [error]))))))
+
+(defn tf-for-async
+  "for async transform"
+  {:added "4.0"}
+  [[_ [[res err] statement] {:keys [success error finally]}]]
+  (h/$ (ngx.thread.spawn
+        (fn []
+          (for:try [[~res ~err] ~statement]
+                   {:success ~success
+                    :error ~error})
+          ~@(if finally [finally])))))
+
+(defn tf-yield
+  "yield transform"
+  {:added "4.0"}
+  [[_ e]]
+  (list 'coroutine.yield e))
+
+(defn tf-defgen
+  "defgen transform"
+  {:added "4.0"}
+  [[_ sym args & body]]
+  (list 'defn sym args
+        (list 'return (list 'coroutine.wrap
+                            (apply list 'fn [] body)))))
+
+(def +features+
+  (-> (grammar/build :include [:builtin
+                               :builtin-global
+                               :builtin-module
+                               :builtin-helper
+                               :free-control
+                               :free-literal
+                               :math
+                               :compare
+                               :logic
+                               :return
+                               :data-table
+                               :data-shortcuts
+                               :vars
+                               :fn
+                               :control-base
+                               :control-general
+                               :top-base
+                               :top-global
+                               :top-declare
+                               :for
+                               :coroutine
+                               :macro
+                               :macro-arrow
+                               :macro-let
+                               :macro-xor])
+      (merge (grammar/build-xtalk))
+      (grammar/build:override
+       {:var    {:symbol '#{var*}}
+        :not    {:raw "not "}
+        :and    {:raw "and"}
+        :or     {:raw "or"}
+        :neq    {:raw "~="}
+        :for-object {:macro #'tf-for-object :emit :macro}
+        :for-array  {:macro #'tf-for-array  :emit :macro}
+        :for-iter   {:macro #'tf-for-iter   :emit :macro}
+        :for-index  {:macro #'tf-for-index  :emit :macro}
+        :for-return {:macro #'tf-for-return :emit :macro}
+        :for-try    {:macro #'tf-for-try    :emit :macro}
+        :for-async  {:macro #'tf-for-async  :emit :macro}
+        :defgen     {:macro #'tf-defgen     :emit :macro}
+        :yield      {:macro #'tf-yield      :emit :macro}})
+      (grammar/build:override fn/+lua+)
+      (grammar/build:extend
+       {:cat    {:op :cat    :symbol '#{cat}       :raw ".."   :emit :infix}
+        :len    {:op :len    :symbol '#{len}       :raw "#"    :emit  :pre}
+        :local  {:op :local  :symbol '#{local var} :macro  #'tf-local :type :macro}
+        :c-ffi  {:op :c-ffi  :symbol '#{%.c}       :macro  #'tf-c-ffi :type :macro}
+        :repeat {:op :repeat
+                 :symbol '#{repeat} :type :block
+                 :block {:raw "repeat"
+                         :main    #{:body}
+                         :control [[:until {:required true
+                                            :input #{:parameter}}]]}}})))
+
+(def +template+
+  (->> {:banned #{:keyword :set :regex}
+        :allow   {:assign  #{:symbol :quote}}
+        :highlight '#{return break local tab until}
+        :default {:comment   {:prefix "--"}
+                  :common    {:apply ":" :statement ""
+                              :namespace-full "___"
+                              :namespace-sep  "_"}
+                  :index     {:offset 1  :end-inclusive true}
+                  :return    {:multi true}
+                  :block     {:parameter {:start " " :end " "}
+                              :body      {:start "" :end ""}}
+                  :function  {:raw "function"
+                              :body      {:start "" :end "end"}}
+                  :infix     {:if  {:check "and" :then "or"}}
+                  :global    {:reference nil}}
+        :token  {:nil       {:as "nil"}
+                 :string    {:quote :single}}
+        :data   {:map-entry {:start ""  :end ""  :space "" :assign "=" :keyword :symbol
+                             :key-fn #'lua-map-key}
+                 :vector    {:start "{" :end "}" :space ""}}
+        :block  {:for       {:body    {:start "do" :end "end"}}
+                 :while     {:body    {:start "do" :end "end"}}
+                 :branch    {:wrap    {:start "" :end "end"}
+                             :control {:default {:parameter  {:start " " :end " then"}
+                                                 :body {:append true}}
+                                       :if      {:raw "if"}
+                                       :elseif  {:raw "elseif"}
+                                       :else    {:raw "else"}}}
+                 :repeat    {:body  {:start "" :end ""}}}
+        :function {:defn      {:raw "local function"}}
+        :define   {:def       {:raw "local"}
+                   :defglobal {:raw ""}
+                   :declare   {:raw "local"}}}
+       (h/merge-nested (emit/default-grammar))))
+
+(defn lua-module-link
+  "gets the absolute lua based module
+
+   (lua-module-link 'kmi.common {:root-ns 'kmi.hello})
+   => \"./common\"
+
+   (lua-module-link 'kmi.exchange
+                    {:root-ns 'kmi :target \"src\"})
+   => \"./kmi/exchange\""
+  {:added "4.0"}
+  ([ns graph]
+   (let [{:keys [target root-ns]} graph
+         root-path (->> (str/split (name root-ns) #"\.")
+                        (butlast)
+                        (str/join "/"))
+
+         ns-path   (str/replace (name ns) #"\." "/")]
+     (if (str/starts-with? ns-path (str root-path))
+       (h/->> (fs/relativize root-path ns-path)
+              (str)
+              (str "./"))
+       (str "./" ns-path)))))
+
+(defn lua-module-export
+  "outputs the js module export form"
+  {:added "4.0"}
+  ([module mopts]
+   (let [table  (->> (module/module-entries module
+                                            #{:defn
+                                              :def})
+                     (cons 'tab))]
+     (list 'return table))))
+
+
+(def +meta+
+  (book/book-meta
+   {:module-current h/NIL
+    :module-link    #'lua-module-link
+    :module-export  #'lua-module-export
+    :module-import  (fn [name {:keys [as]} opts]
+                      (h/$ (var* :local ~as := (require ~(str name)))))
+    :has-ptr        (fn [ptr] (list 'not= (ut/sym-full ptr) nil))
+    :teardown-ptr   (fn [ptr] (list := (ut/sym-full ptr) nil))}))
+
+(def +grammar+
+  (grammar/grammar :lua
+    (grammar/to-reserved +features+)
+    +template+))
+
+(def +book+
+  (book/book {:lang :lua
+              :parent :xtalk
+              :meta +meta+
+              :grammar +grammar+}))
+
+(def +init+
+  (script/install +book+))
+
+(def +book-redis+
+  (book/book {:lang :redis
+              :parent :lua
+              :meta +meta+
+              :grammar (assoc +grammar+ :tag :redis)}))
+
+(def +init-redis+
+  (script/install +book-redis+))
+
+(comment
+  (lib/get-book (impl/default-library) :lua)
+
+  (!.lua
+   (let [#{a} hello
+         b 2]))
+
+  (!.lua
+   (defgen hello []
+     (yield n)))
+  (!.lua (x:offset))
+  (!.lua (x:random))
+
+
+
+  (./create-tests))

--- a/src/bb/lang/model/spec_perl.clj
+++ b/src/bb/lang/model/spec_perl.clj
@@ -1,0 +1,157 @@
+(ns bb.lang.model.spec-perl
+  (:require [bb.lang.base.emit :as emit]
+            [bb.lang.base.grammar :as grammar]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.emit-helper :as helper]
+            [bb.lang.base.emit-preprocess :as preprocess]
+            [bb.lang.base.emit-top-level :as top]
+            [bb.lang.base.emit-data :as data]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.script :as script]
+            [bb.lang.base.util :as ut]
+            [bb.lang.model.spec-xtalk]
+            [bb.lang.model.spec-xtalk.fn-perl :as fn]
+            [bb.string :as str]
+            [bb.lib :as h]))
+
+;;
+;; LANG
+;;
+
+(defn perl-var
+  "emit perl variable declaration"
+  [[_ sym & args]]
+  (let [val (last args)
+        sym-str (if (keyword? sym)
+                  (h/strn sym)
+                  (str "$" (h/strn sym)))]
+    (list :- (str "my " sym-str " = " (common/*emit-fn* val preprocess/*macro-grammar* preprocess/*macro-opts*)))))
+
+(defn perl-symbol
+  "emit perl symbol with $ prefix if it's a variable"
+  [sym grammar mopts]
+  (let [s0 (name sym)
+        s  (if (or (str/includes? s0 "::")
+                   (str/includes? s0 "->"))
+             s0
+             (str/replace s0 "-" "_"))]
+    (cond (:perl/func mopts)
+          s
+
+          (or (str/starts-with? s "$")
+              (str/starts-with? s "@")
+              (str/starts-with? s "%"))
+          s
+
+          :else
+          (str "$" s))))
+
+(defn perl-invoke-args
+  [args grammar mopts]
+  (str/join ", " (common/emit-invoke-args args grammar mopts)))
+
+(defn perl-invoke
+  "emit perl function call"
+  [[f & args] grammar mopts]
+  (let [f-str (common/*emit-fn* f grammar (assoc mopts :perl/func true))
+        args-str (perl-invoke-args args grammar (dissoc mopts :perl/func))]
+    (str f-str "(" args-str ")")))
+
+(defn perl-defn
+  "emit perl subroutine definition"
+  [[_ sym args & body]]
+  (let [grammar preprocess/*macro-grammar*
+        mopts   preprocess/*macro-opts*
+        sym-str (common/emit-symbol sym grammar (assoc mopts :perl/func true))
+        args-emit (map (fn [arg]
+                         (str "my " (perl-symbol arg grammar mopts) " = shift;"))
+                       args)
+        body-str (common/*emit-fn* (cons 'do body) grammar mopts)]
+    (list :- (str "sub " sym-str " {\n"
+                  (if (seq args-emit)
+                    (str (str/join "\n" args-emit) "\n")
+                    "")
+                  body-str "\n}"))))
+
+(defn perl-eval
+  "emit perl eval block"
+  [[_ & args] grammar mopts]
+  (let [body    (common/*emit-fn* (cons 'do args) grammar mopts)]
+    (str "eval {\n" body "\n}")))
+
+(defn perl-array
+  "emit perl array reference"
+  [arr grammar mopts]
+  (str "[" (str/join ", " (common/emit-array arr grammar mopts)) "]"))
+
+(defn perl-map
+  "emit perl hash reference"
+  [m grammar mopts]
+  (let [entries (map (fn [[k v]]
+                       (str (if (keyword? k)
+                              (common/*emit-fn* (h/strn k) grammar mopts)
+                              (common/*emit-fn* k grammar mopts))
+                            " => "
+                            (common/*emit-fn* v grammar mopts)))
+                     m)]
+    (str "{" (str/join ", " entries) "}")))
+
+(def +features+
+  (let [base (grammar/build :exclude [:pointer :block :data-range])
+        base-keys (set (keys base))
+        fn-override (select-keys fn/+perl+ base-keys)
+        fn-extend   (apply dissoc fn/+perl+ (keys fn-override))]
+    (-> base
+        (grammar/build:override
+         {:var        {:macro #'perl-var :emit :macro}
+          :defn       {:macro #'perl-defn :emit :macro}
+          :and        {:raw "&&"}
+          :or         {:raw "||"}
+          :not        {:raw "!"}
+          :pow        {:raw "**" :emit :infix :symbol #{'**}}
+          :eq         {:raw "=="}
+          :neq        {:raw "!="}
+          :gt         {:raw ">"}
+          :lt         {:raw "<"}
+          :gte        {:raw ">="}
+          :lte        {:raw "<="}})
+        (grammar/build:override fn-override)
+        (grammar/build:extend fn-extend)
+        (grammar/build:extend
+         {:concat     {:op :concat :symbol #{'concat} :raw "." :emit :infix :value true}
+          :eval       {:emit #'perl-eval :symbol #{'eval} :value true}
+          :die        {:op :die   :symbol #{'die}   :raw "die"   :emit :prefix}}))))
+
+(def +template+
+  (->> {:banned #{:keyword}
+        :allow   {:assign  #{:symbol}}
+        :default {:common    {:statement ";"
+                              :start  ""
+                              :end    ""}
+                  :block     {:parameter {:start "(" :end ")"}
+                              :body      {:start "{" :end "}"}}
+                  :invoke    {:custom #'perl-invoke}
+                  :function  {:raw "sub"}}
+        :token   {:nil       {:as "undef"}
+                  :boolean   {:as (fn [b] (if b "1" "0"))}
+                  :string    {:quote :double}
+                  :symbol    {:custom #'perl-symbol}}
+        :data    {:vector    {:custom #'perl-array}
+                  :map       {:custom #'perl-map}}
+        :define  {:def       {:raw ""}
+                  :defglobal {:raw ""}}}
+       (h/merge-nested (emit/default-grammar))))
+
+(def +grammar+
+  (grammar/grammar :pl
+    (grammar/to-reserved +features+)
+    +template+))
+
+(def +book+
+  (book/book {:lang :perl
+              :parent :xtalk
+              :meta (book/book-meta {})
+              :grammar +grammar+}))
+
+(def +init+
+  (script/install +book+))

--- a/src/bb/lang/model/spec_php.clj
+++ b/src/bb/lang/model/spec_php.clj
@@ -1,0 +1,179 @@
+(ns bb.lang.model.spec-php
+  (:require [bb.lang.base.emit :as emit]
+            [bb.lang.base.grammar :as grammar]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.emit-helper :as helper]
+            [bb.lang.base.emit-preprocess :as preprocess]
+            [bb.lang.base.emit-top-level :as top]
+            [bb.lang.base.emit-data :as data]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.script :as script]
+            [bb.lang.base.util :as ut]
+            [bb.lang.model.spec-xtalk]
+            [bb.lang.model.spec-xtalk.fn-php :as fn]
+            [bb.string :as str]
+            [bb.lib :as h]))
+
+(defn is-capitalized?
+  "checks if string is capitalized"
+  [s]
+  (let [s (name s)]
+    (and (not (empty? s))
+         (Character/isUpperCase (char (first s))))))
+
+(defn php-symbol
+  "emit php symbol with $ prefix if it's a variable"
+  [sym grammar mopts]
+  (cond (or (:php/func mopts)
+            (:php/func (meta sym))
+            (is-capitalized? sym))
+        (common/emit-symbol sym grammar mopts)
+
+        (namespace sym)
+        (let [ns (namespace sym)
+              nm (name sym)]
+          (str (str/replace ns "." "\\") "::" nm))
+
+        :else
+        (str "$" (common/emit-symbol sym grammar mopts))))
+
+(defn php-invoke-args
+  [args grammar mopts]
+  (str/join ", " (common/emit-invoke-args args grammar mopts)))
+
+(defn php-invoke
+  "emit php function call"
+  [[f & args] grammar mopts]
+  (let [f-str (common/*emit-fn* f grammar (assoc mopts :php/func true))
+        args-str (php-invoke-args args grammar (dissoc mopts :php/func))]
+    (str f-str "(" args-str ")")))
+
+(defn php-var
+  "emit php variable declaration"
+  [[_ sym & args]]
+  (let [val (last args)]
+    (list := sym val)))
+
+(defn php-defn
+  "emit php function definition"
+  [[_ sym args & body]]
+  (let [grammar preprocess/*macro-grammar*
+        mopts   preprocess/*macro-opts*
+        sym-str (common/emit-symbol sym grammar (assoc mopts :php/func true))
+        args-str (php-invoke-args args grammar (dissoc mopts :php/func))
+        body-str (common/*emit-fn* (cons 'do body) grammar mopts)]
+    (list :- (str "function " sym-str "(" args-str ") {\n" body-str "\n}"))))
+
+(defn php-defn-
+  "emit php anonymous function"
+  [[_ args & body]]
+  (let [grammar preprocess/*macro-grammar*
+        mopts   preprocess/*macro-opts*
+        args-str (php-invoke-args args grammar (dissoc mopts :php/func))
+        body-str (common/*emit-fn* (cons 'do body) grammar mopts)]
+    (list :- (str "function (" args-str ") {\n" body-str "\n}"))))
+
+(defn php-array
+  "emit php array"
+  [arr grammar mopts]
+  (str "[" (str/join ", " (common/emit-array arr grammar mopts)) "]"))
+
+(defn php-map
+  "emit php associative array"
+  [m grammar mopts]
+  (let [entries (map (fn [[k v]]
+                       (str (common/*emit-fn* k grammar mopts)
+                            " => "
+                            (common/*emit-fn* v grammar mopts)))
+                     m)]
+    (str "[" (str/join ", " entries) "]")))
+
+(defn php-dot-string
+  [obj props grammar mopts]
+  (loop [curr-str (common/*emit-fn* obj grammar mopts)
+         curr-obj obj
+         [p & more] props]
+    (if p
+      (let [static?  (and (symbol? curr-obj) (is-capitalized? curr-obj))
+            sep      (if static? "::" "->")
+            next-val (if (list? p) (first p) p)
+            next-str (if (list? p)
+                       (str (common/*emit-fn* (first p) grammar (assoc mopts :php/func true))
+                            "(" (php-invoke-args (rest p) grammar mopts) ")")
+                       (common/emit-symbol p grammar (assoc mopts :php/func true)))]
+        (recur (str curr-str sep next-str)
+               next-val
+               more))
+      curr-str)))
+
+(defn php-dot
+  "emit php object access ->"
+  [[_ obj & props]]
+  (let [grammar preprocess/*macro-grammar*
+        mopts   preprocess/*macro-opts*]
+    (list :- (php-dot-string obj props grammar mopts))))
+
+(defn php-new
+  "emit new Class()"
+  [[_ cls & args]]
+  (let [grammar preprocess/*macro-grammar*
+        mopts   preprocess/*macro-opts*
+        cls-str (common/emit-symbol cls grammar (assoc mopts :php/func true))
+        args-str (php-invoke-args args grammar mopts)]
+    (list :- (str "new " cls-str "(" args-str ")"))))
+
+(def +features+
+  (-> (grammar/build :exclude [:pointer :block :data-range])
+      (grammar/build:override
+       {:var        {:macro #'php-var :emit :macro}
+        :defn       {:macro #'php-defn :emit :macro}
+        :fn         {:macro #'php-defn- :emit :macro}
+        :index      {:macro #'php-dot :emit :macro}
+        :new        {:macro #'php-new :emit :macro}
+        :and        {:raw "&&"}
+        :or         {:raw "||"}
+        :not        {:raw "!"}
+        :eq         {:raw "=="}
+        :neq        {:raw "!="}
+        :gt         {:raw ">"}
+        :lt         {:raw "<"}
+        :gte        {:raw ">="}
+        :lte        {:raw "<="}})
+       (grammar/build:override fn/+php+)
+       (grammar/build:extend
+        {:phparray   {:op :phparray :symbol #{'array} :raw "array"}
+         :echo       {:op :echo :symbol #{'echo} :raw "echo" :emit :prefix}
+         :die        {:op :die  :symbol #{'die}  :raw "die"  :emit :prefix}})))
+
+(def +template+
+  (->> {:banned #{:keyword}
+        :allow   {:assign  #{:symbol}}
+        :default {:common    {:statement ";"
+                              :start  "<?php\n"
+                              :end    "\n?>"}
+                  :block     {:parameter {:start "(" :end ")"}
+                              :body      {:start "{" :end "}"}}
+                  :invoke    {:custom #'php-invoke}}
+        :token   {:nil       {:as "null"}
+                  :boolean   {:as (fn [b] (if b "true" "false"))}
+                  :string    {:quote :single}
+                  :symbol    {:custom #'php-symbol}}
+        :data    {:vector    {:custom #'php-array}
+                  :map       {:custom #'php-map}}
+        :define  {:def       {:raw ""}
+                  :defglobal {:raw ""}}}
+       (h/merge-nested (emit/default-grammar))))
+
+(def +grammar+
+  (grammar/grammar :php
+    (grammar/to-reserved +features+)
+    +template+))
+
+(def +book+
+  (book/book {:lang :php
+              :parent :xtalk
+              :meta (book/book-meta {})
+              :grammar +grammar+}))
+
+(def +init+
+  (script/install +book+))

--- a/src/bb/lang/model/spec_python.clj
+++ b/src/bb/lang/model/spec_python.clj
@@ -1,0 +1,257 @@
+(ns bb.lang.model.spec-python
+  (:require [bb.lang.base.emit :as emit]
+            [bb.lang.base.grammar :as grammar]
+            [bb.lang.base.grammar-spec :as spec]
+            [bb.lang.base.emit-preprocess :as preprocess]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.emit-helper :as helper]
+            [bb.lang.base.emit-top-level :as top]
+            [bb.lang.base.emit-data :as data]
+            [bb.lang.base.util :as ut]
+	    [bb.lang.base.book :as book]
+            [bb.lang.base.script :as script]
+            [bb.lang.model.spec-xtalk]
+            [bb.lang.model.spec-xtalk.fn-python :as fn]
+            [bb.string :as str]
+            [bb.lib :as h])
+  (:refer-clojure :exclude [await]))
+
+;;
+;; LANG
+;;
+
+(defn- python-symbol-global
+  [fsym grammar mopts]
+  (list '. '(globals) [(helper/emit-symbol-full fsym
+                                                (namespace fsym)
+                                                grammar)]))
+
+(defn- python-token-boolean
+  [v]
+  (if v "True" "False"))
+
+(defn python-defn-
+  "hidden function without decorators"
+  {:added "4.0"}
+  [form grammar mopts]
+  (top/emit-top-level :defn form grammar mopts))
+
+(defn python-defn
+  "creates a defn function for python"
+  {:added "4.0"}
+  ([form]
+   (let [decorators (get (meta (second form)) :decorators)
+         body  (cons 'defn- (rest form))]
+     (if (empty? decorators)
+       body
+       `(\\ ~(apply list
+                    \\ (mapcat (fn [d]
+                                 [\\ (list :%
+                                           (list :- "@")
+                                           (if (keyword? d)
+                                             (list :- (h/strn d))
+                                             d))])
+                               decorators))
+         \\ ~body)))))
+
+(defn python-fn
+  "basic transform for python lambdas"
+  {:added "4.0"}
+  ([[_ & args]]
+   (cond (symbol? (first args))
+         (apply list 'fn.inner (with-meta (first args)
+                                 {:inner true})
+                (rest args))
+
+         :else
+         (let [[args body] args]
+           (apply list :- :lambda
+                  (concat (if (not-empty args)
+                            [(list 'quote args) ":"]
+                            [":"])
+                          [(if (and (h/form? body)
+                                    (= 'return (first body)))
+                             (second body)
+                             body)]))))))
+
+(defn python-defclass
+  "emits a defclass template for python"
+  {:added "4.0"}
+  ([[_ sym inherit & body]]
+   (let [{:keys [module] :as mopts}  (preprocess/macro-opts)
+         body   (top/transform-defclass-inner body)
+         name   (symbol (:id module) (name sym))
+         supers (list 'quote (remove keyword? inherit))]
+     `(:- :class (:% ~name ~supers) \:
+          (\\
+           \\ (\| (do ~@body))
+           \\)))))
+
+(defn python-var
+  "var -> fn.inner shorthand"
+  {:added "4.0"}
+  ([[_ sym & args]]
+   (let [bound (last args)]
+     (cond (and (h/form? bound)
+                (= 'fn  (first bound)))
+           (apply list 'fn.inner (with-meta sym {:inner true})
+                  (rest bound))
+
+           (vector? sym)
+           (list 'var* (list 'quote sym) := bound)
+
+           (set? sym)
+           (cons 'do
+                 (map (fn [e]
+                        (list 'var* e := (list '. bound (list 'get (ut/sym-default-str e)))))
+                      sym))
+
+           :else
+           (list 'var* sym := bound)))))
+
+(defn tf-for-object
+  "for object loop"
+  {:added "4.0"}
+  [[_ [[k v] m] & body]]
+  (let [[binding method] (cond (= k '_) [v '(values)]
+                               (= v '_) [k '(keys)]
+                               :else [[k v] '(items)])]
+    (apply list 'for [binding :in (list '. m method)]
+           (or (not-empty body)
+               ['(pass)]))))
+
+(defn tf-for-array
+  "for array loop"
+  {:added "4.0"}
+  [[_ [e arr] & body]]
+  (if (vector? e)
+    (let [[i v] e]
+      (apply list 'for [i :in (list 'range (list 'len arr))]
+             (list 'var v (list '. arr [i]))
+             (or (not-empty body)
+               ['(pass)])))
+    (apply list 'for [e :in arr]
+           (or (not-empty body)
+               ['(pass)]))))
+
+(defn tf-for-iter
+  "for iter loop"
+  {:added "4.0"}
+  [[_ [e it] & body]]
+  (apply list 'for [e :in it]
+         (or (not-empty body)
+             ['(pass)])))
+
+(defn tf-for-index
+  "for index transform"
+  {:added "4.0"}
+  [[_ [i range] & body]]
+  (apply list 'for [i :in (apply list 'range (filter identity range))]
+         (or (not-empty body)
+             ['(pass)])))
+
+(defn tf-for-return
+  "for return transform"
+  {:added "4.0"}
+  [[_ [[res err] statement] {:keys [success error]}]]
+   (h/$ (try (var ~res ~statement)
+             ~success
+             (catch [Exception :as ~err] ~error))))
+
+(def +features+
+  (-> (grammar/build :exclude [:pointer
+                               :block])
+      (grammar/build:override
+       {:pow         {:raw "**"}
+        :and         {:raw "and"}
+        :or          {:raw "or"}
+        :not         {:raw "not" :emit :prefix}
+        :throw       {:raw "raise"  :emit :prefix}
+        :fn          {:macro  #'python-fn   :type :macro}
+        :var         {:symbol #{'var*}}
+        :defn        {:symbol #{'defn}   :macro #'python-defn :emit :macro}
+        :defgen      {:symbol #{'defgen} :macro #'python-defn :emit :macro}
+        :fn.inner    {:macro #'python-defn :emit :macro}
+        :with-global {:value true :raw "globals()"}
+        :defclass    {:macro  #'python-defclass :emit :macro}
+        :for-object  {:macro #'tf-for-object :emit :macro}
+        :for-array   {:macro #'tf-for-array  :emit :macro}
+        :for-iter    {:macro #'tf-for-iter   :emit :macro}
+        :for-index   {:macro #'tf-for-index  :emit :macro}
+        :for-return  {:macro #'tf-for-return :emit :macro}})
+      (grammar/build:override fn/+python+)
+      (grammar/build:extend
+       {:defn-     {:op :defn-   :symbol #{'defn-}  :type :block :emit #'python-defn-}
+        :var-let   {:op :var-let :symbol #{'var}  :macro #'python-var :type :macro}
+        :unarr     {:op :unarr   :symbol #{:*}    :raw "*"    :emit :pre}
+        :undict    {:op :undict  :symbol #{:**}   :raw "**"   :emit :pre}
+        :del       {:op :del     :symbol #{'del}  :raw "del"  :emit :prefix}
+        :pass      {:op :pass    :symbol #{'pass} :raw "pass" :emit :return :type :special}
+        :nan       {:op :nan     :symbol #{'NaN}  :raw "NaN"  :value true :emit :throw}
+        :with      {:op :with    :symbol #{'with} :type :block
+                    :block  {:main #{:parameter :body}}}})))
+
+(def +template+
+  (->> {:banned #{:keyword}
+        :allow   {:assign  #{:symbol :quote}}
+        :highlight '#{return break tup with await yield pass raise}
+        :default {:comment   {:prefix "#"}
+                  :common    {:statement ""}
+                  :block     {:parameter {:start " " :end ""}
+                              :body      {:start ":" :end "" :append true}}
+                  :invoke    {:reversed true
+                              :hint ":"}
+                  :function  {:raw "lambda"
+                              :args      {:start " " :end ":" :space ""}
+                              :body      {:start "" :end "" :append true}}
+                  :infix     {:if  {:check "and" :then "or"}}
+                  :global    {:reference '(globals)}}
+        :token   {:nil       {:as "None"}
+                  :boolean   {:as #'python-token-boolean}
+                  :string    {}
+                  :symbol    {:global #'python-symbol-global
+                              :namespace {:alias true :link false}}}
+        :block    {:try      {:control {:catch  {:raw  "except"
+                                                 :args {:start "" :end ":" :space ""}}}}
+                   :branch   {:control {:elseif {:raw "elif"}}}}
+        :data     {:map-entry {:key-fn data/default-map-key}
+                   :set       {:start "{" :end "}" :space ""}
+                   :vector    {:start "[" :end "]" :space ""}
+                   :tuple     {:start "(" :end ")" :space ""}
+                   :free      {:start ""  :end "" :space ""}}
+        :function {:defn        {:raw "def"
+                                 :args  {:start "(" :end "):" :space ""}}
+                   :fn.inner    {:raw "def"
+                                 :symbol {:layout :flat}
+                                 :args   {:start "(" :end "):" :space ""}}}
+        :define   {:defglobal  {:raw ""}
+                   :def        {:raw ""}}}
+       (h/merge-nested (emit/default-grammar))))
+
+(def +grammar+
+  (grammar/grammar :py
+    (grammar/to-reserved +features+)
+    +template+))
+
+(def +meta+
+  (book/book-meta
+   {:module-current (fn []
+                      (h/$ (list (b:& (set [(str x) :for x :in (locals)])
+                                      (set [(str m) :for m :in sys.modules])))))
+    :module-export  (fn [{:keys [as refer]} opts])
+    :module-import  (fn [name {:keys [as refer]} opts]
+                      (if as
+                        (h/$ (:- :import ~name :as ~as))
+                        (h/$ (:- :import ~name))))
+    :module-unload  (fn [name as]
+                      (h/$ (do (del (. sys.modules [~name]))
+                               (del ~(symbol name)))))}))
+
+(def +book+
+  (book/book {:lang :python
+              :parent :xtalk
+              :meta +meta+
+              :grammar +grammar+}))
+
+(def +init+
+  (script/install +book+))

--- a/src/bb/lang/model/spec_r.clj
+++ b/src/bb/lang/model/spec_r.clj
@@ -1,0 +1,227 @@
+(ns bb.lang.model.spec-r
+  (:require [bb.lang.base.emit :as emit]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.emit-top-level :as top]
+            [bb.lang.base.grammar :as grammar]
+            [bb.lang.base.grammar-spec :as spec]
+            [bb.lang.base.util :as ut]
+	    [bb.lang.base.book :as book]
+            [bb.lang.base.script :as script]
+            [bb.lang.model.spec-xtalk]
+            [bb.lang.model.spec-xtalk.fn-r :as fn]
+            [bb.string :as str]
+            [bb.lib :as h]))
+
+(defn tf-defn
+  "function declaration for python
+
+   (tf-defn '(defn hello [x y] (return (+ x y))))
+   => '(def hello (fn [x y] (return (+ x y))))
+
+   (!.R
+    (defn ^{:inner true}
+      hello [x y] (+ x y))
+    (hello 1 2))
+   => 3"
+  {:added "3.0"}
+  ([[_ sym args & body]]
+   (list 'def sym (apply list 'fn args body))))
+
+(defn tf-infix-if
+  "transform for infix if"
+  {:added "4.0"}
+  ([[_ expr & args]]
+   (cond (= 1 (count args))
+         (if (vector? (first args))
+           (apply list (list :- "`if`") expr (first args))
+           (list (list :- "`if`") expr (first args)))
+
+         (= 2 (count args))
+         (apply list (list :- "`if`") expr args)
+
+         (<= 2 (count args))
+         (list (list :- "`if`") expr (first args)
+               (tf-infix-if (cons nil (rest (remove #(= % :else)
+                                                    args))))))))
+
+(defn tf-for-object
+  "transform for `for:object`"
+  {:added "4.0"}
+  [[_ [[k v] m] & body]]
+  (if (= k '_)
+    (apply list 'for [v :in (list '% m)]
+           body)
+    (apply list 'for [k :in (list 'names m)]
+           (concat (if (not= v '_)
+                     [(list ':= v (list '. m [k]))])
+                   body))))
+
+(defn tf-for-array
+  "transform for `for:array`"
+  {:added "4.0"}
+  [[_ [e arr] & body]]
+  (if (vector? e)
+    (let [[i e] e]
+      (h/$ (do (var ~i := 0)
+               (for [~e :in (% ~arr)]
+                 (:= ~i (+ ~i 1))
+                 ~@body))))
+    (apply list 'for [e :in (list '% arr)]
+                body)))
+
+(defn tf-for-iter
+  "transform for `for:iter`"
+  {:added "4.0"}
+  [[_ [e it] & body]]
+  (h/$ (for [~e :in (% ~it)]
+         ~@body)))
+
+(defn tf-for-index
+  "transform for `for:index`"
+  {:added "4.0"}
+  [[_ [i [start end step]] & body]]
+  (h/$ (for [~i :in (seq ~start
+                         ~end
+                         ~(or step 1))]
+         ~@body)))
+
+(defn tf-for-return
+  "transform for `for:return`"
+  {:added "4.0"}
+  [[_ [[res err] statement] {:keys [success error]}]]
+  (h/$ (tryCatch
+        (block
+         (var ~res ~statement)
+         ~success)
+        :error (fn [~err] ~error))))
+
+(defn- r-token-boolean
+  [bool]
+  (if bool "TRUE" "FALSE"))
+
+(def +features+
+  (-> (merge (grammar/build :include [:builtin
+                                      :builtin-global
+                                      :builtin-module
+                                      :builtin-helper
+                                      :free-control
+                                      :free-literal
+                                      :math
+                                      :compare
+                                      :logic
+                                      :block
+                                      :data-shortcuts
+                                      :data-range
+                                      :vars
+                                      :fn
+                                      :control-base
+                                      :control-general
+                                      :top-base
+                                      :top-global
+                                      :top-declare
+                                      :for
+                                      :coroutine
+                                      :macro
+                                      :macro-arrow
+                                      :macro-let
+                                      :macro-xor])
+             (grammar/build-xtalk))
+      (grammar/build:override
+       {:seteq       {:op :seteq :symbol '#{:=} :raw "<-"}
+        :mod         {:raw "%%"}
+        :defn        {:op :defn  :symbol '#{defn}     :macro  #'tf-defn :type :macro}
+        :inif        {:macro #'tf-infix-if   :emit :macro}
+        :for-object  {:macro #'tf-for-object :emit :macro}
+        :for-array   {:macro #'tf-for-array  :emit :macro}
+        :for-iter    {:macro #'tf-for-iter   :emit :macro}
+        :for-index   {:macro #'tf-for-index  :emit :macro}
+        :for-return  {:macro #'tf-for-return :emit :macro}})
+      (grammar/build:override fn/+r+ )
+      (grammar/build:extend
+       {;;:na     {:op :na    :symbol '#{NA}    :raw "NA"    :value true :emit :throw}
+        :next   {:op :next  :symbol '#{:next} :raw "next"  :emit :return}
+        :throw  {:op :next  :symbol '#{throw} :raw 'stop :emit :alias}
+        :repeat {:op :repeat
+                 :symbol '#{repeat} :type :block
+                 :block {:raw "repeat"
+                         :main    #{:body}
+                         :control [[:until {:required true
+                                            :input #{:parameter}}]]}}})))
+
+(def +template+
+  (->> {:banned #{:set :keyword}
+        :highlight '#{block}
+        :default {:comment   {:prefix "#"}
+                  :common    {:apply "$" :assign "<-"}
+                  :invoke    {:space "" :assign "="}
+                  :function  {:raw "function"}
+                  :index     {:offset 1  :end-inclusive true
+                              :start "[[" :end "]]"}}
+        :token  {:nil       {:as "NULL"}
+                 :boolean   {:as #'r-token-boolean}
+                 :string    {:quote :single}
+                 :symbol    {}}
+        :data   {:vector    {:start "list(" :end ")" :space ""}
+                 :map       {:start "list(" :end ")" :space ""}
+                 :map-entry {:start ""  :end ""  :space "" :assign "=" :keyword :symbol}}
+        :define {:def       {:raw ""}
+                 :defn      {:raw ""}}}
+       (h/merge-nested (emit/default-grammar))))
+
+(def +grammar+
+  (grammar/grammar :R
+    (grammar/to-reserved +features+)
+    +template+))
+
+(def +meta+
+  (book/book-meta
+   {:module-current   (fn [])
+    :module-import    (fn [name {:keys [as refer]} opts]
+                        (list 'library name))
+    :module-export    (fn [name {:keys [as refer]} opts])}))
+
+(def +book+
+  (book/book {:lang :r
+              :parent :xtalk
+              :meta +meta+
+              :grammar +grammar+}))
+
+(def +init+
+  (script/install +book+))
+
+(comment
+  (bb.lang/script :r)
+
+  (!.R
+    (NA (+ 1 2 NA))))
+
+
+(comment
+  :on     {:op :on    :symbol '#{on :on}     :raw "~" :emit :bi}
+  :quot   {:op :quot  :symbol '#{quot}   :raw "%/%" :emit :bi}
+  :in     {:op :in    :symbol '#{in :in} :raw "%in%" :emit :bi}
+  :mmul   {:op :mmul  :symbol '#{*| mmul} :raw "%*%" :emit :bi}
+
+
+  (def +reserved+
+    (-> (grammar/ops :exclude [[:general :exclude [:try]]
+                               :type
+                               :counter
+                               :yield
+                               :infix
+                               [:return :exclude [:ret]]
+                               [:bit :exclude [:bitsl :bitsr]]])
+        (h/merge-nested
+         {:new    {:value true}
+          :setrq  {:op :setrq :symbol '#{:>} :raw "->"}
+          :neg    {:emit :invoke}
+
+          :defn   {:emit r-defn}
+
+          :prog   {:op :prog
+                   :symbol '#{prog} :type :block
+                   :block {:raw ""
+                           :main    #{:body}}}})
+        (grammar/map-symbols)))
+
+  )

--- a/src/bb/lang/model/spec_ruby.clj
+++ b/src/bb/lang/model/spec_ruby.clj
@@ -1,0 +1,150 @@
+(ns bb.lang.model.spec-ruby
+  (:require [bb.lang.base.emit :as emit]
+            [bb.lang.base.grammar :as grammar]
+            [bb.lang.base.emit-common :as common]
+            [bb.lang.base.emit-helper :as helper]
+            [bb.lang.base.emit-preprocess :as preprocess]
+            [bb.lang.base.emit-top-level :as top]
+            [bb.lang.base.emit-data :as data]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.script :as script]
+            [bb.lang.base.util :as ut]
+            [bb.lang.model.spec-xtalk]
+            [bb.lang.model.spec-xtalk.fn-ruby :as fn]
+            [bb.string :as str]
+            [bb.lib :as h]))
+
+(defn ruby-symbol
+  "emit ruby symbol
+   (spec-ruby/ruby-symbol :a spec-ruby/+grammar+ {})
+   => \":a\"
+   (spec-ruby/ruby-symbol 'a spec-ruby/+grammar+ {})
+   => \"a\""
+  {:added "4.1"}
+  [sym grammar mopts]
+  (cond (keyword? sym)
+        (str ":" (name sym))
+
+        :else
+        (common/emit-symbol sym grammar mopts)))
+
+(defn ruby-var
+  "emit ruby variable
+   (spec-ruby/ruby-var '(var a 1))
+   => '(:= a 1)"
+  {:added "4.1"}
+  [[_ sym & args]]
+  (list ':= sym (last args)))
+
+(defn ruby-map
+  "emit ruby hash
+   (l/emit-as :ruby '[{:a 1 :b 2}])
+   => \"{:a => 1, :b => 2}\""
+  {:added "4.1"}
+  [m grammar mopts]
+  (let [entries (map (fn [[k v]]
+                       (str (common/*emit-fn* k grammar mopts)
+                            " => "
+                            (common/*emit-fn* v grammar mopts)))
+                     m)]
+    (str "{" (str/join ", " entries) "}")))
+
+(defn ruby-fn
+  "basic transform for ruby blocks
+   (spec-ruby/ruby-fn '(fn [a] (+ a 1)))
+   => '(fn.inner [a] (+ a 1))"
+  {:added "4.1"}
+  ([[_ & args]]
+   (let [[args & body] args]
+     (apply list :- :lambda
+            (concat (if (not-empty args)
+                      [(list 'quote args) "{"]
+                      ["{"])
+                    body
+                    ["}"])))))
+
+(def +features+
+  (-> (grammar/build :exclude [:pointer :block :data-range])
+      (grammar/build:override
+       {:var        {:macro #'ruby-var :emit :macro}
+        :and        {:raw "&&"}
+        :or         {:raw "||"}
+        :not        {:raw "!" :emit :prefix}
+        :eq         {:raw "=="}
+        :fn         {:macro  #'ruby-fn   :type :macro}
+        :neq        {:raw "!="}
+        :gt         {:raw ">"}
+        :lt         {:raw "<"}
+        :gte        {:raw ">="}
+        :lte        {:raw "<="}})
+      (grammar/build:override fn/+ruby+)
+      (grammar/build:extend
+       {:assign     {:op :assign :symbol #{':=} :raw "=" :emit :infix}
+        :puts       {:op :puts :symbol #{'puts} :raw "puts" :emit :prefix}
+        :nil?       {:op :nil? :symbol #{'nil?} :raw "nil?" :emit :postfix}
+        :attr       {:op :attr :symbol #{'attr_accessor} :raw "attr_accessor" :emit :prefix}
+        :end        {:op :end  :symbol #{'end}  :raw "end"  :emit :token}})))
+
+(def +template+
+  (->> {:banned #{}
+        :allow   {:assign  #{:symbol}}
+        :default {:common    {:statement ""}
+                  :block     {:parameter {:start " " :end ""}
+                              :body      {:start "" :end "end" :append false}}
+                  :invoke    {:start "("}
+                  :function  {:raw "def"
+                              :body      {:start "" :end "end"}}}
+        :block   {:try      {:raw  "begin"
+                             :wrap {:start "" :end "end"}
+                             :body {:start "" :end ""}
+                             :control {:catch  {:raw  "rescue Exception =>"
+                                                :body {:start "" :end ""}}}}}
+        :token   {:nil       {:as "nil"}
+                  :boolean   {:as (fn [b] (if b "true" "false"))}
+                  :string    {:quote :double}
+                  :symbol    {:custom #'ruby-symbol}}
+        :data    {:vector    {:start "[" :end "]" :space ""}
+                  :map       {:custom #'ruby-map}}
+        :function {:defn      {:raw "def"
+                               :body      {:start "" :end "end"}}}
+        :define   {:def       {:raw "def"}
+                   :defglobal {:raw "def"}}}
+       (h/merge-nested (emit/default-grammar))))
+
+
+(comment
+  :try     {:raw "BEGIN"
+            :wrap    {:start "" :end "END;"}
+            :body    {:start "" :end "EXCEPTION"}
+            :control {:default {:parameter  {:start "" :end ""}
+                                :body {:append true
+                                       :start "" :end ""}}
+                      :catch   {:raw "WHEN"
+                                :parameter  {:start " " :end " THEN"}}}}
+
+  :default {:comment   {:prefix "--"}
+            :common    {:apply ":" :statement ""
+                        :namespace-full "___"
+                        :namespace-sep  "_"}
+            :index     {:offset 1  :end-inclusive true}
+            :return    {:multi true}
+            :block     {:parameter {:start " " :end " "}
+                        :body      {:start "" :end ""}}
+            :function  {:raw "function"
+                        :body      {:start "" :end "end"}}
+            :infix     {:if  {:check "and" :then "or"}}
+            :global    {:reference nil}})
+
+(def +grammar+
+  (grammar/grammar :rb
+    (grammar/to-reserved +features+)
+    +template+))
+
+(def +book+
+  (book/book {:lang :ruby
+              :parent :xtalk
+              :meta (book/book-meta {})
+              :grammar +grammar+}))
+
+(def +init+
+  (script/install +book+))

--- a/src/bb/lang/model/spec_rust.clj
+++ b/src/bb/lang/model/spec_rust.clj
@@ -1,0 +1,230 @@
+(ns bb.lang.model.spec-rust
+  (:require [bb.lang.base.emit :as emit]
+            [bb.lang.base.emit-fn :as fn]
+            [bb.lang.base.emit-data :as data]
+            [bb.lang.base.emit-helper :as helper]
+            [bb.lang.base.grammar :as grammar]
+            [bb.lang.base.util :as ut]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.script :as script]
+            [bb.string :as str]
+            [bb.lib :as h]))
+
+(defn rst-typesystem
+  "TODO"
+  {:added "4.0"}
+  [arr grammar mopts]
+  (let [{:keys [sep] :as opts} (helper/get-options grammar [:data :vector])
+        [sym & more] (rest arr)]
+    (str sym "<" (str/join ","
+                           (map (fn [input]
+                                  (cond (string? input)
+                                        input
+
+                                        :else
+                                        (emit/emit-main input grammar mopts)))
+                                more))">")))
+
+(defn rst-vector
+  "TODO"
+  {:added "4.0"}
+  ([arr grammar mopts]
+   (let [sym (first arr)]
+     (cond (= :> sym)
+           (rst-typesystem arr grammar mopts)
+
+           :else
+           (data/emit-coll :vector arr grammar mopts)))))
+
+(defn rst-attributes
+  "TODO"
+  {:added "4.0"}
+  [sym]
+  (let [lines (:% (meta sym))]
+    (str/join ""
+              (map (fn [l] (str l "\n"))
+                   lines))))
+
+(defn rst-defenum
+  "TODO"
+  {:added "4.0"}
+  [[_ sym values]]
+  (list :%
+        (list :- (rst-attributes sym))
+        (list :- "enum" sym
+              (list :- "{")
+              (list 'quote (vec values))
+              (list :- "}"))))
+
+(defn rst-deftrait
+  "TODO"
+  {:added "4.0"}
+  [[_ sym & body]]
+  (let [body (h/postwalk (fn [x]
+                           (if (and (list? x)
+                                    (= 'fn (first x))
+                                    (= 3 (count x)))
+                             (apply list 'fn (with-meta (second x)
+                                               (merge (meta (second x))
+                                                      {:header true}))
+                                    (drop 2 x))
+                             x))
+                         body)]
+    (list :%
+          (list :- (rst-attributes sym))
+          (list :- "trait" sym
+                (list :- "{"
+                      (list \\
+                            \\ (list \| (apply list 'do body))))
+                (list :- "\n}")))))
+
+(defn rst-defimpl
+  "TODO"
+  {:added "4.0"}
+  ([[_ sym inherit & body]]
+   (list :%
+         (list :- (rst-attributes sym))
+         (list :- "impl" (first inherit) "for" (last inherit)
+               (list :- "{")
+               (list \\
+                     \\ (list \|
+                              (apply list 'do body)))
+               (list :- "\n}")))))
+
+(defn rst-new
+  "TODO"
+  {:added "4.0"}
+  [[_ sym & args] grammar mopts]
+  (let [items (map (fn [[k v]]
+                     (str (h/strn k) ": " (emit/emit-main v grammar mopts)))
+                   (partition 2 args))]
+    (str (emit/emit-main sym grammar mopts)
+         "{" (str/join ", " items) "}")))
+
+(defn rst-exec
+  "TODO"
+  {:added "4.0"}
+  [[_ & body] grammar mopts]
+  (str "{"
+       (emit/emit-main
+        (list \\
+              \\(list \| (apply list 'do body))) grammar mopts)
+       "\n}"))
+
+(defn rst-defstruct
+  "TODO"
+  {:added "4.0"}
+  [[_ sym items] grammar mopts]
+  (str (rst-attributes sym)
+       (cond (empty? items)
+             (str "struct " sym ";")
+
+
+             (and (vector? items)
+                  (symbol? (first items)))
+             (str "struct " sym "[\n"
+                  (str/join "\n  " items)
+                  "\n]")
+
+             :else
+             (let [strs (mapcat (fn [args]
+                                  (fn/emit-fn-preamble-args
+                                   :fn args
+                                   grammar mopts))
+                                items)]
+               (str "struct " sym "{" (str/join ", " strs) "}")))))
+
+(def +features+
+  (-> (grammar/build)
+      (grammar/build:override
+       {:var        {:symbol '#{var} :raw "let" }
+        :range      {:raw ".."}
+        :new        {:symbol #{'new}
+                     :emit  #'rst-new
+                     :value true :raw "new"}})
+      (grammar/build:extend
+       {:ptr-quote     {:op :ptr-quote  :symbol '#{:'}   :raw "'" :emit :pre}
+        :ptr-qderef    {:op :ptr-qderef :symbol '#{:&'}  :raw "&'" :emit :pre}
+        :range-pattern {:op :range-pattern :symbol '#{:to=}  :raw "..=" :emit :between}
+        :cast          {:op :cast :symbol '#{cast}  :raw "_" :emit :between}
+        :as            {:op :as :symbol '#{:as}  :raw "as" :emit :infix}
+        :unsafe {:op :unsafe
+                 :symbol '#{unsafe} :type :block
+                 :block {:raw "unsafe"
+                         :main    #{:body}
+                         :control []}}
+        :exec      {:op :exec
+                    :symbol '#{exec}  :raw ""
+                    :emit  #'rst-exec}})
+      (grammar/build:extend
+       {:defstruct  {:op :defstruct :symbol '#{defstruct}
+                     :type :def :section :code
+                     :emit  #'rst-defstruct
+                     :static/type :struct}
+        :deftrait   {:op :deftrait :symbol '#{deftrait}
+                     :type :def :section :code :emit :macro
+                     :macro  #'rst-deftrait
+                     :static/type :trait}
+        :defenum    {:op :defenum :symbol '#{defenum}
+                     :type :def :section :code :emit :macro
+                     :macro  #'rst-defenum
+                     :static/type :enum}
+        :defimpl    {:op :defimpl :symbol '#{defimpl}
+                     :type :def :section :code :emit :macro
+                     :macro  #'rst-defimpl
+                     :static/type :impl}})))
+
+(def +sym-replace+
+  {\- "_"
+   \= "_eq"
+   #_#_#_#_
+   \< "_lt"
+   \> "_gt"})
+
+(def +template+
+  (-> (emit/default-grammar)
+      (h/merge-nested
+       {:banned #{:set :map :regex}
+        :highlight '#{return break}
+        :default {:modifier  {:vector-last false}
+                  :function  {:prefix "fn"
+                              :raw ""
+                              :args {:sep ", "}}
+                  :typehint  {:enabled true :assign "->" :space " " :after true}
+                  :invoke    {:reversed true
+                              :hint ":"
+                              :space ""
+                              :static "::"}}
+        :token    {:keyword   {:custom #'name}}
+        :data     {:vector    {:custom #'rst-vector}
+                  :tuple      {:start "" :end "" :space ""}}
+        :block    {:for       {:parameter {:sep ","}}}
+        :function {:defn      {:raw ""
+                               :args  {:start "(" :end ")" :space ""}}
+                   :function  {:raw ""
+                               :args      {:start "|" :end "|" :space ""}
+                               :body      {:start "" :end "" :append true}}}
+        :define   {:defglobal {:raw "let"}
+                   :def       {:raw "let"}
+                   :declare   {:raw "let"}}})
+      (assoc-in [:token :symbol :replace] +sym-replace+)))
+
+(def +grammar+
+  (grammar/grammar :rs
+    (grammar/to-reserved +features+)
+    +template+))
+
+(def +meta+
+  (book/book-meta
+   {:module-current   (fn [])
+    :module-import    (fn [name _ opts]
+                        (list :- "#include" name))
+    :module-export    (fn [{:keys [as refer]} opts])}))
+
+(def +book+
+  (book/book {:lang :rust
+              :meta +meta+
+              :grammar +grammar+}))
+
+(def +init+
+  (script/install +book+))

--- a/src/bb/lang/model/spec_scheme.clj
+++ b/src/bb/lang/model/spec_scheme.clj
@@ -1,0 +1,64 @@
+(ns bb.lang.model.spec-scheme
+  (:require [bb.lang.base.emit :as emit]
+            [bb.lang.base.grammar :as grammar]
+            [bb.lang.base.util :as ut]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.script :as script]
+            [bb.string :as str]
+            [bb.lib :as h]
+            [bb.lang.model.spec-xtalk :as xtalk]))
+
+(def +replace+
+  '{==    =
+    fn:>  lambda
+    fn    lambda
+    nil   '()})
+
+(def +transform+
+  {'return   (fn [[_ & args]]
+               (first args))})
+
+(def +features+
+  (grammar/build-min [:coroutine
+                      :xtalk
+                      :xtalk-math
+                      :xtalk-type
+                      :xtalk-lu
+                      :xtalk-iter
+                      :xtalk-async
+                      :xtalk-obj
+                      :xtalk-arr
+                      :xtalk-fn
+                      :xtalk-str
+                      :xtalk-js]))
+
+(defn emit-scheme
+  "emits code into scheme schema"
+  {:added "4.0"}
+  [form mopts]
+  (pr-str
+   (h/prewalk (fn [x]
+                (if (h/form? x)
+                  (or (if-let [f (get +transform+ (first x))]
+                        (f x))
+                      (if-let [v (get +replace+ (first x))]
+                        (cons v (rest x)))
+                      x)
+                  x))
+              form)))
+
+(def +grammar+
+  (grammar/grammar :scm
+    (grammar/to-reserved +features+)
+    {:emit #'emit-scheme}))
+
+(def +meta+ (book/book-meta {}))
+
+(def +book+
+  (book/book {:lang :scheme
+              :parent :xtalk
+              :meta +meta+
+              :grammar +grammar+}))
+
+(def +init+
+  (script/install +book+))

--- a/src/bb/lang/model/spec_xtalk.clj
+++ b/src/bb/lang/model/spec_xtalk.clj
@@ -1,0 +1,32 @@
+(ns bb.lang.model.spec-xtalk
+  (:require [bb.lang.base.emit :as emit]
+            [bb.lang.base.grammar :as grammar]
+            [bb.lang.base.util :as ut]
+            [bb.lang.base.book :as book]
+            [bb.lang.base.script :as script]
+            [bb.string :as str]
+            [bb.lib :as h]))
+
+(def +features+
+  (-> (grammar/build-min [:top-declare
+                          :coroutine
+                          :macro
+                          :macro-arrow
+                          :macro-let])))
+
+(def +grammar+
+  (grammar/grammar :xt
+    (grammar/to-reserved +features+)
+    (emit/default-grammar
+     {:banned #{:keyword}
+      :allow   {:assign  #{:symbol :vector :set}}})))
+
+(def +meta+ (book/book-meta {}))
+
+(def +book+
+  (book/book {:lang :xtalk
+              :meta +meta+
+              :grammar +grammar+}))
+
+(def +init+
+  (script/install +book+))

--- a/src/bb/lang/model/spec_xtalk/com_js.clj
+++ b/src/bb/lang/model/spec_xtalk/com_js.clj
@@ -1,0 +1,188 @@
+(ns bb.lang.model.spec-xtalk.com-js
+  (:require [bb.lib :as h]))
+
+;;
+;; COM
+;;
+
+(defn js-tf-x-return-encode
+  ([[_ out id key]]
+   (h/$ (do (var type-fn (fn [x]
+                           (let [name (typeof x)]
+                             (return (:? (== name "object") (:? x x.constructor.name name) name)))))
+            (var tb (typeof ~out))
+            (cond (== "function" tb)
+                  (return (JSON.stringify {:id     ~id
+                                           :key    ~key
+                                           :type   "raw"
+                                           :return "function"
+                                           :value  (. ~out (toString))}))
+
+
+                  (not= "object" tb)
+                  (return (JSON.stringify {:id     ~id
+                                           :key    ~key
+                                           :type "data"
+                                           :return tb
+                                           :value ~out}))
+
+                  (== nil ~out)
+                  (return (JSON.stringify {:id     ~id
+                                           :key    ~key
+                                           :type "data"
+                                           :return "nil"
+                                           :value ~out}))
+
+                  :else
+                  (do (var ts (type-fn ~out))
+                      (try
+                        (if (or (== ts "Object")
+                                (== ts "Array"))
+                          (return (JSON.stringify {:id     ~id
+                                                   :key    ~key
+                                                   :type "data"
+                                                   :value ~out}))
+                          (return (JSON.stringify {:id     ~id
+                                                   :key    ~key
+                                                   :type  "raw"
+                                                   :return ts
+                                                   :value (. ~out (toString))})))
+                        (catch e (return (JSON.stringify {:id     id
+                                                          :key    key
+                                                          :type   "raw"
+                                                          :return ts
+                                                          :value (. ~out (toString))}))))))))))
+
+(defn js-tf-x-return-wrap
+  ([[_ f encode-fn]]
+   (h/$ (try (var out := (~f))
+             (return (~encode-fn  out))
+             (catch e (let [err (:? (== "string" (typeof e)) e {:message (. e ["message"]) :stack (. e ["stack"])})]
+                        (return (JSON.stringify {:type "error"
+                                                 :value err}))))))))
+
+(defn js-tf-x-return-eval
+  ([[_ s wrap-fn]]
+   (h/$ (return (~wrap-fn
+                 (fn []
+                   (return (eval ~s))))))))
+
+(def +js-return+
+  {:x-return-encode  {:macro #'js-tf-x-return-encode   :emit :macro}
+   :x-return-wrap    {:macro #'js-tf-x-return-wrap     :emit :macro}
+   :x-return-eval    {:macro #'js-tf-x-return-eval     :emit :macro}})
+
+(defn js-tf-x-socket-connect
+  ([[_ host port opts cb]]
+   (h/$ (do* (var net (eval "require('net')"))
+             (var rl  (eval  "require('readline')"))
+             (var conn (new net.Socket))
+             (return (conn.connect
+                      port host (fn []
+                                  (cb nil conn))))))))
+
+(defn js-tf-x-socket-send
+  ([[_ conn s]]
+   (h/$ (. ~conn (write ~s)))))
+
+(defn js-tf-x-socket-close
+  ([[_ conn]]
+   (h/$ (. ~conn (end)))))
+
+(def +js-socket+
+  {:x-socket-connect      {:macro #'js-tf-x-socket-connect      :emit :macro}
+   :x-socket-send         {:macro #'js-tf-x-socket-send         :emit :macro}
+   :x-socket-close        {:macro #'js-tf-x-socket-close        :emit :macro}})
+
+(defn js-tf-x-ws-connect
+  ([[_ host port opts]]
+   (h/$ (do (var WS := (or (!:G WebSocket)
+                           (require "ws")))
+            (var schema (or (. ~opts ["schema"]) "ws"))
+            (var url    (or (. ~opts ["url"]) "/"))
+            (var conn (new WS (+ schema "://" host ":" port url)))
+            (return [true conn])))))
+
+(defn js-tf-x-ws-send
+  ([[_ wb s]]
+   (h/$ (. ~wb (send ~s)))))
+
+(defn js-tf-x-ws-close
+  ([[_ wb]]
+   (h/$ (. ~wb (close)))))
+
+(def +js-ws+
+  {:x-ws-connect      {:macro #'js-tf-x-ws-connect      :emit :macro}
+   :x-ws-send         {:macro #'js-tf-x-ws-send         :emit :macro}
+   :x-ws-close        {:macro #'js-tf-x-ws-close        :emit :macro}})
+
+(defn js-tf-x-notify-socket
+  ([[_ host port value id key
+     connect-fn
+     encode-fn]]
+   (h/$ (try
+          (var [ok conn] (~connect-fn host port
+                          {:cb  (fn []
+                                  (client.end (~encode-fn ~value ~id ~key)
+                                              "utf8"))}))
+          (return ["async"])
+          (catch e (return ["unable to connect"]))))))
+
+(defn js-tf-x-notify-http
+  ([[_ host port value id key encode-fn]]
+   (h/$ (try
+          (fetch (+ "http://" ~host ":" ~port)
+                 {:method "POST"
+                  :body (~encode-fn ~value ~id ~key)})
+         (return ["async"])
+         (catch e (return ["unable to connect"]))))))
+
+(def +js-notify+
+  {:x-notify-socket  {:macro #'js-tf-x-notify-socket    :emit :macro}
+   :x-notify-http    {:macro #'js-tf-x-notify-http    :emit :macro}})
+
+(defn js-tf-x-client-basic
+  ([[_ host port connect-fn eval-fn]]
+   (h/$ (do (var [ok conn] (~connect-fn host port {}))
+            (var rl  (require "readline"))
+            (var stream  (rl.createInterface conn
+                                             conn))
+            (stream.on "line" (fn [line] (~eval-fn conn line)))))))
+
+(defn js-tf-x-client-ws
+  [[_ host port opts connect-fn eval-fn]]
+  (h/$ (do (var [ok conn] (~connect-fn ~host ~port {}))
+           (:=  (. conn onmessage)
+                (fn [msg]
+                  (~eval-fn conn msg.data))))))
+
+(def +js-client+
+  {:x-client-basic  {:macro #'js-tf-x-client-basic  :emit :macro}
+   :x-client-ws     {:macro #'js-tf-x-client-ws     :emit :macro}})
+
+(defn js-tf-x-print
+  ([[_ & args]]
+   (apply list 'console.log args)))
+
+(defn js-tf-x-shell
+  ([[_ s cm]]
+   (h/$ (do (var p (require "child_process"))
+            (p.exec ~s (fn [err res]
+                         (if err
+                           (if (. ~cm ["error"])
+                             (return (. ~cm (error err))))
+                           (if (. ~cm ["success"])
+                             (return (. ~cm (success res)))))))
+            (return ["async"])))))
+
+(def +js-shell+
+  {:x-print    {:macro #'js-tf-x-print         :emit :macro}
+   :x-shell    {:macro #'js-tf-x-shell         :emit :macro}})
+
+(def +js-com+
+  (merge +js-return+
+         +js-socket+
+         +js-ws+
+         +js-notify+
+         +js-client+
+         +js-shell+))

--- a/src/bb/lang/model/spec_xtalk/com_lua.clj
+++ b/src/bb/lang/model/spec_xtalk/com_lua.clj
@@ -1,0 +1,199 @@
+^{:no-test true}
+(ns bb.lang.model.spec-xtalk.com-lua
+  (:require [bb.lib :as h]))
+
+;;
+;; COM
+;;
+
+(defn lua-tf-x-return-encode
+  ([[_ out id key]]
+   (h/$ (do (do (local ret nil)
+                (local [r-ok r-err]
+                       (pcall (fn []
+                                (cond (== nil ~out)
+                                      (:= ret (cjson.encode {:id  ~id
+                                                             :key ~key
+                                                             :type "data"
+                                                             :value (. cjson ["null"])}))
+
+                                      :else
+                                      (:= ret (cjson.encode {:id  ~id
+                                                             :key ~key
+                                                             :type "data"
+                                                             :value ~out}))))))
+                (cond r-err
+                      (return (cjson.encode {:id  ~id
+                                             :key ~key
+                                             :type "raw"
+                                             :error (tostring r-err)
+                                             :value (tostring ~out)}))
+
+                      :else
+                      (return ret)))))))
+
+(defn lua-tf-x-return-wrap
+  ([[_ f encode-fn]]
+   (h/$ (do (local out)
+            (local [o-ok o-err] (pcall (fn [] (:= out (~f)))))
+            (cond o-err
+                  (return (cjson.encode {:type "error"
+                                         :value o-err}))
+
+                  :else
+                  (return (~encode-fn out)))))))
+
+(defn lua-tf-x-return-eval
+  ([[_ s wrap-fn]]
+   (h/$ (return (~wrap-fn
+                 (fn []
+                   (local load-fn (or loadstring load))
+                   (local [f err] (load-fn ~s))
+                   (if err
+                     (error err)
+                     (return (f)))))))))
+
+(def +lua-return+
+  {:x-return-encode  {:macro #'lua-tf-x-return-encode   :emit :macro}
+   :x-return-wrap    {:macro #'lua-tf-x-return-wrap     :emit :macro}
+   :x-return-eval    {:macro #'lua-tf-x-return-eval     :emit :macro}})
+
+(defn lua-tf-x-socket-connect
+  ([[_ host port opts]]
+   (h/$ (do* (local [conn err])
+             (if ngx
+               (do (:= conn (ngx.socket.tcp))
+                   (:= '[_ err]  (conn:connect ~host ~port)))
+               (do (local socket (require "socket"))
+                   (:= '[conn err] (socket.connect ~host ~port))))
+             (return conn err)))))
+
+(defn lua-tf-x-socket-send
+  ([[_ conn s]]
+   (h/$ (. ~conn (send ~s)))))
+
+(defn lua-tf-x-socket-close
+  ([[_ conn]]
+   (h/$ (. ~conn (close)))))
+
+(def +lua-socket+
+  {:x-socket-connect      {:macro #'lua-tf-x-socket-connect      :emit :macro}
+   :x-socket-send         {:macro #'lua-tf-x-socket-send         :emit :macro}
+   :x-socket-close        {:macro #'lua-tf-x-socket-close        :emit :macro}})
+
+(defn lua-tf-x-ws-connect
+  ([[_ host port opts]]
+   (h/$ (do* (var client := (require "resty.websocket.client"))
+             (var [wb err] (client:new))
+             (var uri (cat (or (. ~opts ["schema"])
+                               "ws")
+                           "://"
+                           ~host
+                           ":"
+                           ~port
+                           (or (. ~opts ["url"]) "/")))
+             (var [ok err] (wb:connect uri))
+             (if (not err)
+               (return [true  wb])
+               (return [false err]))))))
+
+(defn lua-tf-x-ws-send
+  ([[_ wb s]]
+   (h/$ (. ~wb (send-text ~s)))))
+
+(defn lua-tf-x-ws-close
+  ([[_ wb]]
+   (h/$ (. ~wb (close)))))
+
+(def +lua-ws+
+  {:x-ws-connect      {:macro #'lua-tf-x-ws-connect      :emit :macro}
+   :x-ws-send         {:macro #'lua-tf-x-ws-send         :emit :macro}
+   :x-ws-close        {:macro #'lua-tf-x-ws-close        :emit :macro}})
+
+(def +lua-notify+
+  {})
+
+(defn lua-tf-x-client-basic
+  ([[_ host port connect-fn eval-fn]]
+   (h/$ (do* (while true
+               (var '[ok conn] := (unpack (~connect-fn ~host ~port {})))
+               (when (not ok)
+                 (return))
+               (pcall (fn []
+                        (while true
+                          (local [raw err] (conn:receive "*l"))
+                          (if err (break))
+                          (~eval-fn conn raw)))))))))
+
+(defn lua-tf-x-client-ws
+  ([[_ host port opts connect-fn eval-fn]]
+   (h/$ (do* (var '[ok conn] := (unpack (~connect-fn ~host ~port ~opts)))
+             (while true
+               (local [raw type err] (conn:recv-frame))
+               (when err
+                 (ngx.say (cat "failed to read frame: " err))
+                 (break))
+               (when raw
+                 (~eval-fn conn raw)))))))
+
+(def +lua-client+
+  {:x-client-basic  {:macro #'lua-tf-x-client-basic  :emit :macro}
+   :x-client-ws     {:macro #'lua-tf-x-client-ws     :emit :macro}})
+
+
+(defn lua-tf-x-print
+  ([[_ & args]]
+   (apply list 'print args)))
+
+(defn lua-tf-x-shell
+  ([[_ s cm]]
+   (h/$ (do* (var handle (io.popen ~s))
+             (var res (handle:read "*a"))
+             (var f (. ~cm ["success"]))
+             (if f
+               (return (f res))
+               (return res))))))
+
+(def +lua-shell+
+  {:x-print    {:macro #'lua-tf-x-print         :emit :macro}
+   :x-shell    {:macro #'lua-tf-x-shell         :emit :macro}})
+
+
+(def +lua-com+
+  (merge +lua-return+
+         +lua-socket+
+         +lua-ws+
+         +lua-notify+
+         +lua-client+
+         +lua-shell+))
+
+(comment
+
+  (defn lua-tf-x-socket-server
+    ([[_ port handle-line]]
+     (h/$ (do* (var socket (require "socket"))
+               (var server (assert (socket.bind "*" ~port)))
+               (. server (settimeout 0))
+               (var connections {})
+
+               (var handler (fn []
+                              (var [raw err] (conn:receive "*l"))
+                              (if err
+                                (return true)
+                                (do (handle-line raw)
+                                    (return false)))))
+               (while true
+                 (var new-conn (. server (accept server)))
+
+                 (when new-conn
+                   (. new-conn (settimeout 0))
+                   (table.insert connections new-conn))
+
+                 (var readList (socket.select [server (unpack connections)]))
+                 (for [i conn :in (ipairs readList)]
+                   (if (and (not= conn server)
+                            (handle-line conn))
+                     ;; CLEANUP
+                     (for [i v :in (ipairs connections)]
+                       (if (== v conn)
+                         (table.remove connections i)))))))))))

--- a/src/bb/lang/model/spec_xtalk/com_python.clj
+++ b/src/bb/lang/model/spec_xtalk/com_python.clj
@@ -1,0 +1,135 @@
+(ns bb.lang.model.spec-xtalk.com-python
+  (:require [bb.lib :as h]))
+
+(defn python-tf-x-return-encode
+  ([[_ out id key]]
+   (h/$ (do (:- :import json)
+            (try
+              (return (json.dumps {:id  ~id
+                                   :key ~key
+                                   :type  "data"
+                                   :value  ~out}))
+              (catch Exception
+                  (return (json.dumps {:id ~id
+                                       :key ~key
+                                       :type  "raw"
+                                       :value (str ~out)}))))))))
+
+(defn python-tf-x-return-wrap
+  ([[_ f encode-fn]]
+   (h/$ (do (:- :import json)
+            (try (:= out (~f))
+                 (catch [Exception :as e]
+                     (return (json.dumps {:type "error"
+                                          :value (str e)}))))
+            (return (~encode-fn out nil nil))))))
+
+(defn python-tf-x-return-eval
+  ([[_ s wrap-fn]]
+   (h/$ (do (fn thunk []
+              (let [g   (globals)]
+                (exec ~s g g)
+                (return (g.get "OUT"))))
+            (return (~wrap-fn thunk))))))
+
+(def +python-return+
+  {:x-return-encode  {:macro #'python-tf-x-return-encode   :emit :macro}
+   :x-return-wrap    {:macro #'python-tf-x-return-wrap     :emit :macro}
+   :x-return-eval    {:macro #'python-tf-x-return-eval     :emit :macro}})
+
+(defn python-tf-x-socket-connect
+  ([[_ host port opts]]
+   (h/$ (do (:- :import socket)
+            (var conn   (socket.socket))
+            (conn.connect '(host port))
+            (return conn)))))
+
+(defn python-tf-x-socket-send
+  ([[_ conn s]]
+   (h/$ (. ~conn (sendall (. ~s (encode)))))))
+
+(defn python-tf-x-socket-close
+  ([[_ conn]]
+   (h/$ (. ~conn (close)))))
+
+(def +python-socket+
+  {:x-socket-connect      {:macro #'python-tf-x-socket-connect      :emit :macro}
+   :x-socket-send         {:macro #'python-tf-x-socket-send         :emit :macro}
+   :x-socket-close        {:macro #'python-tf-x-socket-close        :emit :macro}})
+
+(defn python-tf-x-ws-connect
+  ([[_ host port opts]]
+   (h/$ (do (:- :import json)
+            (:- :import websocket)
+            (let [schema (:? (hasattr ~opts "schema") (getattr (unquote opts) "schema") "ws")
+                  url    (:? (hasattr ~opts "url") (getattr (unquote opts) "url") "")
+                  conn   (websocket.WebSocketApp
+                          (+ schema "://" ~host ":" (str ~port) url)
+                          :on-message (. ~opts ["cb"]))]
+              (return [true conn]))))))
+
+(defn python-tf-x-ws-send
+  ([[_ wb s]]
+   (h/$ (. ~wb (send ~s)))))
+
+(defn python-tf-x-ws-close
+  ([[_ wb]]
+   (h/$ (. ~wb (close)))))
+
+(def +python-ws+
+  {:x-ws-connect      {:macro #'python-tf-x-ws-connect      :emit :macro}
+   :x-ws-send         {:macro #'python-tf-x-ws-send         :emit :macro}
+   :x-ws-close        {:macro #'python-tf-x-ws-close        :emit :macro}})
+
+(def +python-notify+
+  {})
+
+(defn python-tf-x-client-basic
+  ([[_ host port connect-fn eval-fn]]
+   (h/$ (do (:= '[ok conn] (~connect-fn ~host ~port {}))
+          (while true
+            (let [raw ""
+                  ch (conn.recv 1)
+                  _  (if (== ch (:% b ""))
+                       (break))
+                  _  (while (not= ch (:% b "\n"))
+                       (:+= raw (ch.decode))
+                       (:= ch (conn.recv 1)))]
+              (~eval-fn conn raw)))))))
+
+(defn python-tf-x-client-ws
+  ([[_ host port opts connect-fn eval-fn]]
+   (h/$ (do (:= '[ok conn] (~connect-fn ~host ~port {:cb ~eval-fn}))
+            (:- :import threading)
+            (-> (. threading
+                   (Thread
+                    :target (fn [] (conn.run-forever)))
+                   (start)))))))
+
+(def +python-client+
+  {:x-client-basic  {:macro #'python-tf-x-client-basic  :emit :macro}
+   :x-client-ws     {:macro #'python-tf-x-client-ws     :emit :macro}})
+
+(defn python-tf-x-print
+  ([[_ & args]]
+   (apply list 'print args)))
+
+(defn python-tf-x-shell
+  ([[_ s cm]]
+   (h/$ (do (var res (. (__import__ "os") (system ~s)))
+            (var f (. ~cm (get "success")))
+            (if f
+              (return (f res))
+              (return res))))))
+
+(def +python-shell+
+  {:x-print    {:macro #'python-tf-x-print         :emit :macro}
+   :x-shell    {:macro #'python-tf-x-shell         :emit :macro}})
+
+(def +python-com+
+  (merge +python-return+
+         +python-socket+
+         +python-ws+
+         +python-notify+
+         +python-client+
+         +python-shell+))

--- a/src/bb/lang/model/spec_xtalk/com_r.clj
+++ b/src/bb/lang/model/spec_xtalk/com_r.clj
@@ -1,0 +1,90 @@
+(ns bb.lang.model.spec-xtalk.com-r
+  (:require [bb.lib :as h]))
+
+;;
+;; COM
+;;
+
+(defn r-tf-x-return-encode
+  ([[_ out id key]]
+   (h/$ (do* (library "jsonlite")
+             (tryCatch (block (toJSON {:type "data"
+                                       :value ~out
+                                       :id ~id
+                                       :key ~key}
+                                      :auto-unbox true :null "null"))
+                       :error (fn [err]
+                                (toJSON {:type "raw"
+                                         :value (toString out)
+                                         :id ~id
+                                         :key ~key}
+                                        :auto-unbox true :null "null")))))))
+
+(defn r-tf-x-return-wrap
+  ([[_ f encode-fn]]
+   (h/$ (do* (library "jsonlite")
+             (tryCatch
+              (block
+               (:= out (~f))
+               (~encode-fn out nil nil))
+              :error   (fn [err]
+                         (paste "{\"type\":\"error\",\"value\":"
+                                (toJSON (toString err))
+                                "}")))))))
+
+(defn r-tf-x-return-eval
+  ([[_ s wrap-fn]]
+   (h/$ (return (~wrap-fn
+                 (fn []
+                   (eval (parse :text ~s))))))))
+
+(def +r-return+
+  {:x-return-encode  {:macro #'r-tf-x-return-encode   :emit :macro}
+   :x-return-wrap    {:macro #'r-tf-x-return-wrap     :emit :macro}
+   :x-return-eval    {:macro #'r-tf-x-return-eval     :emit :macro}})
+
+(defn r-tf-x-socket-connect
+  ([[_ host port opts]]
+   (h/$ (do* (return (socketConnection :port ~port :blocking true))))))
+
+(defn r-tf-x-socket-send
+  ([[_ conn s]]
+   (h/$ (writeLines ~s ~conn :sep "\n"))))
+
+(defn r-tf-x-socket-close
+  ([[_ conn]]
+   (h/$ (close ~conn))))
+
+(def +r-socket+
+  {:x-socket-connect      {:macro #'r-tf-x-socket-connect      :emit :macro}
+   :x-socket-send         {:macro #'r-tf-x-socket-send         :emit :macro}
+   :x-socket-close        {:macro #'r-tf-x-socket-close        :emit :macro}})
+
+(def +r-ws+
+  {})
+
+(def +r-notify+
+  {})
+
+(def +r-client+
+  {})
+
+(defn r-tf-x-print
+  ([[_ & args]]
+   (apply list 'print args)))
+
+(defn r-tf-x-shell
+  ([[_ s cm]]
+   (h/$ (system ~s))))
+
+(def +r-shell+
+  {:x-print    {:macro #'r-tf-x-print         :emit :macro}
+   :x-shell    {:macro #'r-tf-x-shell         :emit :macro}})
+
+(def +r-com+
+  (merge +r-return+
+         +r-socket+
+         +r-ws+
+         +r-notify+
+         +r-client+
+         +r-shell+))

--- a/src/bb/lang/model/spec_xtalk/fn_erlang.clj
+++ b/src/bb/lang/model/spec_xtalk/fn_erlang.clj
@@ -1,0 +1,301 @@
+(ns bb.lang.model.spec-xtalk.fn-erlang
+  (:require [bb.lib :as h]
+            [bb.string :as str]))
+
+;;
+;; HELPER
+;;
+
+(defn erlang-tf-x-fn
+  ([[_ & args]]
+   (cons 'fn args)))
+
+;;
+;; GLOBAL
+;;
+
+(def +erlang-global+
+  {})
+
+;;
+;; MATH
+;;
+
+(defn erlang-tf-x-m-abs   [[_ num]] (list 'abs num))
+(defn erlang-tf-x-m-acos  [[_ num]] (list :call "math" "acos" num))
+(defn erlang-tf-x-m-asin  [[_ num]] (list :call "math" "asin" num))
+(defn erlang-tf-x-m-atan  [[_ num]] (list :call "math" "atan" num))
+(defn erlang-tf-x-m-ceil  [[_ num]] (list :call "math" "ceil" num))
+(defn erlang-tf-x-m-cos   [[_ num]] (list :call "math" "cos" num))
+(defn erlang-tf-x-m-cosh  [[_ num]] (list :call "math" "cosh" num))
+(defn erlang-tf-x-m-exp   [[_ num]] (list :call "math" "exp" num))
+(defn erlang-tf-x-m-floor [[_ num]] (list :call "math" "floor" num))
+(defn erlang-tf-x-m-loge  [[_ num]] (list :call "math" "log" num))
+(defn erlang-tf-x-m-log10 [[_ num]] (list :call "math" "log10" num))
+(defn erlang-tf-x-m-max   [[_ & args]] (apply list 'max args))
+(defn erlang-tf-x-m-min   [[_ & args]] (apply list 'min args))
+(defn erlang-tf-x-m-mod   [[_ num denom]] (list 'rem num denom))
+(defn erlang-tf-x-m-pow   [[_ base n]] (list :call "math" "pow" base n))
+(defn erlang-tf-x-m-quot  [[_ num denom]] (list 'div num denom))
+(defn erlang-tf-x-m-sin   [[_ num]] (list :call "math" "sin" num))
+(defn erlang-tf-x-m-sinh  [[_ num]] (list :call "math" "sinh" num))
+(defn erlang-tf-x-m-sqrt  [[_ num]] (list :call "math" "sqrt" num))
+(defn erlang-tf-x-m-tan   [[_ num]] (list :call "math" "tan" num))
+(defn erlang-tf-x-m-tanh  [[_ num]] (list :call "math" "tanh" num))
+
+(def +erlang-math+
+  {:x-m-abs           {:macro #'erlang-tf-x-m-abs,                 :emit :macro}
+   :x-m-acos          {:macro #'erlang-tf-x-m-acos,                :emit :macro}
+   :x-m-asin          {:macro #'erlang-tf-x-m-asin,                :emit :macro}
+   :x-m-atan          {:macro #'erlang-tf-x-m-atan,                :emit :macro}
+   :x-m-ceil          {:macro #'erlang-tf-x-m-ceil,                :emit :macro}
+   :x-m-cos           {:macro #'erlang-tf-x-m-cos,                 :emit :macro}
+   :x-m-cosh          {:macro #'erlang-tf-x-m-cosh,                :emit :macro}
+   :x-m-exp           {:macro #'erlang-tf-x-m-exp,                 :emit :macro}
+   :x-m-floor         {:macro #'erlang-tf-x-m-floor,               :emit :macro}
+   :x-m-loge          {:macro #'erlang-tf-x-m-loge,                :emit :macro}
+   :x-m-log10         {:macro #'erlang-tf-x-m-log10,               :emit :macro}
+   :x-m-max           {:macro #'erlang-tf-x-m-max,                 :emit :macro}
+   :x-m-min           {:macro #'erlang-tf-x-m-min,                 :emit :macro}
+   :x-m-mod           {:macro #'erlang-tf-x-m-mod,                 :emit :macro}
+   :x-m-pow           {:macro #'erlang-tf-x-m-pow,                 :emit :macro}
+   :x-m-quot          {:macro #'erlang-tf-x-m-quot,                :emit :macro}
+   :x-m-sin           {:macro #'erlang-tf-x-m-sin,                 :emit :macro}
+   :x-m-sinh          {:macro #'erlang-tf-x-m-sinh,                :emit :macro}
+   :x-m-sqrt          {:macro #'erlang-tf-x-m-sqrt,                :emit :macro}
+   :x-m-tan           {:macro #'erlang-tf-x-m-tan,                 :emit :macro}
+   :x-m-tanh          {:macro #'erlang-tf-x-m-tanh,                :emit :macro}})
+
+;;
+;; TYPE
+;;
+
+(defn erlang-tf-x-to-string
+  [[_ e]]
+  (list :call "integer_to_list" e))
+
+(defn erlang-tf-x-to-number
+  [[_ e]]
+  (list :call "list_to_integer" e))
+
+(defn erlang-tf-x-is-string?
+  [[_ e]]
+  (list :call "is_list" e))
+
+(defn erlang-tf-x-is-number?
+  [[_ e]]
+  (list :call "is_number" e))
+
+(defn erlang-tf-x-is-integer?
+  [[_ e]]
+  (list :call "is_integer" e))
+
+(defn erlang-tf-x-is-boolean?
+  [[_ e]]
+  (list :call "is_boolean" e))
+
+(defn erlang-tf-x-is-function?
+  [[_ e]]
+  (list :call "is_function" e))
+
+(defn erlang-tf-x-is-object?
+  [[_ e]]
+  (list :call "is_map" e))
+
+(defn erlang-tf-x-is-array?
+  [[_ e]]
+  (list :call "is_list" e))
+
+(def +erlang-type+
+  {:x-to-string      {:macro #'erlang-tf-x-to-string :emit :macro}
+   :x-to-number      {:macro #'erlang-tf-x-to-number :emit :macro}
+   :x-is-string?     {:macro #'erlang-tf-x-is-string? :emit :macro}
+   :x-is-number?     {:macro #'erlang-tf-x-is-number? :emit :macro}
+   :x-is-integer?    {:macro #'erlang-tf-x-is-integer? :emit :macro}
+   :x-is-boolean?    {:macro #'erlang-tf-x-is-boolean? :emit :macro}
+   :x-is-function?   {:macro #'erlang-tf-x-is-function? :emit :macro}
+   :x-is-object?     {:macro #'erlang-tf-x-is-object? :emit :macro}
+   :x-is-array?      {:macro #'erlang-tf-x-is-array? :emit :macro}})
+
+;;
+;; OBJ
+;;
+
+(defn erlang-tf-x-obj-keys
+  [[_ obj]]
+  (list :call "maps" "keys" obj))
+
+(defn erlang-tf-x-obj-vals
+  [[_ obj]]
+  (list :call "maps" "values" obj))
+
+(defn erlang-tf-x-obj-pairs
+  [[_ obj]]
+  (list :call "maps" "to_list" obj))
+
+(defn erlang-tf-x-obj-clone
+  [[_ obj]]
+  obj) ;; immutable
+
+(def +erlang-obj+
+  {:x-obj-keys    {:macro #'erlang-tf-x-obj-keys   :emit :macro}
+   :x-obj-vals    {:macro #'erlang-tf-x-obj-vals   :emit :macro}
+   :x-obj-pairs   {:macro #'erlang-tf-x-obj-pairs  :emit :macro}
+   :x-obj-clone   {:macro #'erlang-tf-x-obj-clone  :emit :macro}})
+
+;;
+;; ARR
+;;
+
+(defn erlang-tf-x-arr-clone
+  [[_ arr]]
+  arr) ;; immutable
+
+(defn erlang-tf-x-arr-slice
+  [[_ arr start end]]
+  (list :call "lists" "sublist" arr (list '+ start 1) (list '- end start)))
+
+(defn erlang-tf-x-arr-push
+  [[_ arr item]]
+  (list :call "lists" "append" arr (list 'list item)))
+
+(defn erlang-tf-x-arr-pop
+  [[_ arr]]
+  (list :call "lists" "droplast" arr))
+
+(defn erlang-tf-x-arr-reverse
+  [[_ arr]]
+  (list :call "lists" "reverse" arr))
+
+(defn erlang-tf-x-arr-push-first
+  [[_ arr item]]
+  (list 'list* item arr))
+
+(defn erlang-tf-x-arr-pop-first
+  [[_ arr]]
+  (list 'tl arr))
+
+(defn erlang-tf-x-arr-insert
+  [[_ arr idx e]]
+  (list 'let ['(tuple L1 L2) (list :call "lists" "split" idx arr)]
+        (list :call "lists" "append" 'L1 (list :call "lists" "append" (list 'list e) 'L2))))
+
+(defn erlang-tf-x-arr-sort
+  [[_ arr key-fn compare-fn]]
+  (list :call "lists" "sort" arr))
+
+(def +erlang-arr+
+  {:x-arr-clone       {:macro #'erlang-tf-x-arr-clone      :emit :macro}
+   :x-arr-slice       {:macro #'erlang-tf-x-arr-slice      :emit :macro}
+   :x-arr-reverse     {:macro #'erlang-tf-x-arr-reverse    :emit :macro}
+   :x-arr-push        {:macro #'erlang-tf-x-arr-push       :emit :macro}
+   :x-arr-pop         {:macro #'erlang-tf-x-arr-pop        :emit :macro}
+   :x-arr-push-first  {:macro #'erlang-tf-x-arr-push-first :emit :macro}
+   :x-arr-pop-first   {:macro #'erlang-tf-x-arr-pop-first  :emit :macro}
+   :x-arr-insert      {:macro #'erlang-tf-x-arr-insert     :emit :macro}
+   :x-arr-sort        {:macro #'erlang-tf-x-arr-sort       :emit :macro}})
+
+;;
+;; STRING
+;;
+
+(defn erlang-tf-x-str-char
+  ([[_ s i]]
+   (list :call "lists" "nth" (list '+ i 1) s)))
+
+(defn erlang-tf-x-str-split
+  ([[_ s tok]]
+   (list :call "string" "split" s tok "all")))
+
+(defn erlang-tf-x-str-join
+  ([[_ s arr]]
+   (list :call "string" "join" arr s)))
+
+(defn erlang-tf-x-str-index-of
+  ([[_ s tok]]
+   (list :call "string" "str" s tok)))
+
+(defn erlang-tf-x-str-substring
+  ([[_ s start & [end]]]
+   (list :call "string" "slice" s start (if end (list '- end start) 'infinity))))
+
+(defn erlang-tf-x-str-to-upper
+  ([[_ s]]
+   (list :call "string" "to_upper" s)))
+
+(defn erlang-tf-x-str-to-lower
+  ([[_ s]]
+   (list :call "string" "to_lower" s)))
+
+(defn erlang-tf-x-str-replace
+  ([[_ s tok replacement]]
+   (list :call "string" "replace" s tok replacement "all")))
+
+(def +erlang-str+
+  {:x-str-char       {:macro #'erlang-tf-x-str-char      :emit :macro}
+   :x-str-split      {:macro #'erlang-tf-x-str-split      :emit :macro}
+   :x-str-join       {:macro #'erlang-tf-x-str-join       :emit :macro}
+   :x-str-index-of   {:macro #'erlang-tf-x-str-index-of   :emit :macro}
+   :x-str-substring  {:macro #'erlang-tf-x-str-substring  :emit :macro}
+   :x-str-to-upper   {:macro #'erlang-tf-x-str-to-upper      :emit :macro}
+   :x-str-to-lower   {:macro #'erlang-tf-x-str-to-lower      :emit :macro}
+   :x-str-replace    {:macro #'erlang-tf-x-str-replace    :emit :macro}})
+
+;;
+;; JSON
+;;
+
+(defn erlang-tf-x-json-encode
+  ([[_ obj]]
+   (list :call "json" "encode" obj)))
+
+(defn erlang-tf-x-json-decode
+  ([[_ s]]
+   (list :call "json" "decode" s)))
+
+(def +erlang-js+
+  {:x-json-encode      {:macro #'erlang-tf-x-json-encode      :emit :macro}
+   :x-json-decode      {:macro #'erlang-tf-x-json-decode      :emit :macro}})
+
+;;
+;; RETURN
+;;
+
+(defn erlang-tf-x-return-encode
+  ([[_ out id key]]
+   (list :call "json" "encode"
+         (hash-map "id" id
+                   "key" key
+                   "type" "data"
+                   "value" out))))
+
+(defn erlang-tf-x-return-wrap
+  ([[_ f encode-fn]]
+   (list 'try
+         (list 'let
+               (list 'out (list f))
+               (list encode-fn 'out nil nil))
+         (list 'catch 'error 'E
+               (list :call "json" "encode"
+                     (hash-map "type" "error"
+                               "value" (list :call "list_to_binary"
+                                             (list :call "io_lib" "format" "~p" (list 'list 'E)))))))))
+
+(defn erlang-tf-x-return-eval
+  ([[_ s wrap-fn]]
+   (list 'EvalHelper s wrap-fn)))
+
+(def +erlang-return+
+  {:x-return-encode  {:macro #'erlang-tf-x-return-encode   :emit :macro}
+   :x-return-wrap    {:macro #'erlang-tf-x-return-wrap     :emit :macro}
+   :x-return-eval    {:macro #'erlang-tf-x-return-eval     :emit :macro}})
+
+(def +erlang+
+  (merge +erlang-global+
+         +erlang-math+
+         +erlang-type+
+         +erlang-obj+
+         +erlang-arr+
+         +erlang-str+
+         +erlang-js+
+         +erlang-return+))

--- a/src/bb/lang/model/spec_xtalk/fn_go.clj
+++ b/src/bb/lang/model/spec_xtalk/fn_go.clj
@@ -1,0 +1,89 @@
+(ns bb.lang.model.spec-xtalk.fn-go
+  (:require [bb.lib :as h]))
+
+(defn- add-sym [m]
+  (h/map-entries (fn [[k v]]
+                   [k (assoc v :symbol #{(symbol (name k))})])
+                 m))
+
+;;
+;; CORE
+;;
+
+(defn go-tf-x-len
+  [[_ arr]]
+  (list 'len arr))
+
+(defn go-tf-x-cat
+  [[_ & args]]
+  (apply list '+ args))
+
+(defn go-tf-x-print
+  [[_ & args]]
+  (apply list 'fmt.Println args))
+
+(def +go-core+
+  (add-sym
+   {:x-print          {:macro #'go-tf-x-print  :emit :macro :value true}
+    :x-len            {:macro #'go-tf-x-len    :emit :macro :value true}
+    :x-cat            {:macro #'go-tf-x-cat    :emit :macro :value true}}))
+
+;;
+;; MATH
+;;
+
+(defn go-tf-x-m-abs   [[_ n]] (list 'math.Abs n))
+(defn go-tf-x-m-max   [[_ a b]] (list 'math.Max a b))
+(defn go-tf-x-m-min   [[_ a b]] (list 'math.Min a b))
+(defn go-tf-x-m-ceil  [[_ n]] (list 'math.Ceil n))
+(defn go-tf-x-m-floor [[_ n]] (list 'math.Floor n))
+(defn go-tf-x-m-sqrt  [[_ n]] (list 'math.Sqrt n))
+(defn go-tf-x-m-pow   [[_ b e]] (list 'math.Pow b e))
+
+(def +go-math+
+  (add-sym
+   {:x-m-abs           {:macro #'go-tf-x-m-abs   :emit :macro :value true}
+    :x-m-max           {:macro #'go-tf-x-m-max   :emit :macro :value true}
+    :x-m-min           {:macro #'go-tf-x-m-min   :emit :macro :value true}
+    :x-m-ceil          {:macro #'go-tf-x-m-ceil  :emit :macro :value true}
+    :x-m-floor         {:macro #'go-tf-x-m-floor :emit :macro :value true}
+    :x-m-sqrt          {:macro #'go-tf-x-m-sqrt  :emit :macro :value true}
+    :x-m-pow           {:macro #'go-tf-x-m-pow   :emit :macro :value true}}))
+
+;;
+;; STRING
+;;
+
+(defn go-tf-x-str-split [[_ s sep]] (list 'strings.Split s sep))
+(defn go-tf-x-str-join  [[_ sep arr]] (list 'strings.Join arr sep))
+(defn go-tf-x-str-index-of [[_ s substr]] (list 'strings.Index s substr))
+(defn go-tf-x-str-to-upper [[_ s]] (list 'strings.ToUpper s))
+(defn go-tf-x-str-to-lower [[_ s]] (list 'strings.ToLower s))
+(defn go-tf-x-str-trim [[_ s]] (list 'strings.TrimSpace s))
+
+(def +go-str+
+  (add-sym
+   {:x-str-split       {:macro #'go-tf-x-str-split      :emit :macro :value true}
+    :x-str-join        {:macro #'go-tf-x-str-join       :emit :macro :value true}
+    :x-str-index-of    {:macro #'go-tf-x-str-index-of   :emit :macro :value true}
+    :x-str-to-upper    {:macro #'go-tf-x-str-to-upper   :emit :macro :value true}
+    :x-str-to-lower    {:macro #'go-tf-x-str-to-lower   :emit :macro :value true}
+    :x-str-trim        {:macro #'go-tf-x-str-trim       :emit :macro :value true}}))
+
+;;
+;; ARR
+;;
+
+(defn go-tf-x-arr-push
+  [[_ arr item]]
+  (list := arr (list 'append arr item)))
+
+(def +go-arr+
+  (add-sym
+   {:x-arr-push        {:macro #'go-tf-x-arr-push       :emit :macro}}))
+
+(def +go+
+  (merge +go-core+
+         +go-math+
+         +go-str+
+         +go-arr+))

--- a/src/bb/lang/model/spec_xtalk/fn_js.clj
+++ b/src/bb/lang/model/spec_xtalk/fn_js.clj
@@ -1,0 +1,653 @@
+(ns bb.lang.model.spec-xtalk.fn-js
+  (:require [bb.lib :as h]))
+
+;;
+;; CORE
+;;
+
+(defn js-tf-x-len
+  [[_ arr]]
+  (list '. arr 'length))
+
+(defn js-tf-x-cat
+  [[_ & args]]
+  (apply list '+ args))
+
+(defn js-tf-x-apply
+  [[_ f args]]
+  (list '. f (list 'apply nil args)))
+
+(defn js-tf-x-shell
+  ([[_ s opts]]
+   (h/$ (do (var p (require "child_process"))
+            (p.exec ~s (fn [err res]
+                         (if err
+                           (if (. ~opts ["error"])
+                             (return (. ~opts (error err))))
+                           (if (. ~opts ["success"])
+                             (return (. ~opts (success res)))))))
+            (return ["async"])))))
+
+(defn js-tf-x-random
+  [_]
+  '(Math.random))
+
+(defn js-tf-x-type-native
+  [[_ obj]]
+  (h/$ (do (when (== ~obj nil)
+             (return nil))
+           (var t := (typeof ~obj))
+           (if (== t "object")
+             (cond (Array.isArray ~obj)
+                   (return "array")
+
+                   :else
+                   (do (var tn := (. ~obj ["constructor"] ["name"]))
+                       (if (== tn "Object")
+                         (return "object")
+                         (return tn))))
+             (return t)))))
+
+(def +js-core+
+  {:x-del            {:emit :alias :raw 'delete}
+   :x-cat            {:macro #'js-tf-x-cat  :emit :macro :value true
+                      :raw "(function (...args) {return args.join('')})"}
+   :x-len            {:macro #'js-tf-x-len  :emit :macro}
+   :x-err            {:emit :alias :raw 'throw}
+   :x-eval           {:emit :alias :raw 'eval}
+   :x-apply          {:macro #'js-tf-x-apply   :emit :macro}
+   :x-unpack         {:emit :alias :raw :..}
+   :x-print          {:emit :alias :raw 'console.log :value true}
+   :x-random         {:emit :alias :raw 'Math.random :value true}
+   :x-shell          {:macro #'js-tf-x-shell         :emit :macro}
+   :x-now-ms         {:emit :alias :raw 'Date.now}
+   :x-type-native    {:macro #'js-tf-x-type-native   :emit :macro}})
+
+(defn js-tf-x-proto-get
+  [[_ obj]]
+  (list 'Object.getPrototypeOf obj))
+
+(defn js-tf-x-proto-set
+  [[_ obj prototype]]
+  (list 'Object.setPrototypeOf obj prototype))
+
+(defn js-tf-x-proto-create
+  [[_ m]]
+  (h/$
+   (do (var out {})
+       (for:object
+        [[k f] ~m]
+        (if (x:is-function? f)
+          (:= (. out [k])
+              (fn:> [...args]
+                (f this ...args)))
+          (:= (. out [k]) f)))
+       (return out))))
+
+(def +js-proto+
+  {:x-this            {:emit :unit :default 'this}
+   :x-proto-get       {:macro #'js-tf-x-proto-get     :emit :macro}
+   :x-proto-set       {:macro #'js-tf-x-proto-set     :emit :macro}
+   :x-proto-create    {:macro #'js-tf-x-proto-create  :emit :macro}
+   :x-proto-tostring  {:emit :unit  :default "toString"}})
+
+
+(def +js-global+
+  {})
+
+(def +js-custom+
+  {:x-callback       {:emit :throw}})
+
+;;
+;; MATH
+;;
+
+(defn js-tf-x-m-max   [[_ & args]] (apply list 'Math.max args))
+(defn js-tf-x-m-min   [[_ & args]] (apply list 'Math.min args))
+(defn js-tf-x-m-mod   [[_ num denom]] (list 'mod num denom))
+(defn js-tf-x-m-quot  [[_ num denom]] (list 'Math.floor (list '/  num denom)))
+
+(def +js-math+
+  {:x-m-abs           {:emit :alias :raw 'Math.abs  :value true}
+   :x-m-acos          {:emit :alias :raw 'Math.acos :value true}
+   :x-m-asin          {:emit :alias :raw 'Math.asin :value true}
+   :x-m-atan          {:emit :alias :raw 'Math.atan :value true}
+   :x-m-ceil          {:emit :alias :raw 'Math.ceil :value true}
+   :x-m-cos           {:emit :alias :raw 'Math.cos  :value true}
+   :x-m-cosh          {:emit :alias :raw 'Math.cosh :value true}
+   :x-m-exp           {:emit :alias :raw 'Math.exp  :value true}
+   :x-m-floor         {:emit :alias :raw 'Math.floor :value true}
+   :x-m-loge          {:emit :alias :raw 'Math.log  :value true}
+   :x-m-log10         {:emit :alias :raw 'Math.log10 :value true}
+   :x-m-max           {:macro #'js-tf-x-m-max,      :raw 'Math.max :emit :macro :value true}
+   :x-m-min           {:macro #'js-tf-x-m-min,      :raw 'Math.min :emit :macro :value true}
+   :x-m-mod           {:macro #'js-tf-x-m-mod,      :emit :macro}
+   :x-m-pow           {:emit :alias :raw 'Math.pow  :value true}
+   :x-m-quot          {:macro #'js-tf-x-m-quot,                :emit :macro}
+   :x-m-sin           {:emit :alias :raw 'Math.sin  :value true}
+   :x-m-sinh          {:emit :alias :raw 'Math.sinh :value true}
+   :x-m-sqrt          {:emit :alias :raw 'Math.sqrt :value true}
+   :x-m-tan           {:emit :alias :raw 'Math.tan  :value true}
+   :x-m-tanh          {:emit :alias :raw 'Math.tanh :value true}})
+
+;;
+;; TYPE
+;;
+
+(defn js-tf-x-is-string?
+  [[_ e]]
+  (list '== "string" (list 'typeof e)))
+
+(defn js-tf-x-is-number?
+  [[_ e]]
+  (list '== "number" (list 'typeof e)))
+
+(defn js-tf-x-is-integer?
+  [[_ e]]
+  (list 'Number.isInteger e))
+
+(defn js-tf-x-is-boolean?
+  [[_ e]]
+  (list '== "boolean" (list 'typeof e)))
+
+(defn js-tf-x-is-object?
+  [[_ e]]
+  (list 'and
+        (list 'not= nil e)
+        (list '== "object" (list 'typeof e))
+        (list 'not (list 'Array.isArray e))))
+
+(defn js-tf-x-is-function?
+  [[_ e]]
+  (list '== "function" (list 'typeof e)))
+
+(def +js-type+
+  {:x-to-string      {:emit :alias :raw 'String}
+   :x-to-number      {:emit :alias :raw 'Number}
+   :x-is-string?     {:macro #'js-tf-x-is-string? :emit :macro}
+   :x-is-number?     {:macro #'js-tf-x-is-number? :emit :macro}
+   :x-is-integer?    {:macro #'js-tf-x-is-integer? :emit :macro}
+   :x-is-boolean?    {:macro #'js-tf-x-is-boolean? :emit :macro}
+   :x-is-function?   {:macro #'js-tf-x-is-function? :emit :macro}
+   :x-is-object?     {:macro #'js-tf-x-is-object? :emit :macro}
+   :x-is-array?      {:emit :alias :raw 'Array.isArray}})
+
+;;
+;; LU
+;;
+
+(defn js-tf-x-lu-get
+  "converts map to array"
+  {:added "4.0"}
+  ([[_ lu obj]]
+   (h/$ (. ~lu (get ~obj)))))
+
+(defn js-tf-x-lu-set
+  "converts map to array"
+  {:added "4.0"}
+  ([[_ lu obj gid]]
+   (h/$ (. ~lu (set ~obj ~gid)))))
+
+(defn js-tf-x-lu-del
+  "converts map to array"
+  {:added "4.0"}
+  ([[_ lu obj]]
+   (h/$ (. ~lu (delete ~obj)))))
+
+(def +js-lu+
+  {:x-lu-create      {:default '(new WeakMap)}
+   :x-lu-get         {:macro #'js-tf-x-lu-get :emit :macro}
+   :x-lu-set         {:macro #'js-tf-x-lu-set :emit :macro}
+   :x-lu-del         {:macro #'js-tf-x-lu-del :emit :macro}})
+
+(defn js-tf-x-obj-keys
+  [[_ obj]]
+  (list 'return (list 'Object.keys obj)))
+
+(defn js-tf-x-obj-vals
+  [[_ obj]]
+  (list 'return (list 'Object.values obj)))
+
+(defn js-tf-x-obj-pairs
+  "converts map to array"
+  {:added "4.0"}
+  ([[_ m]]
+   (list 'return (list 'Object.entries m))))
+
+(defn js-tf-x-obj-clone
+  [[_ m]]
+  (list 'return (list 'Object.assign {} m)))
+
+(defn js-tf-x-obj-assign
+  [[_ obj m]]
+  (list 'return (list 'Object.assign obj m)))
+
+(def +js-obj+
+  {:x-obj-keys      {:macro #'js-tf-x-obj-keys    :emit :macro  :type :template}
+   :x-obj-vals      {:macro #'js-tf-x-obj-vals    :emit :macro  :type :template}
+   :x-obj-pairs     {:macro #'js-tf-x-obj-pairs   :emit :macro  :type :template}
+   :x-obj-clone     {:macro #'js-tf-x-obj-clone   :emit :macro  :type :template}
+   :x-obj-assign    {:macro #'js-tf-x-obj-assign  :emit :macro  :type :template}})
+
+;;
+;; ARR
+;;
+
+
+(defn js-tf-x-arr-slice
+  [[_ arr start end]]
+  (list '. arr (list 'slice start end)))
+
+(defn js-tf-x-arr-reverse
+  [[_ arr]]
+  (list '. arr (list 'slice) (list 'reverse)))
+
+
+
+(defn js-tf-x-arr-push
+  [[_ arr item]]
+  (list '. arr (list 'push item)))
+
+(defn js-tf-x-arr-pop
+  [[_ arr]]
+  (list '. arr (list 'pop)))
+
+(defn js-tf-x-arr-push-first
+  [[_ arr item]]
+  (list '. arr (list 'unshift item)))
+
+(defn js-tf-x-arr-pop-first
+  [[_ arr]]
+  (list '. arr (list 'shift)))
+
+(defn js-tf-x-arr-insert
+  [[_ arr idx e]]
+  (list '. arr (list 'splice idx 0 e)))
+
+(defn js-tf-x-arr-remove
+  [[_ arr idx]]
+  (list '. arr (list 'splice idx 1)))
+
+(defn js-tf-x-arr-sort
+  [[_ arr key-fn comp-fn]]
+  (list '. arr (list 'sort
+                     (h/$ (fn [a b]
+                            (return (:? (~comp-fn
+                                         (~key-fn a)
+                                         (~key-fn b))
+                                        -1 1)))))))
+
+(defn js-tf-x-arr-str-comp
+  [[_ a b]]
+  (list '> 0 (list '. a (list 'localeCompare b))))
+
+(def +js-arr+
+  {:x-arr-clone       {:emit :alias :raw 'Array.from}
+   :x-arr-slice       {:macro #'js-tf-x-arr-slice      :emit :macro   :type :template}
+   :x-arr-reverse     {:macro #'js-tf-x-arr-reverse    :emit :macro   :type :template}
+   :x-arr-push        {:macro #'js-tf-x-arr-push       :emit :macro   :type :template}
+   :x-arr-pop         {:macro #'js-tf-x-arr-pop        :emit :macro   :type :template}
+   :x-arr-push-first  {:macro #'js-tf-x-arr-push-first :emit :macro   :type :template}
+   :x-arr-pop-first   {:macro #'js-tf-x-arr-pop-first  :emit :macro   :type :template}
+   :x-arr-remove      {:macro #'js-tf-x-arr-remove     :emit :macro   :type :template}
+   :x-arr-insert      {:macro #'js-tf-x-arr-insert     :emit :macro   :type :template}
+   :x-arr-sort        {:macro #'js-tf-x-arr-sort       :emit :macro}
+   :x-arr-str-comp    {:macro #'js-tf-x-arr-str-comp   :emit :macro}})
+
+;;
+;; STRING
+;;
+
+(defn js-tf-x-str-char
+  ([[_ s i]]
+   (list '. s (list 'charCodeAt i))))
+
+(defn js-tf-x-str-split
+  ([[_ s tok]]
+   (list '. s (list 'split tok))))
+
+(defn js-tf-x-str-join
+  ([[_ s arr]]
+   (list '. arr (list 'join s))))
+
+(defn js-tf-x-str-index-of
+  ([[_ s tok]]
+   (list '. s (list 'indexOf tok))))
+
+(defn js-tf-x-str-substring
+  ([[_ s start & args]]
+   (list '. s (apply list 'substring start args))))
+
+(defn js-tf-x-str-to-upper
+  ([[_ s]]
+   (list '. s '(toUpperCase))))
+
+(defn js-tf-x-str-to-lower
+  ([[_ s]]
+   (list '. s '(toLowerCase))))
+
+(defn js-tf-x-str-to-fixed
+  ([[_ n digits]]
+   (list '. n (list 'toFixed digits))))
+
+(defn js-tf-x-str-replace
+  ([[_ s tok replacement]]
+   (list '. s (list 'replace (list 'new 'RegExp tok "g") replacement))))
+
+(defn js-tf-x-str-trim
+  ([[_ s]]
+   (list '. s (list 'trim))))
+
+(defn js-tf-x-str-trim-left
+  ([[_ s]]
+   (list '. s (list 'trimLeft))))
+
+(defn js-tf-x-str-trim-right
+  ([[_ s]]
+   (list '. s (list 'trimRight))))
+
+(def +js-str+
+  {:x-str-char        {:macro #'js-tf-x-str-char       :emit :macro}
+   :x-str-split       {:macro #'js-tf-x-str-split      :emit :macro}
+   :x-str-join        {:macro #'js-tf-x-str-join       :emit :macro}
+   :x-str-index-of    {:macro #'js-tf-x-str-index-of   :emit :macro}
+   :x-str-substring   {:macro #'js-tf-x-str-substring  :emit :macro}
+   :x-str-to-upper    {:macro #'js-tf-x-str-to-upper   :emit :macro}
+   :x-str-to-lower    {:macro #'js-tf-x-str-to-lower   :emit :macro}
+   :x-str-to-fixed    {:macro #'js-tf-x-str-to-fixed   :emit :macro}
+   :x-str-replace     {:macro #'js-tf-x-str-replace    :emit :macro}
+   :x-str-trim        {:macro #'js-tf-x-str-trim       :emit :macro}
+   :x-str-trim-left   {:macro #'js-tf-x-str-trim-left  :emit :macro}
+   :x-str-trim-right  {:macro #'js-tf-x-str-trim-right :emit :macro}})
+
+;;
+;; JSON
+;;
+
+(def +js-js+
+  {:x-json-encode      {:emit :alias :raw 'JSON.stringify}
+   :x-json-decode      {:emit :alias :raw 'JSON.parse}})
+
+;;
+;; COM
+;;
+
+(defn js-tf-x-return-encode
+  ([[_ out id key]]
+   (h/$ (do (var type-fn (fn [x]
+                           (let [name (typeof x)]
+                             (return (:? (== name "object") (:? x x.constructor.name name) name)))))
+            (var tb (typeof ~out))
+            (cond (== "function" tb)
+                  (return (JSON.stringify {:id     ~id
+                                           :key    ~key
+                                           :type   "raw"
+                                           :return "function"
+                                           :value  (. ~out (toString))}))
+
+
+                  (not= "object" tb)
+                  (return (JSON.stringify {:id     ~id
+                                           :key    ~key
+                                           :type "data"
+                                           :return tb
+                                           :value ~out}))
+
+                  (== nil ~out)
+                  (return (JSON.stringify {:id     ~id
+                                           :key    ~key
+                                           :type "data"
+                                           :return "nil"
+                                           :value ~out}))
+
+                  :else
+                  (do (var ts (type-fn ~out))
+                      (try
+                        (if (or (== ts "Object")
+                                (== ts "Array"))
+                          (return (JSON.stringify {:id     ~id
+                                                   :key    ~key
+                                                   :type "data"
+                                                   :value ~out}))
+                          (return (JSON.stringify {:id     ~id
+                                                   :key    ~key
+                                                   :type  "raw"
+                                                   :return ts
+                                                   :value (. ~out (toString))})))
+                        (catch e (return (JSON.stringify {:id     id
+                                                          :key    key
+                                                          :type   "raw"
+                                                          :return ts
+                                                          :value (. ~out (toString))}))))))))))
+
+(defn js-tf-x-return-wrap
+  ([[_ f encode-fn]]
+   (h/$ (try (var out := (~f))
+             (return (~encode-fn  out))
+             (catch e (let [err (:? (== "string" (typeof e)) e {:message (. e ["message"]) :stack (. e ["stack"])})]
+                        (return (JSON.stringify {:type "error"
+                                                 :value err}))))))))
+
+(defn js-tf-x-return-eval
+  ([[_ s wrap-fn]]
+   (h/$ (return (~wrap-fn
+                 (fn []
+                   (return (eval ~s))))))))
+
+(def +js-return+
+  {:x-return-encode  {:macro #'js-tf-x-return-encode   :emit :macro}
+   :x-return-wrap    {:macro #'js-tf-x-return-wrap     :emit :macro}
+   :x-return-eval    {:macro #'js-tf-x-return-eval     :emit :macro}})
+
+(defn js-tf-x-socket-connect
+  ([[_ host port opts cb]]
+   (h/$ (do* (var net (eval "require('net')"))
+             (var rl  (eval  "require('readline')"))
+             (var conn (new net.Socket))
+             (return (conn.connect
+                      port host (fn []
+                                  (cb nil conn))))))))
+
+(defn js-tf-x-socket-send
+  ([[_ conn s]]
+   (h/$ (. ~conn (write ~s)))))
+
+(defn js-tf-x-socket-close
+  ([[_ conn]]
+   (h/$ (. ~conn (end)))))
+
+(def +js-socket+
+  {:x-socket-connect      {:macro #'js-tf-x-socket-connect      :emit :macro}
+   :x-socket-send         {:macro #'js-tf-x-socket-send         :emit :macro}
+   :x-socket-close        {:macro #'js-tf-x-socket-close        :emit :macro}})
+
+;;
+;; ITER
+;;
+
+(defn js-tf-x-iter-from-obj
+  ([[_ obj]]
+   (list (list '. (list 'Object.entries obj) '[Symbol.iterator]))))
+
+(defn js-tf-x-iter-from-arr
+  ([[_ arr]]
+   (list (list '. arr '[Symbol.iterator]))))
+
+(defn js-tf-x-iter-from
+  ([[_ obj]]
+   (list (list '. obj '[Symbol.iterator]))))
+
+(defn js-tf-x-iter-eq
+  ([[_ it0 it1 eq-fn]]
+   (h/$ (do (for [:let x0 :of ~it0]
+              (var r1 (. ~it1 (next)))
+              (cond (. r1 done)
+                    (return false)
+
+                    (not (~eq-fn x0 (. r1 value)))
+                    (return false)))
+            (return (. ~it1 (next) done))))))
+
+(defn js-tf-x-iter-next
+  ([[_ it]]
+   (list '. it (list 'next))))
+
+(defn js-tf-x-iter-has?
+  ([[_ obj]]
+   (list 'not= nil (list '. obj '[Symbol.iterator]))))
+
+(defn js-tf-x-iter-native?
+  ([[_ it]]
+   (list '== "function" (list 'typeof (list '. it ["next"])))))
+
+(def +js-iter+
+  {:x-iter-from-obj    {:macro #'js-tf-x-iter-from-obj       :emit :macro}
+   :x-iter-from-arr    {:macro #'js-tf-x-iter-from-arr       :emit :macro}
+   :x-iter-from        {:macro #'js-tf-x-iter-from           :emit :macro}
+   :x-iter-eq          {:macro #'js-tf-x-iter-eq             :emit :macro}
+   :x-iter-next        {:macro #'js-tf-x-iter-next           :emit :macro}
+   :x-iter-has?        {:macro #'js-tf-x-iter-has?           :emit :macro}
+   :x-iter-native?     {:macro #'js-tf-x-iter-native?        :emit :macro}})
+
+;;
+;; CACHE
+;;
+
+(defn js-tf-x-cache
+  ([[_ name]]
+   (if (= (h/strn name) "GLOBAL")
+     'window.localStorage
+     'window.sessionStorage)))
+
+(defn js-tf-x-cache-list
+  ([[_ cache]]
+   (list 'or
+         (list '. cache ["_keys"])
+         (list 'Object.keys cache))))
+
+(defn js-tf-x-cache-flush
+  ([[_ cache]]
+   (list '. cache '(clear))))
+
+(defn js-tf-x-cache-get
+  ([[_ cache key]]
+   (list '. cache (list 'getItem key))))
+
+(defn js-tf-x-cache-set
+  ([[_ cache key val]]
+   (list '. cache (list 'setItem key val))))
+
+(defn js-tf-x-cache-del
+  ([[_ cache key]]
+   (list '. cache (list 'removeItem key))))
+
+(defn js-tf-x-cache-incr
+  ([[_ cache key num]]
+   (h/$ (do:> (var prev (Number (. ~cache (getItem ~key))))
+              (var curr (+ prev ~num))
+              (. ~cache (setItem ~key curr))
+              (return curr)))))
+
+(def +js-cache+
+  {:x-cache                 {:macro #'js-tf-x-cache           :emit :macro}
+   :x-cache-flush           {:macro #'js-tf-x-cache-flush     :emit :macro}
+   :x-cache-list            {:macro #'js-tf-x-cache-list      :emit :macro}
+   :x-cache-get             {:macro #'js-tf-x-cache-get       :emit :macro}
+   :x-cache-set             {:macro #'js-tf-x-cache-set       :emit :macro}
+   :x-cache-del             {:macro #'js-tf-x-cache-del       :emit :macro}
+   :x-cache-incr            {:macro #'js-tf-x-cache-incr      :emit :macro}})
+
+;;
+;; FILE
+;;
+
+(defn js-tf-x-slurp
+  ([[_ filename]]))
+
+(defn js-tf-x-spit
+  ([[_ filename s]]))
+
+(def +js-file+
+  {:x-slurp          {:macro #'js-tf-x-slurp         :emit :macro}
+   :x-spit           {:macro #'js-tf-x-spit          :emit :macro}})
+
+;;
+;; THREAD
+;;
+
+(defn js-tf-x-thread-spawn
+  ([[_ thunk]]
+   (h/$ (new Promise (fn [resolve reject]
+                       (resolve (~thunk)))))))
+
+(defn js-tf-x-thread-join
+  ([[_ thread]]
+   '(x:error "Thread join not Supported")))
+
+(defn js-tf-x-with-delay
+  ([[_ thunk ms]]
+   (h/$ (setTimeout (fn []
+                      (new Promise (fn [resolve reject]
+                                     (resolve (~thunk)))))
+                    ~ms))))
+
+(defn js-tf-x-start-interval
+  ([[_ thunk ms]]
+   (h/$ (setInterval (fn []
+                      (new Promise (fn [resolve reject]
+                                     (resolve (~thunk)))))
+                    ~ms))))
+
+(defn js-tf-x-stop-interval
+  ([[_ instance]]
+   (h/$ (clearInterval instance))))
+
+(def +js-thread+
+  {:x-thread-spawn   {:macro #'js-tf-x-thread-spawn   :emit :macro}
+   :x-thread-join    {:macro #'js-tf-x-thread-join    :emit :macro}
+   :x-with-delay     {:macro #'js-tf-x-with-delay     :emit :macro}
+   :x-start-interval {:macro #'js-tf-x-start-interval :emit :macro}
+   :x-stop-interval  {:macro #'js-tf-x-stop-interval  :emit :macro}})
+
+(def +js-b64+
+  {:x-b64-decode     {:emit :alias :raw 'atob}
+   :x-b64-encode     {:emit :alias :raw 'btoa}})
+
+(def +js-uri+
+  {:x-uri-decode     {:emit :alias :raw 'decodeURIComponent}
+   :x-uri-encode     {:emit :alias :raw 'encodeURIComponent}})
+
+(defn js-tf-x-notify-http
+  ([[_ host port value id key opts]]
+   (h/$ (try
+          (var #{path scheme} (or ~opts {}))
+          (fetch (+ (or scheme "http") "://" ~host ":" ~port "/" (or path ""))
+                 {:method "POST"
+                  :body (xt.lang.base-repl/return-encode ~value ~id ~key)})
+          (return ["async"])
+          (catch e (return ["unable to connect"]))))))
+
+(def +js-special+
+  {:x-notify-http   {:macro #'js-tf-x-notify-http    :emit :macro   :type :template}})
+
+(def +js+
+  (merge +js-core+
+         +js-proto+
+         +js-global+
+         +js-custom+
+         +js-math+
+         +js-type+
+         +js-lu+
+         +js-obj+
+         +js-arr+
+         +js-str+
+         +js-js+
+         +js-return+
+         +js-socket+
+         +js-iter+
+         +js-cache+
+         +js-thread+
+         +js-file+
+         +js-b64+
+         +js-uri+
+         +js-special+))

--- a/src/bb/lang/model/spec_xtalk/fn_julia.clj
+++ b/src/bb/lang/model/spec_xtalk/fn_julia.clj
@@ -1,0 +1,348 @@
+(ns bb.lang.model.spec-xtalk.fn-julia
+  (:require [bb.lib :as h]))
+
+(defn julia-tf-x-del
+  [[_ obj]]
+  (list 'delete! obj))
+
+(defn julia-tf-x-cat
+  [[_ & args]]
+  (apply list '* args))
+
+(defn julia-tf-x-len
+  [[_ arr]]
+  (list 'length arr))
+
+(defn julia-tf-x-get-key
+  [[_ obj key default]]
+  (list 'get obj key default))
+
+(defn julia-tf-x-err
+  [[_ msg]]
+  (list 'error msg))
+
+(defn julia-tf-x-eval
+  [[_ s]]
+  (list 'eval (list 'Meta.parse s)))
+
+(defn julia-tf-x-apply
+  [[_ f args]]
+  (list f (list :... args)))
+
+(defn julia-tf-x-random
+  [_]
+  (list 'rand))
+
+(defn julia-tf-x-print
+  ([[_ & args]]
+   (apply list 'println args)))
+
+(defn julia-tf-x-type-native
+  [[_ obj]]
+  (list 'string (list 'typeof obj)))
+
+(def +julia-core+
+  {:x-del            {:macro #'julia-tf-x-del    :emit :macro}
+   :x-cat            {:macro #'julia-tf-x-cat    :emit :macro}
+   :x-len            {:macro #'julia-tf-x-len    :emit :macro}
+   :x-err            {:macro #'julia-tf-x-err    :emit :macro}
+   :x-eval           {:macro #'julia-tf-x-eval   :emit :macro}
+   :x-apply          {:macro #'julia-tf-x-apply  :emit :macro}
+   :x-unpack         {:raw :... :emit :alias}
+   :x-random         {:macro #'julia-tf-x-random :emit :macro}
+   :x-print          {:macro #'julia-tf-x-print  :emit :macro}
+   :x-now-ms         {:default '(round (* 1000 (time))) :emit :unit}
+   :x-get-key        {:macro #'julia-tf-x-get-key :emit :macro}
+   :x-type-native    {:macro #'julia-tf-x-type-native :emit :macro}})
+
+;;
+;; GLOBAL
+;;
+
+(def +julia-global+
+  {})
+
+;;
+;; MATH
+;;
+
+(defn julia-tf-x-m-abs   [[_ num]] (list 'abs num))
+(defn julia-tf-x-m-acos  [[_ num]] (list 'acos num))
+(defn julia-tf-x-m-asin  [[_ num]] (list 'asin num))
+(defn julia-tf-x-m-atan  [[_ num]] (list 'atan num))
+(defn julia-tf-x-m-ceil  [[_ num]] (list 'ceil num))
+(defn julia-tf-x-m-cos   [[_ num]] (list 'cos num))
+(defn julia-tf-x-m-cosh  [[_ num]] (list 'cosh num))
+(defn julia-tf-x-m-exp   [[_ num]] (list 'exp num))
+(defn julia-tf-x-m-floor [[_ num]] (list 'floor num))
+(defn julia-tf-x-m-loge  [[_ num]] (list 'log num))
+(defn julia-tf-x-m-log10 [[_ num]] (list 'log10 num))
+(defn julia-tf-x-m-max   [[_ & args]] (apply list 'max args))
+(defn julia-tf-x-m-min   [[_ & args]] (apply list 'min args))
+(defn julia-tf-x-m-mod   [[_ num denom]] (list :% num denom))
+(defn julia-tf-x-m-pow   [[_ base n]] (list '^ base n))
+(defn julia-tf-x-m-quot  [[_ num denom]] (list 'div num denom))
+(defn julia-tf-x-m-sin   [[_ num]] (list 'sin num))
+(defn julia-tf-x-m-sinh  [[_ num]] (list 'sinh num))
+(defn julia-tf-x-m-sqrt  [[_ num]] (list 'sqrt num))
+(defn julia-tf-x-m-tan   [[_ num]] (list 'tan num))
+(defn julia-tf-x-m-tanh  [[_ num]] (list 'tanh num))
+
+(def +julia-math+
+  {:x-m-abs           {:macro #'julia-tf-x-m-abs,                 :emit :macro}
+   :x-m-acos          {:macro #'julia-tf-x-m-acos,                :emit :macro}
+   :x-m-asin          {:macro #'julia-tf-x-m-asin,                :emit :macro}
+   :x-m-atan          {:macro #'julia-tf-x-m-atan,                :emit :macro}
+   :x-m-ceil          {:macro #'julia-tf-x-m-ceil,                :emit :macro}
+   :x-m-cos           {:macro #'julia-tf-x-m-cos,                 :emit :macro}
+   :x-m-cosh          {:macro #'julia-tf-x-m-cosh,                :emit :macro}
+   :x-m-exp           {:macro #'julia-tf-x-m-exp,                 :emit :macro}
+   :x-m-floor         {:macro #'julia-tf-x-m-floor,               :emit :macro}
+   :x-m-loge          {:macro #'julia-tf-x-m-loge,                :emit :macro}
+   :x-m-log10         {:macro #'julia-tf-x-m-log10,               :emit :macro}
+   :x-m-max           {:macro #'julia-tf-x-m-max,                 :emit :macro}
+   :x-m-min           {:macro #'julia-tf-x-m-min,                 :emit :macro}
+   :x-m-mod           {:macro #'julia-tf-x-m-mod,                 :emit :macro}
+   :x-m-pow           {:macro #'julia-tf-x-m-pow,                 :emit :macro}
+   :x-m-quot          {:macro #'julia-tf-x-m-quot,                :emit :macro}
+   :x-m-sin           {:macro #'julia-tf-x-m-sin,                 :emit :macro}
+   :x-m-sinh          {:macro #'julia-tf-x-m-sinh,                :emit :macro}
+   :x-m-sqrt          {:macro #'julia-tf-x-m-sqrt,                :emit :macro}
+   :x-m-tan           {:macro #'julia-tf-x-m-tan,                 :emit :macro}
+   :x-m-tanh          {:macro #'julia-tf-x-m-tanh,                :emit :macro}})
+
+;;
+;; TYPE
+;;
+
+(defn julia-tf-x-to-string
+  [[_ e]]
+  (list 'string e))
+
+(defn julia-tf-x-to-number
+  [[_ e]]
+  (list 'parse 'Float64 e))
+
+(defn julia-tf-x-is-string?
+  [[_ e]]
+  (list 'isa e 'String))
+
+(defn julia-tf-x-is-number?
+  [[_ e]]
+  (list 'isa e 'Number))
+
+(defn julia-tf-x-is-integer?
+  [[_ e]]
+  (list 'isa e 'Integer))
+
+(defn julia-tf-x-is-boolean?
+  [[_ e]]
+  (list 'isa e 'Bool))
+
+(defn julia-tf-x-is-function?
+  [[_ e]]
+  (list 'isa e 'Function))
+
+(defn julia-tf-x-is-object?
+  [[_ e]]
+  (list 'isa e 'Dict))
+
+(defn julia-tf-x-is-array?
+  [[_ e]]
+  (list 'isa e 'AbstractArray))
+
+(def +julia-type+
+  {:x-to-string      {:macro #'julia-tf-x-to-string :emit :macro}
+   :x-to-number      {:macro #'julia-tf-x-to-number :emit :macro}
+   :x-is-string?     {:macro #'julia-tf-x-is-string? :emit :macro}
+   :x-is-number?     {:macro #'julia-tf-x-is-number? :emit :macro}
+   :x-is-integer?    {:macro #'julia-tf-x-is-integer? :emit :macro}
+   :x-is-boolean?    {:macro #'julia-tf-x-is-boolean? :emit :macro}
+   :x-is-function?   {:macro #'julia-tf-x-is-function? :emit :macro}
+   :x-is-object?     {:macro #'julia-tf-x-is-object? :emit :macro}
+   :x-is-array?      {:macro #'julia-tf-x-is-array? :emit :macro}})
+
+;;
+;; OBJ
+;;
+
+(defn julia-tf-x-obj-keys
+  [[_ obj]]
+  (list 'collect (list 'keys obj)))
+
+(defn julia-tf-x-obj-vals
+  [[_ obj]]
+  (list 'collect (list 'values obj)))
+
+(defn julia-tf-x-obj-pairs
+  [[_ obj]]
+  (list 'collect obj))
+
+(defn julia-tf-x-obj-clone
+  [[_ obj]]
+  (list 'copy obj))
+
+(def +julia-obj+
+  {:x-obj-keys    {:macro #'julia-tf-x-obj-keys   :emit :macro}
+   :x-obj-vals    {:macro #'julia-tf-x-obj-vals   :emit :macro}
+   :x-obj-pairs   {:macro #'julia-tf-x-obj-pairs  :emit :macro}
+   :x-obj-clone   {:macro #'julia-tf-x-obj-clone  :emit :macro}})
+
+;;
+;; ARR
+;;
+
+(defn julia-tf-x-arr-clone
+  [[_ arr]]
+  (list 'copy arr))
+
+(defn julia-tf-x-arr-slice
+  [[_ arr start end]]
+  (list 'getindex arr (list :to (list '+ start 1) end)))
+
+(defn julia-tf-x-arr-push
+  [[_ arr item]]
+  (list 'push! arr item))
+
+(defn julia-tf-x-arr-pop
+  [[_ arr]]
+  (list 'pop! arr))
+
+(defn julia-tf-x-arr-reverse
+  [[_ arr]]
+  (list 'reverse arr))
+
+(defn julia-tf-x-arr-push-first
+  [[_ arr item]]
+  (list 'pushfirst! arr item))
+
+(defn julia-tf-x-arr-pop-first
+  [[_ arr]]
+  (list 'popfirst! arr))
+
+(defn julia-tf-x-arr-insert
+  [[_ arr idx e]]
+  (list 'insert! arr (list '+ idx 1) e))
+
+(defn julia-tf-x-arr-sort
+  [[_ arr key-fn compare-fn]]
+  (list 'sort! arr :lt (list 'fn '[a b]
+                             (list '< (list key-fn 'a) (list key-fn 'b)))))
+
+(def +julia-arr+
+  {:x-arr-clone       {:macro #'julia-tf-x-arr-clone      :emit :macro}
+   :x-arr-slice       {:macro #'julia-tf-x-arr-slice      :emit :macro}
+   :x-arr-reverse     {:macro #'julia-tf-x-arr-reverse    :emit :macro}
+   :x-arr-push        {:macro #'julia-tf-x-arr-push       :emit :macro}
+   :x-arr-pop         {:macro #'julia-tf-x-arr-pop        :emit :macro}
+   :x-arr-push-first  {:macro #'julia-tf-x-arr-push-first :emit :macro}
+   :x-arr-pop-first   {:macro #'julia-tf-x-arr-pop-first  :emit :macro}
+   :x-arr-insert      {:macro #'julia-tf-x-arr-insert     :emit :macro}
+   :x-arr-sort        {:macro #'julia-tf-x-arr-sort       :emit :macro}})
+
+;;
+;; STRING
+;;
+
+(defn julia-tf-x-str-char
+  ([[_ s i]]
+   (list 'Int (list 'getindex s (list '+ i 1)))))
+
+(defn julia-tf-x-str-split
+  ([[_ s tok]]
+   (list 'split s tok)))
+
+(defn julia-tf-x-str-join
+  ([[_ s arr]]
+   (list 'join arr s)))
+
+(defn julia-tf-x-str-index-of
+  ([[_ s tok]]
+   (list 'findfirst tok s)))
+
+(defn julia-tf-x-str-substring
+  ([[_ s start & [end]]]
+   (list 'getindex s (list :to (list '+ start 1) (or end '(end))))))
+
+(defn julia-tf-x-str-to-upper
+  ([[_ s]]
+   (list 'uppercase s)))
+
+(defn julia-tf-x-str-to-lower
+  ([[_ s]]
+   (list 'lowercase s)))
+
+(defn julia-tf-x-str-replace
+  ([[_ s tok replacement]]
+   (list 'replace s (list '=> tok replacement))))
+
+(def +julia-str+
+  {:x-str-char       {:macro #'julia-tf-x-str-char      :emit :macro}
+   :x-str-split      {:macro #'julia-tf-x-str-split      :emit :macro}
+   :x-str-join       {:macro #'julia-tf-x-str-join       :emit :macro}
+   :x-str-index-of   {:macro #'julia-tf-x-str-index-of   :emit :macro}
+   :x-str-substring  {:macro #'julia-tf-x-str-substring  :emit :macro}
+   :x-str-to-upper   {:macro #'julia-tf-x-str-to-upper      :emit :macro}
+   :x-str-to-lower   {:macro #'julia-tf-x-str-to-lower      :emit :macro}
+   :x-str-replace    {:macro #'julia-tf-x-str-replace    :emit :macro}})
+
+;;
+;; JSON
+;;
+
+(defn julia-tf-x-json-encode
+  ([[_ obj]]
+   (list '. 'JSON (list 'json obj))))
+
+(defn julia-tf-x-json-decode
+  ([[_ s]]
+   (list '. 'JSON (list 'parse s))))
+
+(def +julia-js+
+  {:x-json-encode      {:macro #'julia-tf-x-json-encode      :emit :macro}
+   :x-json-decode      {:macro #'julia-tf-x-json-decode      :emit :macro}})
+
+;;
+;; RETURN
+;;
+
+(defn julia-tf-x-return-encode
+  ([[_ out id key]]
+   (list '. 'JSON (list 'json (list 'Dict
+                                   "id" id
+                                   "key" key
+                                   "type" "data"
+                                   "value" out)))))
+
+(defn julia-tf-x-return-wrap
+  ([[_ f encode-fn]]
+   (list 'try
+         (list 'let
+               (list 'out (list f))
+               (list encode-fn 'out nil nil))
+         (list 'catch 'e
+               (list '. 'JSON (list 'json (list 'Dict
+                                               "type" "error"
+                                               "value" (list 'string 'e))))))))
+
+(defn julia-tf-x-return-eval
+  ([[_ s wrap-fn]]
+   (list wrap-fn
+         (list 'fn []
+               (list 'include_string 'Main s)))))
+
+(def +julia-return+
+  {:x-return-encode  {:macro #'julia-tf-x-return-encode   :emit :macro}
+   :x-return-wrap    {:macro #'julia-tf-x-return-wrap     :emit :macro}
+   :x-return-eval    {:macro #'julia-tf-x-return-eval     :emit :macro}})
+
+(def +julia+
+  (merge +julia-core+
+         +julia-global+
+         +julia-math+
+         +julia-type+
+         +julia-obj+
+         +julia-arr+
+         +julia-str+
+         +julia-js+
+         +julia-return+))

--- a/src/bb/lang/model/spec_xtalk/fn_lua.clj
+++ b/src/bb/lang/model/spec_xtalk/fn_lua.clj
@@ -1,0 +1,654 @@
+(ns bb.lang.model.spec-xtalk.fn-lua
+  (:require [bb.lib :as h]))
+
+;;
+;; CORE
+;;
+
+(defn lua-tf-x-del
+  [[_ obj]]
+  (list := obj nil))
+
+(defn lua-tf-x-cat
+  [[_ & args]]
+  (apply list 'cat args))
+
+(defn lua-tf-x-eval
+  [[_ s]]
+  (list (list 'loadstring (list 'cat "return " s))))
+
+(defn lua-tf-x-apply
+  [[_ f args]]
+  (list f (list 'unpack args)))
+
+(defn lua-tf-x-err
+  [[_ s & [data]]]
+  (if data
+    (h/$ (error (cjson.encode ~[s data])))
+    (h/$ (error ~s))))
+
+(defn lua-tf-x-shell
+  ([[_ s cm]]
+   (h/$ (do* (var handle (io.popen ~s))
+             (var res (handle:read "*a"))
+             (var f (. ~cm ["success"]))
+             (if f
+               (return (f res))
+               (return res))))))
+
+(defn lua-tf-x-hash-id
+  [[_ obj]]
+  (h/$ (return nil)))
+
+(defn lua-tf-x-type-native
+  [[_ obj]]
+  (h/$ (do (local t := (type ~obj))
+           (if (== t "table")
+             (if (== nil (. '(~obj) [1]))
+               (return "object")
+               (return "array"))
+             (return t)))))
+
+(def +lua-core+
+  {:x-del            {:macro #'lua-tf-x-del  :emit :macro}
+   :x-cat            {:macro #'lua-tf-x-cat  :emit :macro}
+   :x-len            {:emit :alias :raw 'len}
+   :x-err            {:macro #'lua-tf-x-err    :emit :macro}
+   :x-eval           {:macro #'lua-tf-x-eval   :emit :macro}
+   :x-apply          {:macro #'lua-tf-x-apply  :emit :macro}
+   :x-unpack         {:emit :alias :raw 'unpack}
+   :x-print          {:emit :alias :raw 'print}
+
+   :x-random         {:emit :alias :raw 'math.random}
+   :x-shell          {:macro #'lua-tf-x-shell         :emit :macro}
+   :x-now-ms         {:default '(math.floor (* 1000 (os.time)))   :emit :unit}
+   :x-type-native    {:macro #'lua-tf-x-type-native  :emit :macro}})
+
+(defn lua-tf-x-proto-create
+  [[_ m]]
+  (h/$
+   (do (var mt ~m)
+       (:= (. mt __index) mt)
+       (return mt))))
+
+(def +lua-proto+
+  {:x-this            {:emit :unit  :default 'self}
+   :x-proto-get       {:emit :alias :raw 'getmetatable}
+   :x-proto-set       {:emit :alias :raw 'setmetatable}
+   :x-proto-create    {:macro #'lua-tf-x-proto-create  :emit :macro}
+   :x-proto-tostring  {:emit :unit  :default "__tostring"}})
+
+;;
+;; GLOBAL
+;;
+
+(defn lua-tf-x-global-has?
+  [[_ sym]]
+  (list 'not= (symbol sym) nil))
+
+(defn lua-tf-x-global-set
+  [[_ sym val]]
+  (list ':= (symbol sym) val))
+
+(defn lua-tf-x-global-del
+  [[_ sym]]
+  (list ':= (symbol sym) nil))
+
+(def +lua-global+
+  {:x-global-has?   {:macro #'lua-tf-x-global-has?  :emit :macro}
+   :x-global-set    {:macro #'lua-tf-x-global-set   :emit :macro}
+   :x-global-del    {:macro #'lua-tf-x-global-del   :emit :macro}})
+
+;;
+;; CUSTOM
+;;
+
+(def +lua-custom+
+  {})
+
+;;
+;; MATH
+;;
+
+(defn lua-tf-x-m-quot  [[_ num denom]] (list 'math.floor
+                                             (list '/ num denom)))
+
+(def +lua-math+
+  {:x-m-abs           {:emit :alias :raw 'math.abs}
+   :x-m-acos          {:emit :alias :raw 'math.acos}
+   :x-m-asin          {:emit :alias :raw 'math.asin}
+   :x-m-atan          {:emit :alias :raw 'math.atan}
+   :x-m-ceil          {:emit :alias :raw 'math.ceil}
+   :x-m-cos           {:emit :alias :raw 'math.cos}
+   :x-m-cosh          {:emit :alias :raw 'math.cosh}
+   :x-m-exp           {:emit :alias :raw 'math.exp}
+   :x-m-floor         {:emit :alias :raw 'math.floor}
+   :x-m-loge          {:emit :alias :raw 'math.log}
+   :x-m-log10         {:emit :alias :raw 'math.log10}
+   :x-m-max           {:emit :alias :raw 'math.max}
+   :x-m-min           {:emit :alias :raw 'math.min}
+   :x-m-mod           {:emit :alias :raw 'math.mod}
+   :x-m-pow           {:emit :alias :raw 'math.pow}
+   :x-m-quot          {:macro #'lua-tf-x-m-quot,     :emit :macro}
+   :x-m-sin           {:emit :alias :raw 'math.sin}
+   :x-m-sinh          {:emit :alias :raw 'math.sinh}
+   :x-m-sqrt          {:emit :alias :raw 'math.sqrt}
+   :x-m-tan           {:emit :alias :raw 'math.tan}
+   :x-m-tanh          {:emit :alias :raw 'math.tanh}})
+
+
+;;
+;; TYPE
+;;
+
+(defn lua-tf-x-is-string?
+  [[_ e]]
+  (list '== "string" (list 'type e)))
+
+(defn lua-tf-x-is-number?
+  [[_ e]]
+  (list '== "number" (list 'type e)))
+
+(defn lua-tf-x-is-integer?
+  [[_ e]]
+  (list '== 0 (list 'mod e 1)))
+
+(defn lua-tf-x-is-boolean?
+  [[_ e]]
+  (list '== "boolean" (list 'type e)))
+
+(defn lua-tf-x-is-function?
+  [[_ e]]
+  (list '== "function" (list 'type e)))
+
+(defn lua-tf-x-is-object?
+  [[_ e]]
+  (h/$ (or (and (== "table" (type ~e))
+                (== nil (. '(~e) [1])))
+           (== "object" (type ~e)))))
+
+(defn lua-tf-x-is-array?
+  [[_ e]]
+  (h/$ (or (and (== "table" (type ~e))
+                (not= nil (. '(~e) [1])))
+           (== "array" (type ~e)))))
+
+(def +lua-type+
+  {:x-to-string      {:emit :alias :raw 'tostring}
+   :x-to-number      {:emit :alias :raw 'tonumber}
+   :x-is-string?     {:macro #'lua-tf-x-is-string? :emit :macro}
+   :x-is-number?     {:macro #'lua-tf-x-is-number? :emit :macro}
+   :x-is-integer?    {:macro #'lua-tf-x-is-integer? :emit :macro}
+   :x-is-boolean?    {:macro #'lua-tf-x-is-boolean? :emit :macro}
+   :x-is-function?   {:macro #'lua-tf-x-is-function? :emit :macro}
+   :x-is-object?     {:macro #'lua-tf-x-is-object? :emit :macro}
+   :x-is-array?      {:macro #'lua-tf-x-is-array? :emit :macro}})
+
+;;
+;; LU
+;;
+
+(defn lua-tf-x-lu-create
+  ([[_]]
+   (list 'setmetatable {} {"__mode" "k"})))
+
+(defn lua-tf-x-lu-get
+  ([[_ lu obj]]
+   (h/$ (. ~lu [(tostring ~obj)]))))
+
+(defn lua-tf-x-lu-set
+  ([[_ lu obj gid]]
+   (h/$ (:= (. ~lu [(tostring ~obj)]) ~gid))))
+
+(defn lua-tf-x-lu-del
+  ([[_ lu obj]]
+   (h/$ (:= (. ~lu [(tostring ~obj)]) nil))))
+
+(def +lua-lu+
+  {:x-lu-create      {:macro #'lua-tf-x-lu-create :emit :macro}
+   :x-lu-get         {:macro #'lua-tf-x-lu-get :emit :macro}
+   :x-lu-set         {:macro #'lua-tf-x-lu-set :emit :macro}
+   :x-lu-del         {:macro #'lua-tf-x-lu-del :emit :macro}})
+
+
+;;
+;; BIT
+;;
+
+(defn lua-tf-x-bit-and
+  "lookup equals transform"
+  {:added "4.0"}
+  [[_ i1 i2]]
+  (list 'bit.band i1 i2))
+
+(defn lua-tf-x-bit-or
+  "lookup equals transform"
+  {:added "4.0"}
+  [[_ i1 i2]]
+  (list 'bit.bor i1 i2))
+
+(defn lua-tf-x-bit-lshift
+  "lookup equals transform"
+  {:added "4.0"}
+  [[_ x n]]
+  (list 'bit.lshift x n))
+
+(defn lua-tf-x-bit-rshift
+  "lookup equals transform"
+  {:added "4.0"}
+  [[_ x n]]
+  (list 'bit.rshift x n))
+
+(defn lua-tf-x-bit-xor
+  "lookup equals transform"
+  {:added "4.0"}
+  [[_ x n]]
+  (list 'bit.bxor x n))
+
+(def +lua-bit+
+  {:x-bit-and         {:macro #'lua-tf-x-bit-and    :emit :macro}
+   :x-bit-or          {:macro #'lua-tf-x-bit-or     :emit :macro}
+   :x-bit-lshift      {:macro #'lua-tf-x-bit-lshift :emit :macro}
+   :x-bit-rshift      {:macro #'lua-tf-x-bit-rshift :emit :macro}
+   :x-bit-xor         {:macro #'lua-tf-x-bit-xor :emit :macro}})
+
+;;
+;; OBJ
+;;
+
+(def +lua-obj+
+  {})
+
+;;
+;; ARR
+;;
+
+(defn lua-tf-x-arr-clone
+  [[_ arr]]
+  [(list 'unpack arr)])
+
+(defn lua-tf-x-arr-slice
+  [[_ arr start end]]
+  [(list 'unpack arr (list 'x:offset start) end)])
+
+(defn lua-tf-x-arr-remove
+  [[_ arr i]]
+  (list 'table.remove arr (list 'x:offset i)))
+
+(defn lua-tf-x-arr-push-first
+  [[_ arr item]]
+  (list 'table.insert arr 1 item))
+
+(defn lua-tf-x-arr-pop-first
+  [[_ arr]]
+  (list 'table.remove arr 1))
+
+(defn lua-tf-x-arr-insert
+  [[_ arr idx item]]
+  (list 'table.insert arr idx item))
+
+(defn lua-tf-x-arr-sort
+  [[_ arr key-fn comp-fn]]
+  (list 'table.sort arr
+        (h/$ (fn [a b]
+               (return (~comp-fn
+                        (~key-fn a)
+                        (~key-fn b)))))))
+
+(def +lua-arr+
+  {:x-arr-clone       {:macro #'lua-tf-x-arr-clone      :emit :macro  :type :template}
+   :x-arr-slice       {:macro #'lua-tf-x-arr-slice      :emit :macro  :type :template}
+   :x-arr-push        {:emit :alias :raw 'table.insert}
+   :x-arr-pop         {:emit :alias :raw 'table.remove}
+   :x-arr-remove      {:macro #'lua-tf-x-arr-remove     :emit :macro  :type :template}
+   :x-arr-find        {:macro #'lua-tf-x-arr-remove     :emit :macro  :type :template}
+   :x-arr-push-first  {:macro #'lua-tf-x-arr-push-first :emit :macro}
+   :x-arr-pop-first   {:macro #'lua-tf-x-arr-pop-first  :emit :macro}
+   :x-arr-insert      {:macro #'lua-tf-x-arr-insert     :emit :macro}
+   :x-arr-sort        {:macro #'lua-tf-x-arr-sort       :emit :macro}
+   :x-arr-str-comp    {:emit :alias :raw '<}})
+
+;;
+;; STRING
+;;
+
+(defn lua-tf-x-str-split
+  ([[_ s tok]]
+   (h/$ ('((fn [s tok]
+             (var out := {})
+             (string.gsub s
+                          (string.format "([^%s]+)" tok)
+                          (fn [c]
+                            (table.insert out c)))
+             (return out)))
+         ~s ~tok))))
+
+(defn lua-tf-x-str-join
+  ([[_ s arr]]
+   (list 'table.concat arr s)))
+
+(defn lua-tf-x-str-index-of
+  ([[_ s tok]]
+   (list 'or (list 'string.find s tok) -1)))
+
+(defn lua-tf-x-str-to-fixed
+  ([[_ num digits]]
+   (list 'string.format (list 'cat "%." digits "f")  num)))
+
+(defn lua-tf-x-str-replace
+  ([[_ s tok replacement]]
+   (list 'string.gsub s tok replacement)))
+
+(defn lua-tf-x-str-trim
+  ([[_ s]]
+   (list 'string.gsub s "^%s*(.-)%s*$" "%1")))
+
+(defn lua-tf-x-str-trim-left
+  ([[_ s]]
+   (list 'string.gsub s "^%s*" "")))
+
+(defn lua-tf-x-str-trim-right
+  ([[_ s]]
+   (list 'string.gsub s "^(%s*.-)%s*$" "%1")))
+
+(def +lua-str+
+  {:x-str-char       {:emit :alias :raw 'string.byte}
+   :x-str-split      {:macro #'lua-tf-x-str-split      :emit :macro}
+   :x-str-join       {:macro #'lua-tf-x-str-join       :emit :macro}
+   :x-str-index-of   {:macro #'lua-tf-x-str-index-of   :emit :macro}
+   :x-str-substring  {:emit :alias :raw 'string.sub}
+   :x-str-to-upper   {:emit :alias :raw 'string.upper}
+   :x-str-to-lower   {:emit :alias :raw 'string.lower}
+   :x-str-to-fixed   {:macro #'lua-tf-x-str-to-fixed   :emit :macro}
+   :x-str-replace    {:macro #'lua-tf-x-str-replace    :emit :macro}
+   :x-str-trim       {:macro #'lua-tf-x-str-trim       :emit :macro}
+   :x-str-trim-left  {:macro #'lua-tf-x-str-trim-left  :emit :macro}
+   :x-str-trim-right {:macro #'lua-tf-x-str-trim-right :emit :macro}})
+
+;;
+;; JSON
+;;
+
+(def +lua-js+
+  {:x-json-encode      {:emit :alias :raw 'cjson.encode}
+   :x-json-decode      {:emit :alias :raw 'cjson.decode}})
+
+;;
+;; RETURN
+;;
+
+(defn lua-tf-x-return-encode
+  ([[_ out id key]]
+   (h/$ (do (do (local ret nil)
+                (local '[r-ok r-err]
+                       (pcall (fn []
+                                (cond (== nil ~out)
+                                      (:= ret (cjson.encode {:id  ~id
+                                                             :key ~key
+                                                             :type "data"
+                                                             :value (. cjson ["null"])}))
+
+                                      :else
+                                      (:= ret (cjson.encode {:id  ~id
+                                                             :key ~key
+                                                             :type "data"
+                                                             :value ~out}))))))
+                (cond r-err
+                      (return (cjson.encode {:id  ~id
+                                             :key ~key
+                                             :type "raw"
+                                             :error (tostring r-err)
+                                             :value (tostring ~out)}))
+
+                      :else
+                      (return ret)))))))
+
+(defn lua-tf-x-return-wrap
+  ([[_ f encode-fn]]
+   (h/$ (do (local out)
+            (local '[o-ok o-err] (pcall (fn [] (:= out (~f)))))
+            (cond o-err
+                  (return (cjson.encode {:type "error"
+                                         :value o-err}))
+
+                  :else
+                  (return (~encode-fn out)))))))
+
+(defn lua-tf-x-return-eval
+  ([[_ s wrap-fn]]
+   (h/$ (return (~wrap-fn
+                 (fn []
+                   (local load-fn (or loadstring load))
+                   (local '[f err] (load-fn ~s))
+                   (if err
+                     (error err)
+                     (return (f)))))))))
+
+(def +lua-return+
+  {:x-return-encode  {:macro #'lua-tf-x-return-encode   :emit :macro}
+   :x-return-wrap    {:macro #'lua-tf-x-return-wrap     :emit :macro}
+   :x-return-eval    {:macro #'lua-tf-x-return-eval     :emit :macro}})
+
+;;
+;; SOCKET
+;;
+
+(defn lua-tf-x-socket-connect
+  ([[_ host port opts]]
+   (h/$ (do* (local '[conn err])
+             (local '[ok res] (pcall (fn:> [] (not= nil ngx))))
+             (when (== ~host "host.docker.internal")
+               (local handle (io.popen
+                              (cat "ping host.docker.internal -c 1 -q 2>&1"
+                                   " | "
+                                   "grep -Po \"(\\d{1,3}\\.){3}\\d{1,3}\"")))
+
+               (:= ~host (handle:read "*a"))
+               (:= ~host (string.sub ~host 1 (- (len ~host) 1)))
+               (handle:close))
+             (if (and ok res)
+               (do (:= conn (ngx.socket.tcp))
+                   (:= '[res err]  (conn:connect ~host ~port)))
+               (do (local socket (require "socket"))
+                   (:= '[conn err] (socket.connect ~host ~port))))
+             (return conn err)))))
+
+(defn lua-tf-x-socket-send
+  ([[_ conn s]]
+   (h/$ (. ~conn (send ~s)))))
+
+(defn lua-tf-x-socket-close
+  ([[_ conn]]
+   (h/$ (. ~conn (close)))))
+
+(def +lua-socket+
+  {:x-socket-connect      {:macro #'lua-tf-x-socket-connect      :emit :macro}
+   :x-socket-send         {:macro #'lua-tf-x-socket-send         :emit :macro}
+   :x-socket-close        {:macro #'lua-tf-x-socket-close        :emit :macro}})
+
+
+;;
+;; ITER
+;;
+
+(defn lua-tf-x-iter-from-obj
+  ([[_ obj]]
+   (h/$ (coroutine.wrap
+         (fn [] (for [k v :in (pairs ~obj)]
+                  (coroutine.yield [k v])))))))
+
+(defn lua-tf-x-iter-from-arr
+  ([[_ arr]]
+   (h/$ (coroutine.wrap
+          (fn [] (for [_ v :in (ipairs ~arr)]
+                   (coroutine.yield v)))))))
+
+(defn lua-tf-x-iter-from
+  ([[_ obj]]
+   (h/$ (coroutine.wrap
+         (fn [] (for [e :in (. ~obj ["iterator"])]
+                  (coroutine.yield v)))))))
+
+(defn lua-tf-x-iter-eq
+  ([[_ it0 it1 eq-fn]]
+   (h/$ (do (for [x0 :in ~it0]
+              (var x1 (~it1))
+              (when (not (~eq-fn x0 x1))
+                (return false)))
+            (return (== nil (~it1)))))))
+
+(defn lua-tf-x-iter-next
+  ([[_ it]]
+   (list it)))
+
+(defn lua-tf-x-iter-has?
+  ([[_ obj]]
+   (h/$ (and (== "table" (type ~obj))
+             (== "function" (. '(~obj) ["iterator"]))))))
+
+(defn lua-tf-x-iter-native?
+  ([[_ it]]
+   (list '== "function" (list 'type it))))
+
+(def +lua-iter+
+  {:x-iter-from-obj       {:macro #'lua-tf-x-iter-from-obj       :emit :macro}
+   :x-iter-from-arr       {:macro #'lua-tf-x-iter-from-arr       :emit :macro}
+   :x-iter-from           {:macro #'lua-tf-x-iter-from           :emit :macro}
+   :x-iter-eq             {:macro #'lua-tf-x-iter-eq             :emit :macro}
+   :x-iter-next           {:macro #'lua-tf-x-iter-next           :emit :macro}
+   :x-iter-has?           {:macro #'lua-tf-x-iter-has?           :emit :macro}
+   :x-iter-native?        {:macro #'lua-tf-x-iter-native?        :emit :macro}})
+
+;;
+;; CACHE
+;;
+
+(defn lua-tf-x-cache
+  ([[_ key]]
+   (list '. 'ngx.shared [(if (symbol? key)
+                           key
+                           (h/strn key))])))
+
+(defn lua-tf-x-cache-list
+  ([[_ cache]]
+   (list '. cache '(get-keys 0))))
+
+(defn lua-tf-x-cache-flush
+  ([[_ cache]]
+   (list '. cache '(flush-all))))
+
+(defn lua-tf-x-cache-get
+  ([[_ cache key]]
+   (list '. cache (list 'get key))))
+
+(defn lua-tf-x-cache-set
+  ([[_ cache key val]]
+   (list '. cache (list 'set key val))))
+
+(defn lua-tf-x-cache-del
+  ([[_ cache key]]
+   (list '. cache (list 'delete key))))
+
+(defn lua-tf-x-cache-incr
+  ([[_ cache key num]]
+   (list '. cache (list 'incr key num))))
+
+(def +lua-cache+
+  {:x-cache                 {:macro #'lua-tf-x-cache          :emit :macro}
+   :x-cache-list            {:macro #'lua-tf-x-cache-list      :emit :macro}
+   :x-cache-flush           {:macro #'lua-tf-x-cache-flush     :emit :macro}
+   :x-cache-get             {:macro #'lua-tf-x-cache-get       :emit :macro}
+   :x-cache-set             {:macro #'lua-tf-x-cache-set       :emit :macro}
+   :x-cache-del             {:macro #'lua-tf-x-cache-del       :emit :macro}
+   :x-cache-incr            {:macro #'lua-tf-x-cache-incr      :emit :macro}})
+
+
+;;
+;; THREAD
+;;
+
+(defn lua-tf-x-thread-spawn
+  ([[_ thunk & [strategy]]]
+   (case strategy
+     :mock  (list 'coroutine.create thunk)
+     (list 'ngx.thread.spawn  thunk))))
+
+(defn lua-tf-x-thread-join
+  ([[_ thread & [strategy]]]
+   (case strategy
+     :mock (list  'coroutine.resume thread)
+     (list 'ngx.thread.wait thread))))
+
+(defn lua-tf-x-with-delay
+  ([[_ thunk ms]]
+   (list 'return (list 'ngx.thread.spawn (list 'fn []
+                                              (list 'ngx.sleep (list '/ ms 1000))
+                                              (list 'var 'f := thunk)
+                                              (list 'return (list 'f)))))))
+
+(def +lua-thread+
+  {:x-thread-spawn   {:macro #'lua-tf-x-thread-spawn  :emit :macro}
+   :x-thread-join    {:macro #'lua-tf-x-thread-join   :emit :macro}
+   :x-with-delay     {:macro #'lua-tf-x-with-delay    :emit :macro}})
+
+;;
+;; BASE 64
+;;
+
+(def +lua-b64+
+  {:x-b64-decode     {:emit :alias :raw 'ngx.decode-base64}
+   :x-b64-encode     {:emit :alias :raw 'ngx.encode-base64}})
+
+
+;;
+;; URI
+;;
+
+(def +lua-uri+
+  {:x-uri-decode     {:emit :alias :raw 'ngx.unescape-uri}
+   :x-uri-encode     {:emit :alias :raw 'ngx.escape-uri}})
+
+
+;;
+;; FILE
+;;
+
+(defn lua-tf-x-slurp
+  ([[_ filename]]))
+
+(defn lua-tf-x-spit
+  ([[_ filename s]]))
+
+(def +lua-file+
+  {:x-slurp          {:macro #'lua-tf-x-slurp         :emit :macro}
+   :x-spit           {:macro #'lua-tf-x-spit          :emit :macro}})
+
+;;
+;; SPECIAL
+;;
+
+(def +lua-special+
+  {})
+
+(def +lua+
+  (merge +lua-core+
+         +lua-proto+
+         +lua-global+
+         +lua-custom+
+         +lua-math+
+         +lua-type+
+         +lua-bit+
+         +lua-lu+
+         +lua-obj+
+         +lua-arr+
+         +lua-str+
+         +lua-js+
+         +lua-return+
+         +lua-socket+
+         +lua-iter+
+         +lua-cache+
+         +lua-thread+
+         +lua-file+
+         +lua-b64+
+         +lua-uri+
+         +lua-special+))

--- a/src/bb/lang/model/spec_xtalk/fn_perl.clj
+++ b/src/bb/lang/model/spec_xtalk/fn_perl.clj
@@ -1,0 +1,166 @@
+(ns bb.lang.model.spec-xtalk.fn-perl
+  (:require [bb.lib :as h]))
+
+;;
+;; CORE
+;;
+
+(defn perl-tf-x-len
+  [[_ arr]]
+  (list 'scalar arr))
+
+(defn perl-tf-x-cat
+  [[_ & args]]
+  (apply list 'concat args))
+
+(defn perl-tf-x-print
+  [[_ & args]]
+  (apply list 'print (concat args ["\n"])))
+
+(def +perl-core+
+  {:x-len            {:macro #'perl-tf-x-len  :emit :macro :symbol #{'x:len}}
+   :x-cat            {:macro #'perl-tf-x-cat  :emit :macro :value true :symbol #{'x:cat}}
+   :x-print          {:macro #'perl-tf-x-print :emit :macro :symbol #{'x:print}}})
+
+;;
+;; MATH
+;;
+
+(defn perl-tf-x-m-abs   [[_ n]] (list 'abs n))
+(defn perl-tf-x-m-cos   [[_ n]] (list 'cos n))
+(defn perl-tf-x-m-sin   [[_ n]] (list 'sin n))
+(defn perl-tf-x-m-sqrt  [[_ n]] (list 'sqrt n))
+(defn perl-tf-x-m-log   [[_ n]] (list 'log n))
+(defn perl-tf-x-m-exp   [[_ n]] (list 'exp n))
+(defn perl-tf-x-m-pow   [[_ b p]] (list '** b p))
+
+(def +perl-math+
+  {:x-m-abs           {:macro #'perl-tf-x-m-abs :emit :macro :value true :symbol #{'x:m-abs}}
+   :x-m-cos           {:macro #'perl-tf-x-m-cos :emit :macro :value true :symbol #{'x:m-cos}}
+   :x-m-sin           {:macro #'perl-tf-x-m-sin :emit :macro :value true :symbol #{'x:m-sin}}
+   :x-m-sqrt          {:macro #'perl-tf-x-m-sqrt :emit :macro :value true :symbol #{'x:m-sqrt}}
+   :x-m-loge          {:macro #'perl-tf-x-m-log :emit :macro :value true :symbol #{'x:m-loge}}
+   :x-m-exp           {:macro #'perl-tf-x-m-exp :emit :macro :value true :symbol #{'x:m-exp}}
+   :x-m-pow           {:macro #'perl-tf-x-m-pow :emit :macro :value true :symbol #{'x:m-pow}}})
+
+;;
+;; ARR
+;;
+
+(defn perl-tf-x-arr-push
+  [[_ arr item]]
+  (list 'push arr item))
+
+(defn perl-tf-x-arr-pop
+  [[_ arr]]
+  (list 'pop arr))
+
+(defn perl-tf-x-arr-push-first
+  [[_ arr item]]
+  (list 'unshift arr item))
+
+(defn perl-tf-x-arr-pop-first
+  [[_ arr]]
+  (list 'shift arr))
+
+(def +perl-arr+
+  {:x-arr-push        {:macro #'perl-tf-x-arr-push       :emit :macro :symbol #{'x:arr-push}}
+   :x-arr-pop         {:macro #'perl-tf-x-arr-pop        :emit :macro :symbol #{'x:arr-pop}}
+   :x-arr-push-first  {:macro #'perl-tf-x-arr-push-first :emit :macro :symbol #{'x:arr-push-first}}
+   :x-arr-pop-first   {:macro #'perl-tf-x-arr-pop-first  :emit :macro :symbol #{'x:arr-pop-first}}})
+
+;;
+;; STRING
+;;
+
+(defn perl-tf-x-str-split
+  ([[_ s tok]]
+   (list 'split tok s)))
+
+(defn perl-tf-x-str-join
+  ([[_ s arr]]
+   (list 'join s arr)))
+
+(defn perl-tf-x-str-index-of
+  ([[_ s tok]]
+   (list 'index s tok)))
+
+(defn perl-tf-x-str-substring
+  ([[_ s start & [len]]]
+   (if len
+     (list 'substr s start len)
+     (list 'substr s start))))
+
+(defn perl-tf-x-str-to-upper
+  ([[_ s]]
+   (list 'uc s)))
+
+(defn perl-tf-x-str-to-lower
+  ([[_ s]]
+   (list 'lc s)))
+
+(def +perl-str+
+  {:x-str-split       {:macro #'perl-tf-x-str-split      :emit :macro :symbol #{'x:str-split}}
+   :x-str-join        {:macro #'perl-tf-x-str-join       :emit :macro :symbol #{'x:str-join}}
+   :x-str-index-of    {:macro #'perl-tf-x-str-index-of   :emit :macro :symbol #{'x:str-index-of}}
+   :x-str-substring   {:macro #'perl-tf-x-str-substring  :emit :macro :symbol #{'x:str-substring}}
+   :x-str-to-upper    {:macro #'perl-tf-x-str-to-upper   :emit :macro :symbol #{'x:str-to-upper}}
+   :x-str-to-lower    {:macro #'perl-tf-x-str-to-lower   :emit :macro :symbol #{'x:str-to-lower}}})
+
+;;
+;; TYPE
+;;
+
+(def +perl-type+
+  {:x-to-string {:emit :macro
+                 :macro (fn [[_ s]] (list '. "\"\"" s))
+                 :symbol #{'x:to-string}}})
+
+;;
+;; RETURN
+;;
+
+(defn perl-tf-x-return-encode
+  ([[_ out id key]]
+   (h/$ (do (:- "use JSON::PP;")
+            (var res (eval
+                      (return (encode_json {:id  ~id
+                                   :key ~key
+                                   :type  "data"
+                                   :value  ~out}))))
+            (if ~(symbol "$@")
+              (return (encode_json {:id  ~id
+                                    :key ~key
+                                    :type  "raw"
+                                    :value (x:to-string ~out)})))
+            (return res)))))
+
+(defn perl-tf-x-return-wrap
+  ([[_ f encode-fn]]
+   (let [f-var (symbol (str "$" (h/strn f) "->"))]
+     (h/$ (do (:- "use JSON::PP;")
+              (var out)
+              (eval
+               (:= out (~f-var)))
+              (if ~(symbol "$@")
+                (return (encode_json {:type "error"
+                                      :value (x:to-string ~(symbol "$@"))})))
+              (return (~encode-fn out nil nil)))))))
+
+(defn perl-tf-x-return-eval
+  ([[_ s wrap-fn]]
+   (h/$ (return (~wrap-fn (fn []
+                            (return (eval ~s))))))))
+
+(def +perl-return+
+  {:x-return-encode  {:macro #'perl-tf-x-return-encode   :emit :macro}
+   :x-return-wrap    {:macro #'perl-tf-x-return-wrap     :emit :macro}
+   :x-return-eval    {:macro #'perl-tf-x-return-eval     :emit :macro}})
+
+(def +perl+
+  (merge +perl-core+
+         +perl-math+
+         +perl-arr+
+         +perl-str+
+         +perl-type+
+         +perl-return+))

--- a/src/bb/lang/model/spec_xtalk/fn_php.clj
+++ b/src/bb/lang/model/spec_xtalk/fn_php.clj
@@ -1,0 +1,266 @@
+(ns bb.lang.model.spec-xtalk.fn-php
+  (:require [bb.lib :as h]))
+
+;;
+;; CORE
+;;
+
+(defn php-tf-x-len
+  [[_ arr]]
+  (list 'count arr))
+
+(defn php-tf-x-cat
+  [[_ & args]]
+  (apply list '. args))
+
+(defn php-tf-x-apply
+  [[_ f args]]
+  (list 'call_user_func_array f args))
+
+(defn php-tf-x-shell
+  ([[_ s opts]]
+   (list 'shell_exec s)))
+
+(defn php-tf-x-random
+  [_]
+  (list '/ (list 'rand 0 (list 'getrandmax)) (list 'getrandmax)))
+
+(defn php-tf-x-type-native
+  [[_ obj]]
+  (list 'gettype obj))
+
+(defn php-tf-x-err
+  [[_ msg]]
+  (list 'throw (list 'new 'Exception msg)))
+
+(defn php-tf-x-eval
+  [[_ s]]
+  (list 'eval s))
+
+(defn php-tf-x-print
+  ([[_ & args]]
+   (apply list 'var_dump args)))
+
+(defn php-tf-x-now-ms
+  [_]
+  (list '* 1000 (list 'microtime true)))
+
+(def +php-core+
+  {:x-del            {:emit :alias :raw 'unset}
+   :x-cat            {:macro #'php-tf-x-cat  :emit :macro}
+   :x-len            {:macro #'php-tf-x-len  :emit :macro}
+   :x-err            {:macro #'php-tf-x-err  :emit :macro}
+   :x-eval           {:macro #'php-tf-x-eval :emit :macro}
+   :x-apply          {:macro #'php-tf-x-apply :emit :macro}
+   :x-unpack         {:emit :alias :raw :...}
+   :x-print          {:macro #'php-tf-x-print :emit :macro :value true}
+   :x-random         {:macro #'php-tf-x-random :emit :macro :value true}
+   :x-shell          {:macro #'php-tf-x-shell :emit :macro}
+   :x-now-ms         {:macro #'php-tf-x-now-ms :emit :macro}
+   :x-type-native    {:macro #'php-tf-x-type-native :emit :macro}})
+
+;;
+;; MATH
+;;
+
+(defn php-tf-x-m-max   [[_ & args]] (apply list 'max args))
+(defn php-tf-x-m-min   [[_ & args]] (apply list 'min args))
+(defn php-tf-x-m-mod   [[_ num denom]] (list :% num (list :- " % ") denom))
+(defn php-tf-x-m-quot  [[_ num denom]] (list 'floor (list '/ num denom)))
+
+(def +php-math+
+  {:x-m-abs           {:emit :alias :raw 'abs  :value true}
+   :x-m-acos          {:emit :alias :raw 'acos :value true}
+   :x-m-asin          {:emit :alias :raw 'asin :value true}
+   :x-m-atan          {:emit :alias :raw 'atan :value true}
+   :x-m-ceil          {:emit :alias :raw 'ceil :value true}
+   :x-m-cos           {:emit :alias :raw 'cos  :value true}
+   :x-m-cosh          {:emit :alias :raw 'cosh :value true}
+   :x-m-exp           {:emit :alias :raw 'exp  :value true}
+   :x-m-floor         {:emit :alias :raw 'floor :value true}
+   :x-m-loge          {:emit :alias :raw 'log  :value true}
+   :x-m-log10         {:emit :alias :raw 'log10 :value true}
+   :x-m-max           {:macro #'php-tf-x-m-max,      :raw 'max :emit :macro :value true}
+   :x-m-min           {:macro #'php-tf-x-m-min,      :raw 'min :emit :macro :value true}
+   :x-m-mod           {:macro #'php-tf-x-m-mod,      :emit :macro}
+   :x-m-pow           {:emit :alias :raw 'pow  :value true}
+   :x-m-quot          {:macro #'php-tf-x-m-quot,     :emit :macro}
+   :x-m-sin           {:emit :alias :raw 'sin  :value true}
+   :x-m-sinh          {:emit :alias :raw 'sinh :value true}
+   :x-m-sqrt          {:emit :alias :raw 'sqrt :value true}
+   :x-m-tan           {:emit :alias :raw 'tan  :value true}
+   :x-m-tanh          {:emit :alias :raw 'tanh :value true}})
+
+;;
+;; TYPE
+;;
+
+(defn php-tf-x-is-string?
+  [[_ e]]
+  (list 'is_string e))
+
+(defn php-tf-x-is-number?
+  [[_ e]]
+  (list 'or (list 'is_int e) (list 'is_float e)))
+
+(defn php-tf-x-is-integer?
+  [[_ e]]
+  (list 'is_int e))
+
+(defn php-tf-x-is-boolean?
+  [[_ e]]
+  (list 'is_bool e))
+
+(defn php-tf-x-is-object?
+  [[_ e]]
+  (list 'is_object e))
+
+(defn php-tf-x-is-array?
+  [[_ e]]
+  (list 'is_array e))
+
+(def +php-type+
+  {:x-to-string      {:emit :alias :raw '(string)}
+   :x-to-number      {:emit :alias :raw '(float)}
+   :x-is-string?     {:macro #'php-tf-x-is-string? :emit :macro}
+   :x-is-number?     {:macro #'php-tf-x-is-number? :emit :macro}
+   :x-is-integer?    {:macro #'php-tf-x-is-integer? :emit :macro}
+   :x-is-boolean?    {:macro #'php-tf-x-is-boolean? :emit :macro}
+   :x-is-function?   {:emit :alias :raw 'is_callable}
+   :x-is-object?     {:macro #'php-tf-x-is-object? :emit :macro}
+   :x-is-array?      {:macro #'php-tf-x-is-array? :emit :macro}})
+
+;;
+;; ARR
+;;
+
+(defn php-tf-x-arr-push
+  [[_ arr item]]
+  (list 'array_push arr item))
+
+(defn php-tf-x-arr-pop
+  [[_ arr]]
+  (list 'array_pop arr))
+
+(defn php-tf-x-arr-push-first
+  [[_ arr item]]
+  (list 'array_unshift arr item))
+
+(defn php-tf-x-arr-pop-first
+  [[_ arr]]
+  (list 'array_shift arr))
+
+(defn php-tf-x-arr-slice
+  [[_ arr start end]]
+  (list 'array_slice arr start (if end (list '- end start) nil)))
+
+(def +php-arr+
+  {:x-arr-push        {:macro #'php-tf-x-arr-push       :emit :macro}
+   :x-arr-pop         {:macro #'php-tf-x-arr-pop        :emit :macro}
+   :x-arr-push-first  {:macro #'php-tf-x-arr-push-first :emit :macro}
+   :x-arr-pop-first   {:macro #'php-tf-x-arr-pop-first  :emit :macro}
+   :x-arr-slice       {:macro #'php-tf-x-arr-slice      :emit :macro}})
+
+;;
+;; STRING
+;;
+
+(defn php-tf-x-str-char
+  ([[_ s i]]
+   (list 'ord (list 'substr s i 1))))
+
+(defn php-tf-x-str-split
+  ([[_ s tok]]
+   (list 'explode tok s)))
+
+(defn php-tf-x-str-join
+  ([[_ s arr]]
+   (list 'implode s arr)))
+
+(defn php-tf-x-str-index-of
+  ([[_ s tok]]
+   (list 'strpos s tok)))
+
+(defn php-tf-x-str-substring
+  ([[_ s start & args]]
+   (list 'substr s start (first args))))
+
+(defn php-tf-x-str-to-upper
+  ([[_ s]]
+   (list 'strtoupper s)))
+
+(defn php-tf-x-str-to-lower
+  ([[_ s]]
+   (list 'strtolower s)))
+
+(defn php-tf-x-str-replace
+  ([[_ s tok replacement]]
+   (list 'str_replace tok replacement s)))
+
+(defn php-tf-x-str-trim
+  ([[_ s]]
+   (list 'trim s)))
+
+(def +php-str+
+  {:x-str-char        {:macro #'php-tf-x-str-char       :emit :macro}
+   :x-str-split       {:macro #'php-tf-x-str-split      :emit :macro}
+   :x-str-join        {:macro #'php-tf-x-str-join       :emit :macro}
+   :x-str-index-of    {:macro #'php-tf-x-str-index-of   :emit :macro}
+   :x-str-substring   {:macro #'php-tf-x-str-substring  :emit :macro}
+   :x-str-to-upper    {:macro #'php-tf-x-str-to-upper   :emit :macro}
+   :x-str-to-lower    {:macro #'php-tf-x-str-to-lower   :emit :macro}
+   :x-str-replace     {:macro #'php-tf-x-str-replace    :emit :macro}
+   :x-str-trim        {:macro #'php-tf-x-str-trim       :emit :macro}})
+
+;;
+;; JSON
+;;
+
+(def +php-js+
+  {:x-json-encode      {:emit :alias :raw 'json_encode}
+   :x-json-decode      {:emit :alias :raw 'json_decode}})
+
+;;
+;; RETURN
+;;
+
+(defn php-tf-x-return-encode
+  ([[_ out id key]]
+   (h/$ (do (try
+              (return (json_encode {:id  ~id
+                                    :key ~key
+                                    :type  "data"
+                                    :value  ~out}))
+              (catch Exception $e
+                (return (json_encode {:id ~id
+                                      :key ~key
+                                      :type  "raw"
+                                      :value (. "" ~out)}))))))))
+
+(defn php-tf-x-return-wrap
+  ([[_ f encode-fn]]
+   (h/$ (do (try
+              (:= out (~f))
+              (catch Exception $e
+                (return (json_encode {:type "error"
+                                      :value (. "" $e)}))))
+            (return (~encode-fn out nil nil))))))
+
+(defn php-tf-x-return-eval
+  ([[_ s wrap-fn]]
+   (h/$ (return (~wrap-fn (function []
+                            (return (eval ~s))))))))
+
+(def +php-return+
+  {:x-return-encode  {:macro #'php-tf-x-return-encode   :emit :macro}
+   :x-return-wrap    {:macro #'php-tf-x-return-wrap     :emit :macro}
+   :x-return-eval    {:macro #'php-tf-x-return-eval     :emit :macro}})
+
+(def +php+
+  (merge +php-core+
+         +php-math+
+         +php-type+
+         +php-arr+
+         +php-str+
+         +php-js+
+         +php-return+))

--- a/src/bb/lang/model/spec_xtalk/fn_python.clj
+++ b/src/bb/lang/model/spec_xtalk/fn_python.clj
@@ -1,0 +1,678 @@
+(ns bb.lang.model.spec-xtalk.fn-python
+  (:require [bb.lib :as h]))
+
+(defn python-tf-x-del
+  [[_ obj]]
+  (list 'del obj))
+
+(defn python-tf-x-cat
+  [[_ & args]]
+  (apply list '+ args))
+
+(defn python-tf-x-len
+  [[_ arr]]
+  (list 'len arr))
+
+(defn python-tf-x-get-key
+  [[_ obj key default]]
+  (let [val (list '. obj (list 'get key))]
+    (if default
+      (list 'or val default)
+      val)))
+
+(defn python-tf-x-err
+  [[_ msg]]
+  (list 'throw (list 'Exception msg)))
+
+(defn python-tf-x-eval
+  [[_ s]]
+  (list 'eval s))
+
+(defn python-tf-x-apply
+  [[_ f args]]
+  (list f (list :* args)))
+
+(defn python-tf-x-random
+  [_]
+  '(. (__import__ "random")
+      (random)))
+
+(defn python-tf-x-print
+  ([[_ & args]]
+   (apply list 'print args)))
+
+(defn python-tf-x-shell
+  ([[_ s cm]]
+   (h/$ (do (var res (. (__import__ "os") (system ~s)))
+            (var f (. ~cm (get "success")))
+            (if f
+              (return (f res))
+              (return res))))))
+
+(defn python-tf-x-type-native
+  [[_ obj]]
+  (h/$ (cond (isinstance ~obj '(dict))
+             (return "object")
+
+             (isinstance ~obj '(list))
+             (return "array")
+
+             (callable ~obj)
+             (return "function")
+
+             (== bool (type ~obj))
+             (return "boolean")
+
+             (isinstance ~obj '(int float))
+             (return "number")
+
+             (isinstance ~obj '(str))
+             (return "string")
+
+             :else
+             (return (str (type ~obj))))))
+
+(def +python-core+
+  {:x-del            {:macro #'python-tf-x-del    :emit :macro}
+   :x-cat            {:macro #'python-tf-x-cat    :emit :macro}
+   :x-len            {:macro #'python-tf-x-len    :emit :macro}
+   :x-err            {:macro #'python-tf-x-err     :emit :macro}
+   :x-eval           {:macro #'python-tf-x-eval    :emit :macro}
+   :x-apply          {:macro #'python-tf-x-apply   :emit :macro}
+   :x-unpack         {:raw :*  :emit :alias}
+   :x-random         {:macro #'python-tf-x-random  :emit :macro}
+   :x-print          {:macro #'python-tf-x-print         :emit :macro}
+   :x-shell          {:macro #'python-tf-x-shell         :emit :macro}
+   :x-now-ms         {:default '(round (* 1000 (. (__import__ "time") (time)))) :emit :unit}
+   :x-type-native    {:macro #'python-tf-x-type-native   :emit :macro}})
+
+
+;;
+;; GLOBAL
+;;
+
+(def +python-global+
+  {})
+
+;;
+;; CUSTOM
+;;
+
+(def +python-custom+
+  {:x-get-key        {:macro #'python-tf-x-get-key}})
+
+;;
+;; MATH
+;;
+
+
+(defn python-tf-x-m-abs   [[_ num]] (list 'abs num))
+(defn python-tf-x-m-acos  [[_ num]] (list '. (list '__import__ "math")
+                                          (list 'acos num)))
+(defn python-tf-x-m-asin  [[_ num]] (list '. (list '__import__ "math")
+                                          (list 'asin num)))
+(defn python-tf-x-m-atan  [[_ num]] (list '. (list '__import__ "math")
+                                          (list 'atan num)))
+(defn python-tf-x-m-ceil  [[_ num]] (list '. (list '__import__ "math")
+                                          (list 'ceil num)))
+(defn python-tf-x-m-cos   [[_ num]] (list '. (list '__import__ "math")
+                                          (list 'cos num)))
+(defn python-tf-x-m-cosh  [[_ num]] (list '. (list '__import__ "math")
+                                          (list 'cosh num)))
+(defn python-tf-x-m-exp   [[_ num]] (list '. (list '__import__ "math")
+                                          (list 'exp num)))
+(defn python-tf-x-m-floor [[_ num]] (list '. (list '__import__ "math")
+                                          (list 'floor num)))
+(defn python-tf-x-m-loge  [[_ num]] (list '. (list '__import__ "math")
+                                          (list 'log num)))
+(defn python-tf-x-m-log10 [[_ num]] (list '. (list '__import__ "math")
+                                          (list 'log10 num)))
+(defn python-tf-x-m-max   [[_ & args]] (apply list 'max args))
+(defn python-tf-x-m-min   [[_ & args]] (apply list 'min args))
+(defn python-tf-x-m-mod   [[_ num denom]] (list :% num (list :- " % ") denom))
+(defn python-tf-x-m-quot  [[_ num denom]] (list :% num (list :- " // ") denom))
+(defn python-tf-x-m-pow   [[_ base n]] (list 'pow base n))
+(defn python-tf-x-m-sin   [[_ num]] (list '. (list '__import__ "math")
+                                          (list 'sin num)))
+(defn python-tf-x-m-sinh  [[_ num]] (list '. (list '__import__ "math")
+                                          (list 'sinh num)))
+(defn python-tf-x-m-sqrt  [[_ num]] (list '. (list '__import__ "math")
+                                          (list 'sqrt num)))
+(defn python-tf-x-m-tan   [[_ num]] (list '. (list '__import__ "math")
+                                          (list 'tan num)))
+(defn python-tf-x-m-tanh  [[_ num]] (list '. (list '__import__ "math")
+                                          (list 'tanh num)))
+
+(def +python-math+
+  {:x-m-abs           {:macro #'python-tf-x-m-abs,                 :emit :macro}
+   :x-m-acos          {:macro #'python-tf-x-m-acos,                :emit :macro}
+   :x-m-asin          {:macro #'python-tf-x-m-asin,                :emit :macro}
+   :x-m-atan          {:macro #'python-tf-x-m-atan,                :emit :macro}
+   :x-m-ceil          {:macro #'python-tf-x-m-ceil,                :emit :macro}
+   :x-m-cos           {:macro #'python-tf-x-m-cos,                 :emit :macro}
+   :x-m-cosh          {:macro #'python-tf-x-m-cosh,                :emit :macro}
+   :x-m-exp           {:macro #'python-tf-x-m-exp,                 :emit :macro}
+   :x-m-floor         {:macro #'python-tf-x-m-floor,               :emit :macro}
+   :x-m-loge          {:macro #'python-tf-x-m-loge,                :emit :macro}
+   :x-m-log10         {:macro #'python-tf-x-m-log10,               :emit :macro}
+   :x-m-max           {:macro #'python-tf-x-m-max,                 :emit :macro}
+   :x-m-min           {:macro #'python-tf-x-m-min,                 :emit :macro}
+   :x-m-mod           {:macro #'python-tf-x-m-mod,                 :emit :macro}
+   :x-m-pow           {:macro #'python-tf-x-m-pow,                 :emit :macro}
+   :x-m-quot          {:macro #'python-tf-x-m-quot,                :emit :macro}
+   :x-m-sin           {:macro #'python-tf-x-m-sin,                 :emit :macro}
+   :x-m-sinh          {:macro #'python-tf-x-m-sinh,                :emit :macro}
+   :x-m-sqrt          {:macro #'python-tf-x-m-sqrt,                :emit :macro}
+   :x-m-tan           {:macro #'python-tf-x-m-tan,                 :emit :macro}
+   :x-m-tanh          {:macro #'python-tf-x-m-tanh,                :emit :macro}})
+
+;;
+;; TYPE
+;;
+
+(defn python-tf-x-to-string
+  [[_ e]]
+  (list 'str e))
+
+(defn python-tf-x-to-number
+  [[_ e]]
+  (list 'float e))
+
+(defn python-tf-x-is-string?
+  [[_ e]]
+  (list 'isinstance e 'str))
+
+(defn python-tf-x-is-number?
+  [[_ e]]
+  (list 'isinstance e ''(int float)))
+
+(defn python-tf-x-is-integer?
+  [[_ e]]
+  (list 'isinstance e ''(int)))
+
+(defn python-tf-x-is-boolean?
+  [[_ e]]
+  (list '== 'bool (list 'type e)))
+
+(defn python-tf-x-is-function?
+  [[_ e]]
+  (list 'callable e))
+
+(defn python-tf-x-is-object?
+  [[_ e]]
+  (list 'isinstance e 'dict))
+
+(defn python-tf-x-is-array?
+  [[_ e]]
+  (list 'isinstance e 'list))
+
+(def +python-type+
+  {:x-to-string      {:macro #'python-tf-x-to-string :emit :macro}
+   :x-to-number      {:macro #'python-tf-x-to-number :emit :macro}
+   :x-is-string?     {:macro #'python-tf-x-is-string? :emit :macro}
+   :x-is-number?     {:macro #'python-tf-x-is-number? :emit :macro}
+   :x-is-integer?    {:macro #'python-tf-x-is-integer? :emit :macro}
+   :x-is-boolean?    {:macro #'python-tf-x-is-boolean? :emit :macro}
+   :x-is-function?   {:macro #'python-tf-x-is-function? :emit :macro}
+   :x-is-object?     {:macro #'python-tf-x-is-object? :emit :macro}
+   :x-is-array?      {:macro #'python-tf-x-is-array? :emit :macro}})
+
+;;
+;; LU
+;;
+
+
+
+(defn python-tf-x-lu-create
+  "converts map to array"
+  {:added "4.0"}
+  ([[_]]
+   '(. (__import__ "weakref")
+       (WeakKeyDictionary))))
+
+(defn python-tf-x-lu-eq
+  "converts map to array"
+  {:added "4.0"}
+  ([[_ o1 o2]]
+   (list '== (list 'id o1) (list 'id o2))))
+
+(defn python-tf-x-lu-get
+  "converts map to array"
+  {:added "4.0"}
+  ([[_ lu obj]]
+   (h/$ (. ~lu (get (id ~obj))))))
+
+(defn python-tf-x-lu-set
+  "converts map to array"
+  {:added "4.0"}
+  ([[_ lu obj gid]]
+   (h/$ (:= (. ~lu [(id ~obj)]) ~gid))))
+
+(defn python-tf-x-lu-del
+  "converts map to array"
+  {:added "4.0"}
+  ([[_ lu obj]]
+   (h/$ (del (. ~lu [(id ~obj)])))))
+
+(def +python-lu+
+  {;;:x-lu-create      {:macro #'python-tf-x-lu-create  :emit :macro}
+   :x-lu-eq          {:macro #'python-tf-x-lu-eq  :emit :macro}
+   :x-lu-get         {:macro #'python-tf-x-lu-get :emit :macro}
+   :x-lu-set         {:macro #'python-tf-x-lu-set :emit :macro}
+   :x-lu-del         {:macro #'python-tf-x-lu-del :emit :macro}})
+
+;;
+;; OBJ
+;;
+
+(defn python-tf-x-obj-keys
+  [[_ obj]]
+  (list 'return (list 'list (list '. obj '(keys)))))
+
+(defn python-tf-x-obj-vals
+  [[_ obj]]
+  (list 'return (list 'list (list '. obj '(values)))))
+
+(defn python-tf-x-obj-pairs
+  "converts map to array"
+  {:added "4.0"}
+  ([[_ obj]]
+   (list 'return (list 'list (list '. obj '(items))))))
+
+(defn python-tf-x-obj-clone
+  [[_ obj]]
+  (list 'return (list '. obj '(copy))))
+
+(def +python-obj+
+  {:x-obj-keys    {:macro #'python-tf-x-obj-keys   :emit :macro}
+   :x-obj-vals    {:macro #'python-tf-x-obj-vals   :emit :macro}
+   :x-obj-pairs   {:macro #'python-tf-x-obj-pairs  :emit :macro}
+   :x-obj-clone   {:macro #'python-tf-x-obj-clone  :emit :macro}})
+
+;;
+;; ARR
+;;
+
+(defn python-tf-x-arr-clone
+    [[_ arr]]
+    (list '. arr [(list :- ":")]))
+
+  (defn python-tf-x-arr-slice
+    [[_ arr start end]]
+    (list '. arr [(list :to start end)]))
+
+
+
+(defn python-tf-x-arr-push
+  [[_ arr item]]
+  (list '. arr (list 'append item)))
+
+(defn python-tf-x-arr-pop
+  [[_ arr]]
+  (list '. arr (list 'pop)))
+
+(defn python-tf-x-arr-reverse
+  [[_ arr]]
+  (list 'list (list 'reversed arr)))
+
+(defn python-tf-x-arr-push-first
+  [[_ arr item]]
+  (list '. arr (list 'insert 0 item)))
+
+(defn python-tf-x-arr-pop-first
+  [[_ arr]]
+  (list '. arr (list 'pop 0)))
+
+(defn python-tf-x-arr-insert
+  [[_ arr idx e]]
+  (list '. arr (list 'insert idx e)))
+
+(defn python-tf-x-arr-sort
+  [[_ arr key-fn compare-fn]]
+  (list '. arr (list 'sort :key #_key-fn
+                     (h/$ (. (__import__ "functools")
+                             (cmp_to_key
+                              (fn:> [a b]
+                                    (:? (~compare-fn
+                                         (~key-fn a)
+                                         (~key-fn b))
+                                        -1 1))))))))
+
+(defn python-tf-x-arr-str-comp
+  [[_ a b]]
+  (list '< a b))
+
+(def +python-arr+
+  {:x-arr-clone       {:macro #'python-tf-x-arr-clone      :emit :macro :type :template}
+   :x-arr-slice       {:macro #'python-tf-x-arr-slice      :emit :macro :type :template}
+   :x-arr-reverse     {:macro #'python-tf-x-arr-reverse    :emit :macro :type :template}
+   :x-arr-push        {:macro #'python-tf-x-arr-push       :emit :macro}
+   :x-arr-pop         {:macro #'python-tf-x-arr-pop        :emit :macro}
+   :x-arr-push-first  {:macro #'python-tf-x-arr-push-first :emit :macro}
+   :x-arr-pop-first   {:macro #'python-tf-x-arr-pop-first  :emit :macro}
+   :x-arr-insert      {:macro #'python-tf-x-arr-insert     :emit :macro}
+   :x-arr-sort        {:macro #'python-tf-x-arr-sort       :emit :macro}
+   :x-arr-str-comp    {:macro #'python-tf-x-arr-str-comp   :emit :macro}})
+
+
+;;
+;; STRING
+;;
+
+(defn python-tf-x-str-char
+  ([[_ s i]]
+   (list 'ord (list '. s [i]))))
+
+(defn python-tf-x-str-split
+  ([[_ s tok]]
+   (list '. s (list 'split tok))))
+
+(defn python-tf-x-str-join
+  ([[_ s arr]]
+   (list '. s (list 'join arr))))
+
+(defn python-tf-x-str-index-of
+  ([[_ s tok]]
+   (list '. s (list 'find tok))))
+
+(defn python-tf-x-str-substring
+  ([[_ s start & [end]]]
+   (h/$ (. ~s [~(list :to start (or end \0))]))))
+
+(defn python-tf-x-str-to-upper
+  ([[_ s]]
+   (list '. s '(upper))))
+
+(defn python-tf-x-str-to-lower
+  ([[_ s]]
+   (list '. s '(lower))))
+
+(defn python-tf-x-str-replace
+  ([[_ s tok replacement]]
+   (list '. s (list 'replace tok replacement))))
+
+(def +python-str+
+  {:x-str-char       {:macro #'python-tf-x-str-char      :emit :macro}
+   :x-str-split      {:macro #'python-tf-x-str-split      :emit :macro}
+   :x-str-join       {:macro #'python-tf-x-str-join       :emit :macro}
+   :x-str-index-of   {:macro #'python-tf-x-str-index-of   :emit :macro}
+   :x-str-substring  {:macro #'python-tf-x-str-substring  :emit :macro}
+   :x-str-to-upper   {:macro #'python-tf-x-str-to-upper      :emit :macro}
+   :x-str-to-lower   {:macro #'python-tf-x-str-to-lower      :emit :macro}
+   :x-str-replace    {:macro #'python-tf-x-str-replace    :emit :macro}})
+
+;;
+;; JSON
+;;
+
+(defn python-tf-x-json-encode
+  ([[_ obj]]
+   (list '. (list '__import__ "json")
+         (list 'dumps obj))))
+
+(defn python-tf-x-json-decode
+  ([[_ s]]
+   (list '. (list '__import__ "json")
+         (list 'loads s))))
+
+(def +python-js+
+  {:x-json-encode      {:macro #'python-tf-x-json-encode      :emit :macro}
+   :x-json-decode      {:macro #'python-tf-x-json-decode      :emit :macro}})
+
+;;
+;; RETURN
+;;
+
+(defn python-tf-x-return-encode
+  ([[_ out id key]]
+   (h/$ (do (:- :import json)
+            (try
+              (return (json.dumps {:id  ~id
+                                   :key ~key
+                                   :type  "data"
+                                   :value  ~out}))
+              (catch Exception
+                  (return (json.dumps {:id ~id
+                                       :key ~key
+                                       :type  "raw"
+                                       :value (str ~out)}))))))))
+
+(defn python-tf-x-return-wrap
+  ([[_ f encode-fn]]
+   (h/$ (do (:- :import json)
+            (try (:= out (~f))
+                 (catch [Exception :as e]
+                     (return (json.dumps {:type "error"
+                                          :value (str e)}))))
+            (return (~encode-fn out nil nil))))))
+
+(defn python-tf-x-return-eval
+  ([[_ s wrap-fn]]
+   (h/$ (do (fn thunk []
+              (let [g   (globals)]
+                (exec ~s g g)
+                (return (g.get "OUT"))))
+            (return (~wrap-fn thunk))))))
+
+(def +python-return+
+  {:x-return-encode  {:macro #'python-tf-x-return-encode   :emit :macro}
+   :x-return-wrap    {:macro #'python-tf-x-return-wrap     :emit :macro}
+   :x-return-eval    {:macro #'python-tf-x-return-eval     :emit :macro}})
+
+;;
+;; ITER
+;;
+
+(defn python-tf-x-socket-connect
+  ([[_ host port opts]]
+   (h/$ (do (:- :import socket)
+            (var conn   (socket.socket))
+            (conn.connect '(host port))
+            (return conn)))))
+
+(defn python-tf-x-socket-send
+  ([[_ conn s]]
+   (h/$ (. ~conn (sendall (. ~s (encode)))))))
+
+(defn python-tf-x-socket-close
+  ([[_ conn]]
+   (h/$ (. ~conn (close)))))
+
+(def +python-socket+
+  {:x-socket-connect      {:macro #'python-tf-x-socket-connect      :emit :macro}
+   :x-socket-send         {:macro #'python-tf-x-socket-send         :emit :macro}
+   :x-socket-close        {:macro #'python-tf-x-socket-close        :emit :macro}})
+
+
+;;
+;; ITER
+;;
+
+(defn python-tf-x-iter-from-obj
+  ([[_ obj]]
+   (list 'iter (list '. obj '(items)))))
+
+(defn python-tf-x-iter-from-arr
+  ([[_ arr]]
+   (list 'iter arr)))
+
+(defn python-tf-x-iter-from
+  ([[_ x]]
+   (list 'iter x)))
+
+(defn python-tf-x-iter-eq
+  ([[_ it0 it1 eq-fn]]
+   (h/$ (do (for [x0 :in ~it0]
+              (try
+                (var x1 (next ~it1))
+                (if (not (~eq-fn x0 x1))
+                  (return false))
+                (catch StopIteration (return false))))
+            (try
+              (next ~it1)
+              (return false)
+              (catch StopIteration (return true)))))))
+
+(defn python-tf-x-iter-next
+  ([[_ it]]
+   (list 'next it)))
+
+(defn python-tf-x-iter-has?
+  ([[_ x]]
+   (list 'hasattr x "__iter__")))
+
+(defn python-tf-x-iter-native?
+  ([[_ it]]
+   (list 'hasattr it "__next__")))
+
+(def +python-iter+
+  {:x-iter-from-obj       {:macro #'python-tf-x-iter-from-obj       :emit :macro}
+   :x-iter-from-arr       {:macro #'python-tf-x-iter-from-arr       :emit :macro}
+   :x-iter-from           {:macro #'python-tf-x-iter-from           :emit :macro}
+   :x-iter-eq             {:macro #'python-tf-x-iter-eq             :emit :macro}
+   :x-iter-null           {:default '(if false (yield))}
+   :x-iter-next           {:macro #'python-tf-x-iter-next           :emit :macro}
+   :x-iter-has?           {:macro #'python-tf-x-iter-has?           :emit :macro}
+   :x-iter-native?        {:macro #'python-tf-x-iter-native?        :emit :macro}})
+
+;;
+;; ASYNC
+;;
+
+(defn python-tf-x-thread-spawn
+  ([[_ thunk]]
+   (h/$ (. (__import__ "threading")
+           (Thread :target ~thunk)
+           (start)))))
+
+(defn python-tf-x-thread-spawn
+  ([[_ thunk]]
+   (with-meta
+     (h/$ (do (var threading  (__import__ "threading"))
+              (var thread := (threading.Thread :target ~thunk))
+              (. thread (start))))
+     {:assign/template 'thread})))
+
+(defn python-tf-x-thread-join
+  ([[_ thread]]
+   '(x:error "Thread join not Supported")))
+
+(defn python-tf-x-with-delay
+  ([[_ thunk ms]]
+   (h/$ (x:thread-spawn
+         (fn []
+           (return [(. (__import__ "time")
+                       (sleep (/ ~ms 1000)))
+                    ('(~thunk))]))))))
+
+(def +python-thread+
+  {:x-thread-spawn   {:macro #'python-tf-x-thread-spawn  :emit :macro   :type :template}
+   :x-thread-join    {:macro #'python-tf-x-thread-join   :emit :macro}
+   :x-with-delay     {:macro #'python-tf-x-with-delay    :emit :macro}})
+
+;;
+;; FILE
+;;
+
+(defn python-tf-x-slurp
+  ([[_ filename]]))
+
+(defn python-tf-x-spit
+  ([[_ filename s]]))
+
+(def +python-file+
+  {:x-slurp          {:macro #'python-tf-x-slurp         :emit :macro}
+   :x-spit           {:macro #'python-tf-x-spit          :emit :macro}})
+
+;;
+;; BASE 64
+;;
+
+(defn python-tf-x-b64-encode
+  ([[_ obj]]
+   (list '. (list '. (list '__import__ "base64")
+                  (list 'b64encode (list 'bytes obj "utf-8")))
+         (list 'decode "utf-8"))))
+
+(defn python-tf-x-b64-decode
+  ([[_ s]]
+   (list '. (list '. (list '__import__ "base64")
+            (list 'b64decode s))
+         (list 'decode "utf-8"))))
+
+(def +python-b64+
+  {:x-b64-decode     {:macro #'python-tf-x-b64-decode         :emit :macro}
+   :x-b64-encode     {:macro #'python-tf-x-b64-encode         :emit :macro}})
+
+(def +python+
+  (merge +python-core+
+         +python-global+
+         +python-custom+
+         +python-math+
+         +python-type+
+         +python-lu+
+         +python-obj+
+         +python-arr+
+         +python-str+
+         +python-js+
+         +python-return+
+         +python-socket+
+         +python-iter+
+         +python-thread+
+         +python-file+
+         +python-b64+))
+
+
+(comment
+
+
+
+  ;;
+  ;; FN
+  ;;
+
+  (defn python-tf-x-fn-every
+    [[_ arr pred]]
+    (h/$ (return (all (map pred arr)))))
+
+  (defn python-tf-x-fn-some
+    [[_ arr pred]]
+    (h/$ (return (any (map pred arr)))))
+
+  (defn python-tf-x-fn-foldl
+    [[_ arr f init]]
+    (h/$ (do (:- :import functools)
+             (return (functools.reduce ~f ~arr ~init)))))
+
+  (defn python-tf-x-fn-foldr
+    [[_ arr f init]]
+    (h/$ (do (:- :import functools)
+             (return (functools.reduce ~f
+                                       (:% ~arr [(:- "::-1")])
+                                       ~init)))))
+
+  (def +python-fn+
+    {:x-fn-every       {:macro #'python-tf-x-fn-every   :emit :macro}
+     :x-fn-some        {:macro #'python-tf-x-fn-some    :emit :macro}
+     :x-fn-foldl       {:macro #'python-tf-x-fn-foldl   :emit :macro}
+     :x-fn-foldr       {:macro #'python-tf-x-fn-foldr   :emit :macro}})
+
+
+  (defn python-tf-x-str-pad-left
+    ([[_ s n ch]]
+     (list '. s (list 'rjust n ch))))
+
+  (defn python-tf-x-str-pad-right
+    ([[_ s n ch]]
+     (list '. s (list 'ljust n ch))))
+  :x-str-pad-left   {:macro #'python-tf-x-str-pad-left   :emit :macro}
+  :x-str-pad-right  {:macro #'python-tf-x-str-pad-right  :emit :macro}
+
+
+  ;;
+  ;; ARR
+  ;;
+
+
+
+  )

--- a/src/bb/lang/model/spec_xtalk/fn_r.clj
+++ b/src/bb/lang/model/spec_xtalk/fn_r.clj
@@ -1,0 +1,501 @@
+^{:no-test true}
+(ns bb.lang.model.spec-xtalk.fn-r
+  (:require [bb.lib :as h]
+            [bb.lang.base.grammar-xtalk :as default]))
+
+;;
+;; CORE
+;;
+
+(defn r-tf-x-del
+  [[_ obj]]
+  (list := obj nil))
+
+(defn r-tf-x-cat
+  [[_ & args]]
+  (apply list 'paste (concat args [:sep ""])))
+
+(defn r-tf-x-len
+  [[_ arr]]
+  (list 'length arr))
+
+(defn r-tf-x-err
+  [[_ msg]]
+  (list 'stop msg))
+
+(defn r-tf-x-eval
+  [[_ s]]
+  (list 'eval (list 'parse :text s)))
+
+(defn r-tf-x-apply
+  [[_ f args]]
+  (list 'do.call f args))
+
+(defn r-tf-x-print
+  ([[_ & args]]
+   (apply list 'print args)))
+
+(defn r-tf-x-shell
+  ([[_ s cm]]
+   (h/$ (system ~s))))
+
+(defn r-tf-x-random
+  [_]
+  '(runif 1))
+
+(defn r-tf-x-type-native
+  [[_ obj]]
+  (h/$ (do (var t := (typeof ~obj))
+           (cond (== t "list")
+                 (if (not (is.null (names ~obj)))
+                   (return "object")
+                   (return "array"))
+
+                 (== t "closure")
+                 (return "function")
+
+                 (== t "double")
+                 (return "number")
+
+                 (== t "character")
+                 (return "string")
+
+                 (== t "logical")
+                 (return "boolean")
+
+                 :else (return t)))))
+
+(def +r-core+
+  {:x-del            {:macro #'r-tf-x-del   :emit :macro}
+   :x-cat            {:macro #'r-tf-x-cat   :emit :macro}
+   :x-len            {:macro #'r-tf-x-len   :emit :macro}
+   :x-err            {:macro #'r-tf-x-err     :emit :macro}
+   :x-eval           {:macro #'r-tf-x-eval    :emit :macro}
+   :x-random         {:macro #'r-tf-x-random  :emit :macro}
+   :x-apply          {:macro #'r-tf-x-apply   :emit :macro}
+   :x-print          {:macro #'r-tf-x-print         :emit :macro}
+   :x-shell          {:macro #'r-tf-x-shell         :emit :macro}
+   :x-now-ms         {:default '(floor (* 1000 (as.numeric (Sys.time)))) :emit :unit}
+   :x-type-native    {:macro #'r-tf-x-type-native    :emit :macro}})
+
+;;
+;; GLOBAL
+;;
+
+(defn r-tf-x-global-has?
+  [[_ sym]]
+  (list 'not (list 'x:nil? (list 'tryCatch (list 'get (str sym) :envir '.GlobalEnv)
+                                 :error '(fn:> [e] nil)))))
+
+(defn r-tf-x-global-set
+  [[_ sym val]]
+  (list 'assign (str sym) val :envir '.GlobalEnv))
+
+(defn r-tf-x-global-del
+  [[_ sym]]
+  (list 'assign (str sym) nil :envir '.GlobalEnv))
+
+(def +r-global+
+  {:x-global-has?   {:macro #'r-tf-x-global-has?  :emit :macro}
+   :x-global-set    {:macro #'r-tf-x-global-set   :emit :macro}
+   :x-global-del    {:macro #'r-tf-x-global-del   :emit :macro}})
+
+;;
+;; CUSTOM
+;;
+
+(defn r-tf-x-not-nil?
+  [[_ obj]]
+  (list 'not (list 'is.null obj)))
+
+(defn r-tf-x-nil?
+  [[_ obj]]
+  (list 'is.null obj))
+
+(defn r-tf-x-has-key?
+  [[_ obj key check]]
+  (if check
+    (list '== check (list 'x:get-key obj key nil))
+    (list :- (list '% key) "%in%" (list 'names obj))))
+
+(defn r-tf-x-get-key
+  [[_ obj key default]]
+  (let [val (default/tf-get-key [_ obj key])]
+    (if default
+      (list :?
+            (list 'x:has-key? obj key)
+            val
+            default)
+      val)))
+
+(def +r-custom+
+  {:x-not-nil?         {:macro #'r-tf-x-not-nil? :emit :macro}
+   :x-nil?             {:macro #'r-tf-x-nil?  :emit :macro}
+   :x-has-key?         {:macro #'r-tf-x-has-key? :emit :macro}
+   :x-get-key          {:macro #'r-tf-x-get-key :emit :macro}})
+
+;;
+;; MATH
+;;
+
+(defn r-tf-x-m-abs   [[_ num]] (list 'abs num))
+(defn r-tf-x-m-acos  [[_ num]] (list 'acos num))
+(defn r-tf-x-m-asin  [[_ num]] (list 'asin num))
+(defn r-tf-x-m-atan  [[_ num]] (list 'atan num))
+(defn r-tf-x-m-ceil  [[_ num]] (list 'ceiling num))
+(defn r-tf-x-m-cos   [[_ num]] (list 'cos num))
+(defn r-tf-x-m-cosh  [[_ num]] (list 'cosh num))
+(defn r-tf-x-m-exp   [[_ num]] (list 'exp num))
+(defn r-tf-x-m-floor [[_ num]] (list 'floor num))
+(defn r-tf-x-m-loge  [[_ num]] (list 'log num))
+(defn r-tf-x-m-log10 [[_ num]] (list 'log10 num))
+(defn r-tf-x-m-max   [[_ & args]] (apply list 'max args))
+(defn r-tf-x-m-min   [[_ & args]] (apply list 'min args))
+(defn r-tf-x-m-mod   [[_ num denom]] (list 'mod num denom))
+(defn r-tf-x-m-quot  [[_ num denom]] (list 'floor
+                                             (list '/ num denom)))
+(defn r-tf-x-m-pow   [[_ base n]] (list 'pow base n))
+(defn r-tf-x-m-sin   [[_ num]] (list 'sin num))
+(defn r-tf-x-m-sinh  [[_ num]] (list 'sinh num))
+(defn r-tf-x-m-sqrt  [[_ num]] (list 'sqrt num))
+(defn r-tf-x-m-tan   [[_ num]] (list 'tan num))
+(defn r-tf-x-m-tanh  [[_ num]] (list 'tanh num))
+
+(def +r-math+
+  {:x-m-abs           {:macro #'r-tf-x-m-abs,                 :emit :macro}
+   :x-m-acos          {:macro #'r-tf-x-m-acos,                :emit :macro}
+   :x-m-asin          {:macro #'r-tf-x-m-asin,                :emit :macro}
+   :x-m-atan          {:macro #'r-tf-x-m-atan,                :emit :macro}
+   :x-m-ceil          {:macro #'r-tf-x-m-ceil,                :emit :macro}
+   :x-m-cos           {:macro #'r-tf-x-m-cos,                 :emit :macro}
+   :x-m-cosh          {:macro #'r-tf-x-m-cosh,                :emit :macro}
+   :x-m-exp           {:macro #'r-tf-x-m-exp,                 :emit :macro}
+   :x-m-floor         {:macro #'r-tf-x-m-floor,               :emit :macro}
+   :x-m-loge          {:macro #'r-tf-x-m-loge,                :emit :macro}
+   :x-m-log10         {:macro #'r-tf-x-m-log10,               :emit :macro}
+   :x-m-max           {:macro #'r-tf-x-m-max,                 :emit :macro}
+   :x-m-min           {:macro #'r-tf-x-m-min,                 :emit :macro}
+   :x-m-mod           {:macro #'r-tf-x-m-mod,                 :emit :macro}
+   :x-m-pow           {:macro #'r-tf-x-m-pow,                 :emit :macro}
+   :x-m-quot          {:macro #'r-tf-x-m-quot,                :emit :macro}
+   :x-m-sin           {:macro #'r-tf-x-m-sin,                 :emit :macro}
+   :x-m-sinh          {:macro #'r-tf-x-m-sinh,                :emit :macro}
+   :x-m-sqrt          {:macro #'r-tf-x-m-sqrt,                :emit :macro}
+   :x-m-tan           {:macro #'r-tf-x-m-tan,                 :emit :macro}
+   :x-m-tanh          {:macro #'r-tf-x-m-tanh,                :emit :macro}})
+
+;;
+;; TYPE
+;;
+
+(defn r-tf-x-to-string
+  [[_ e]]
+  (list 'toString e))
+
+(defn r-tf-x-to-number
+  [[_ e]]
+  (list 'as.numeric e))
+
+(defn r-tf-x-is-string?
+  [[_ e]]
+  (list '== "character" (list 'typeof e)))
+
+(defn r-tf-x-is-number?
+  [[_ e]]
+  (list 'is.numeric e))
+
+(defn r-tf-x-is-boolean?
+  [[_ e]]
+  (list '== "logical" (list 'typeof e)))
+
+(defn r-tf-x-is-function?
+  [[_ e]]
+  (list '== "closure" (list 'typeof e)))
+
+(defn r-tf-x-is-object?
+  [[_ e]]
+  (h/$ (and (== "list" (typeof ~e))
+            (not (is.null (names ~e))))))
+
+(defn r-tf-x-is-array?
+  [[_ e]]
+  (h/$ (and (== "list" (typeof ~e))
+            (is.null (names ~e)))))
+
+(def +r-type+
+  {:x-to-string      {:macro #'r-tf-x-to-string :emit :macro}
+   :x-to-number      {:macro #'r-tf-x-to-number :emit :macro}
+   :x-is-string?     {:macro #'r-tf-x-is-string? :emit :macro}
+   :x-is-number?     {:macro #'r-tf-x-is-number? :emit :macro}
+   :x-is-boolean?    {:macro #'r-tf-x-is-boolean? :emit :macro}
+   :x-is-function?   {:macro #'r-tf-x-is-function? :emit :macro}
+   :x-is-object?     {:macro #'r-tf-x-is-object? :emit :macro}
+   :x-is-array?      {:macro #'r-tf-x-is-array? :emit :macro}})
+
+;;
+;; LU
+;;
+
+(defn r-tf-x-lu-eq
+  "converts map to array"
+  {:added "4.0"}
+  ([[_ o1 o2]]
+   (list '== (list 'tracemem o1) (list 'tracemem o2))))
+
+(defn r-tf-x-lu-get
+  "converts map to array"
+  {:added "4.0"}
+  ([[_ lu obj]]
+   (h/$ (. ~lu [(tracemem ~obj)]))))
+
+(defn r-tf-x-lu-set
+  "converts map to array"
+  {:added "4.0"}
+  ([[_ lu obj gid]]
+   (h/$ (:= (. ~lu [(tracemem ~obj)]) ~gid))))
+
+(defn r-tf-x-lu-del
+  "converts map to array"
+  {:added "4.0"}
+  ([[_ lu obj]]
+   (h/$ (:= (. ~lu [(tracemem ~obj)])
+            nil))))
+
+(def +r-lu+
+  {:x-lu-eq          {:macro #'r-tf-x-lu-eq}
+   :x-lu-get         {:macro #'r-tf-x-lu-get :emit :macro}
+   :x-lu-set         {:macro #'r-tf-x-lu-set :emit :macro}
+   :x-lu-del         {:macro #'r-tf-x-lu-del :emit :macro}})
+
+;;
+;; ARR
+;;
+
+(defn r-tf-x-arr-push
+  [[_ arr item]]
+  (h/$ (:= (. ~arr [(+ (length ~arr) 1)])
+            ~item)))
+
+(defn r-tf-x-arr-pop
+  [[_ arr]]
+  (list := (list '. arr [(list 'length arr)])
+        nil))
+
+(defn r-tf-x-arr-push-first
+  [[_ arr item]]
+  (list := arr (list 'append [item] arr)))
+
+(defn r-tf-x-arr-pop-first
+  [[_ arr]]
+  (list := (list '. arr [1]) nil))
+
+(def +r-arr+
+  {:x-arr-push        {:macro #'r-tf-x-arr-push    :emit :macro}
+   :x-arr-pop         {:macro #'r-tf-x-arr-pop     :emit :macro}
+   :x-arr-push-first  {:macro #'r-tf-x-arr-push-first :emit :macro}
+   :x-arr-pop-first   {:macro #'r-tf-x-arr-pop-first  :emit :macro}
+   :x-arr-insert      {:emit :throw}})
+
+;;
+;; STRING
+;;
+
+(defn r-tf-x-str-len
+  ([[_ s]]
+   (list 'nchar s)))
+
+(defn r-tf-x-str-split
+  ([[_ s tok]]
+   (list 'unlist (list 'strsplit s tok))))
+
+(defn r-tf-x-str-join
+  ([[_ s arr]]
+   (list 'paste arr :collapse s)))
+
+(defn r-tf-x-str-index-of
+  ([[_ s tok]]
+   (list 'x:get-idx (list 'gregexpr :text s :pattern tok) 1)))
+
+(defn r-tf-x-str-substring
+  ([[_ s start & [end]]]
+   (list 'substr s start (or end (list 'nchar s)))))
+
+(defn r-tf-x-str-to-upper
+  ([[_ s]]
+   (list 'toupper s)))
+
+(defn r-tf-x-str-to-lower
+  ([[_ s]]
+   (list 'tolower s)))
+
+(defn r-tf-x-str-replace
+  ([[_ s tok replacement]]
+   (list 'gsub tok replacement s)))
+
+(def +r-str+
+  {:x-str-len        {:macro #'r-tf-x-str-len        :emit :macro}
+   :x-str-split      {:macro #'r-tf-x-str-split      :emit :macro}
+   :x-str-join       {:macro #'r-tf-x-str-join       :emit :macro}
+   :x-str-index-of   {:macro #'r-tf-x-str-index-of   :emit :macro}
+   :x-str-substring  {:macro #'r-tf-x-str-substring  :emit :macro}
+   :x-str-to-upper      {:macro #'r-tf-x-str-to-upper      :emit :macro}
+   :x-str-to-lower      {:macro #'r-tf-x-str-to-lower      :emit :macro}
+   :x-str-replace    {:macro #'r-tf-x-str-replace    :emit :macro}})
+
+
+;;
+;; JSON
+;;
+
+(defn r-tf-x-json-encode
+  ([[_ obj]]
+   (list 'toJSON obj :auto-unbox true)))
+
+(defn r-tf-x-json-decode
+  ([[_ s]]
+   (list 'fromJSON s)))
+
+(def +r-js+
+  {:x-json-encode      {:macro #'r-tf-x-json-encode      :emit :macro}
+   :x-json-decode      {:macro #'r-tf-x-json-decode      :emit :macro}})
+
+
+
+;;
+;; COM
+;;
+
+(defn r-tf-x-return-encode
+  ([[_ out id key]]
+   (h/$ (do* (library "jsonlite")
+             (tryCatch (block (toJSON {:type "data"
+                                       :value ~out
+                                       :id ~id
+                                       :key ~key}
+                                      :auto-unbox true :null "null"))
+                       :error (fn [err]
+                                (toJSON {:type "raw"
+                                         :value (toString out)
+                                         :id ~id
+                                         :key ~key}
+                                        :auto-unbox true :null "null")))))))
+
+(defn r-tf-x-return-wrap
+  ([[_ f encode-fn]]
+   (h/$ (do* (library "jsonlite")
+             (tryCatch
+              (block
+               (:= out (~f))
+               (~encode-fn out nil nil))
+              :error   (fn [err]
+                         (paste "{\"type\":\"error\",\"value\":"
+                                (toJSON (toString err))
+                                "}")))))))
+
+(defn r-tf-x-return-eval
+  ([[_ s wrap-fn]]
+   (h/$ (return (~wrap-fn
+                 (fn []
+                   (eval (parse :text ~s))))))))
+
+(def +r-return+
+  {:x-return-encode  {:macro #'r-tf-x-return-encode   :emit :macro}
+   :x-return-wrap    {:macro #'r-tf-x-return-wrap     :emit :macro}
+   :x-return-eval    {:macro #'r-tf-x-return-eval     :emit :macro}})
+
+(defn r-tf-x-socket-connect
+  ([[_ host port opts]]
+   (h/$ (do* (return (socketConnection :port ~port :blocking true))))))
+
+(defn r-tf-x-socket-send
+  ([[_ conn s]]
+   (h/$ (writeLines ~s ~conn :sep "\n"))))
+
+(defn r-tf-x-socket-close
+  ([[_ conn]]
+   (h/$ (close ~conn))))
+
+(def +r-socket+
+  {:x-socket-connect      {:macro #'r-tf-x-socket-connect      :emit :macro}
+   :x-socket-send         {:macro #'r-tf-x-socket-send         :emit :macro}
+   :x-socket-close        {:macro #'r-tf-x-socket-close        :emit :macro}})
+
+;;
+;; ITER
+;;
+
+(def +r-iter+
+  {})
+
+;;
+;; THREAD
+;;
+
+(def +r-thread+
+  {})
+
+;;
+;; PROMISE
+;;
+
+(def +r-promise+
+  {})
+
+(def +r+
+  (merge +r-core+
+         +r-global+
+         +r-custom+
+         +r-math+
+         +r-type+
+         +r-lu+
+         +r-arr+
+         +r-str+
+         +r-js+
+         +r-return+
+         +r-socket+
+         +r-iter+
+         +r-thread+
+         +r-promise+))
+
+
+(comment
+
+
+;;
+;; OBJ
+;;
+
+
+(defn r-tf-x-obj-keys
+  [[_ m]]
+  (list 'names m))
+
+(defn r-tf-x-obj-vals
+  [[_ m]]
+  (list 'c (list 'unlist  m)))
+
+(def +r-obj+
+  {:x-obj-keys       {:macro #'r-tf-x-obj-keys       :emit :macro}
+   :x-obj-vals       {:macro #'r-tf-x-obj-vals       :emit :macro}})
+
+;;
+;; FN
+;;
+
+(def +r-fn+
+  {})
+
+(defn r-tf-x-arr-clone
+  [[_ arr]]
+  (list 'append [] arr))
+
+(defn r-tf-x-arr-slice
+  [[_ arr start end]]
+  (list :% arr \[ (list :to (+ start 1) end) \]))
+
+:x-arr-clone       {:macro #'r-tf-x-arr-clone   :emit :macro}
+:x-arr-slice       {:macro #'r-tf-x-arr-slice   :emit :macro}
+
+
+
+  )

--- a/src/bb/lang/model/spec_xtalk/fn_ruby.clj
+++ b/src/bb/lang/model/spec_xtalk/fn_ruby.clj
@@ -1,0 +1,174 @@
+(ns bb.lang.model.spec-xtalk.fn-ruby
+  (:require [bb.lib :as h]))
+
+;;
+;; CORE
+;;
+
+(defn ruby-tf-x-len
+  [[_ arr]]
+  (list '. arr 'length))
+
+(defn ruby-tf-x-cat
+  [[_ & args]]
+  (apply list '+ args))
+
+(defn ruby-tf-x-print
+  [[_ & args]]
+  (apply list 'puts args))
+
+(defn ruby-tf-x-random
+  [_]
+  '(rand))
+
+(defn ruby-tf-x-now-ms
+  [_]
+  (list '. (list '* (list '. 'Time.now 'to_f) 1000) 'to_i))
+
+(def +ruby-core+
+  {:x-cat            {:macro #'ruby-tf-x-cat  :emit :macro :value true
+                      :raw "(lambda { |*args| args.join('') })"}
+   :x-len            {:macro #'ruby-tf-x-len  :emit :macro}
+   :x-err            {:emit :alias :raw 'raise}
+   :x-eval           {:emit :alias :raw 'eval}
+   :x-print          {:macro #'ruby-tf-x-print :emit :macro :value true}
+   :x-random         {:emit :alias :raw 'rand :value true}
+   :x-now-ms         {:macro #'ruby-tf-x-now-ms :emit :macro}})
+
+;;
+;; MATH
+;;
+
+(defn ruby-tf-x-m-mod   [[_ num denom]] (list '% num denom))
+
+(def +ruby-math+
+  {:x-m-abs           {:emit :alias :raw 'abs  :value true}
+   :x-m-cos           {:emit :alias :raw 'Math.cos  :value true}
+   :x-m-exp           {:emit :alias :raw 'Math.exp  :value true}
+   :x-m-loge          {:emit :alias :raw 'Math.log  :value true}
+   :x-m-sin           {:emit :alias :raw 'Math.sin  :value true}
+   :x-m-sqrt          {:emit :alias :raw 'Math.sqrt :value true}
+   :x-m-mod           {:macro #'ruby-tf-x-m-mod,      :emit :macro}})
+
+;;
+;; ARR
+;;
+
+(defn ruby-tf-x-arr-push
+  [[_ arr item]]
+  (list '. arr (list 'push item)))
+
+(defn ruby-tf-x-arr-pop
+  [[_ arr]]
+  (list '. arr (list 'pop)))
+
+(defn ruby-tf-x-arr-push-first
+  [[_ arr item]]
+  (list '. arr (list 'unshift item)))
+
+(defn ruby-tf-x-arr-pop-first
+  [[_ arr]]
+  (list '. arr (list 'shift)))
+
+(defn ruby-tf-x-arr-insert
+  [[_ arr idx e]]
+  (list '. arr (list 'insert idx e)))
+
+(defn ruby-tf-x-arr-remove
+  [[_ arr idx]]
+  (list '. arr (list 'delete_at idx)))
+
+(defn ruby-tf-x-arr-sort
+  [[_ arr key-fn comp-fn]]
+  (list '. arr (list 'sort!))) ;; simplified
+
+(def +ruby-arr+
+  {:x-arr-push        {:macro #'ruby-tf-x-arr-push       :emit :macro}
+   :x-arr-pop         {:macro #'ruby-tf-x-arr-pop        :emit :macro}
+   :x-arr-push-first  {:macro #'ruby-tf-x-arr-push-first :emit :macro}
+   :x-arr-pop-first   {:macro #'ruby-tf-x-arr-pop-first  :emit :macro}
+   :x-arr-remove      {:macro #'ruby-tf-x-arr-remove     :emit :macro}
+   :x-arr-insert      {:macro #'ruby-tf-x-arr-insert     :emit :macro}})
+
+;;
+;; STRING
+;;
+
+(defn ruby-tf-x-str-split
+  ([[_ s tok]]
+   (list '. s (list 'split tok))))
+
+(defn ruby-tf-x-str-join
+  ([[_ s arr]]
+   (list '. arr (list 'join s))))
+
+(defn ruby-tf-x-str-index-of
+  ([[_ s tok]]
+   (list '. s (list 'index tok))))
+
+(defn ruby-tf-x-str-substring
+  ([[_ s start & args]]
+   (if (empty? args)
+     (list '. s (list 'slice start))
+     (list '. s (list 'slice start (first args))))))
+
+(defn ruby-tf-x-str-to-upper
+  ([[_ s]]
+   (list '. s (list 'upcase))))
+
+(defn ruby-tf-x-str-to-lower
+  ([[_ s]]
+   (list '. s (list 'downcase))))
+
+(def +ruby-str+
+  {:x-str-split       {:macro #'ruby-tf-x-str-split      :emit :macro}
+   :x-str-join        {:macro #'ruby-tf-x-str-join       :emit :macro}
+   :x-str-index-of    {:macro #'ruby-tf-x-str-index-of   :emit :macro}
+   :x-str-substring   {:macro #'ruby-tf-x-str-substring  :emit :macro}
+   :x-str-to-upper    {:macro #'ruby-tf-x-str-to-upper   :emit :macro}
+   :x-str-to-lower    {:macro #'ruby-tf-x-str-to-lower   :emit :macro}})
+
+;;
+;; RETURN
+;;
+
+(defn ruby-tf-x-return-encode
+  ([[_ out id key]]
+   (h/$ (do (:- "require 'json'")
+            (try
+              (return (JSON.generate {:id  ~id
+                                      :key ~key
+                                      :type  "data"
+                                      :value  ~out}))
+              (catch e
+                  (return (JSON.generate {:id ~id
+                                          :key ~key
+                                          :type  "raw"
+                                          :value (. e (to_s))}))))))))
+
+(defn ruby-tf-x-return-wrap
+  ([[_ f encode-fn]]
+   (h/$ (do (:- "require 'json'")
+            (try
+              (:= out (. ~f (call)))
+              (catch e
+                (return (JSON.generate {:type "error"
+                                        :value (. e (to_s))}))))
+            (return (~encode-fn out nil nil))))))
+
+(defn ruby-tf-x-return-eval
+  ([[_ s wrap-fn]]
+   (h/$ (return (~wrap-fn (fn []
+                            (return (eval ~s))))))))
+
+(def +ruby-return+
+  {:x-return-encode  {:macro #'ruby-tf-x-return-encode   :emit :macro}
+   :x-return-wrap    {:macro #'ruby-tf-x-return-wrap     :emit :macro}
+   :x-return-eval    {:macro #'ruby-tf-x-return-eval     :emit :macro}})
+
+(def +ruby+
+  (merge +ruby-core+
+         +ruby-math+
+         +ruby-arr+
+         +ruby-str+
+         +ruby-return+))

--- a/src/bb/lang/readme.clj
+++ b/src/bb/lang/readme.clj
@@ -1,0 +1,164 @@
+(ns bb.lang.readme)
+
+'(. \*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*
+
+    [TABLE OF CONTENTS]
+
+    \*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*
+
+
+    (\. [\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*
+
+         - [:0 INTRODUCTION
+
+            :1 WHY USE "H Lang" ?
+
+            :2 WORKFLOW DESIGN
+
+            :3 ARCHITECTURE DESIGN
+
+            :4 FUTURE EXTENSIONS]
+
+         \*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*]))
+
+
+'(. \*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*
+
+    [:0 INTRODUCTION]
+
+    \*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*
+
+    (\. ["H Lang" is a language, compiler and runtime
+         allowing for \:
+
+         - [a Meta-language for defining a
+            language spec for creating a DSL
+            that will transpile the code to ]
+
+         - [dynamic generation and execution
+            of arbitrary code for any language
+            with an existing compatible spec]
+
+         - [easier to evaluate performance
+            on different platforms without
+            the hurdle on setups for each]
+
+         - [testing with part systems piecemeal
+            for comms between systems]
+
+         - [target and multiple runtimes with the
+            availability of "X Lang" for creating
+            notification pathways as will as
+            arbitrary generated ui test-beds]]))
+
+'(. \*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*
+
+    [:1 WHY USE ^H LANG]
+
+    \*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*
+
+    (\. [Real world systems are a combination of many systems,
+         requiring different languages and runtimes
+         to operate seamlessly alongside each other to produce
+         the needed results])
+
+    (\. [With this approach, code is managed at the function level
+         stored in a Format that the easily analysable and having
+         the ability to transpile lisp code to the target language
+         the per unit approach allows better management due to the
+         fact that all testing and documentation uses the same
+         framework which avoids context switching on big projects.])
+
+    (\. [top level forms such as defn.<tag> will push code to the
+         language library and then create a pointer to that piece
+         of code.]))
+
+'(. \*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*
+
+    [:2 WORKFLOW DESIGN]
+
+    \*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*)
+
+'(. \*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*
+
+    [:3 ARCHITECTURE DESIGN]
+
+    \*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*)
+
+'(. \*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*
+
+    [:4 FUTURE EXTENSIONS]
+
+    \*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*)
+
+
+
+;;
+;; There is really two important concepts at play here:
+;;
+;; LIBRARY/PROJECT
+;;
+;; - In general, most real world systems are a combination of
+;;   many systems, requiring different languages and runtimes
+;;   to operate seamlessly alongside each other to produce
+;;   the needed results
+;;
+;; - with this approach, code is managed at the function level
+;;   stored in a format that the easily analysable and having
+;;   the ability to transpile lisp code to the target language
+;;   the per unit approach allows better management due to the
+;;   fact that all testing and documentation uses the same framework
+;;   which avoids context switching on big projects.
+;;
+;; - top level forms such as defn.<tag> will push code to the
+;;   language library and then create a pointer to that piece
+;;   of code.
+;;
+;; - there is also a codegen component to the library that can
+;;   be used to generate static files as well as provide the
+;;   basic to send inputs to various runtimes.
+;;
+;; - codegen for projects allows both the sources and their
+;;   the project configuration to be generated and emitted
+;;   a `Makefile` is used to provide the most versatile setup
+;;   that is language agnostic. Various config formats such
+;;   as `yaml`, `toml`, `json`, `nginx.conf` are supported
+;;   as well as being able to extend custom formats
+;;
+;; RUNTIME/TESTING
+;;
+;; - the main reason for this is to provide a unified way of
+;;   executing code and quickly verifying that the code is
+;;   correct on a step by step approach.
+;;
+;; - the pointer is static and points to code in a given module
+;;
+;; - different runtimes need different setups
+;;   - some need to be run either remotely or within a specific context
+;;   - all require the source to be formatted a certain way
+;;   - some retain state of the functions per session (terminal based)
+;;   - some retain state of the function indefinately (database, blockchain)
+;;   - some execute only on input sent (redis, openresty)
+;;
+;; - the runtime which contains dynamic information determining
+;;   how the pointer will behave when certain actions are required
+;;
+;;   - a default module name (for creating new code and pointers)
+;;   - runtime type (specifies the general behaviour of pointers)
+;;       - by default, code is stored into library and will emit
+;;         a string of it's own form when evaluated and when
+;;         invoked with args, will output the string of the
+;;         form
+;;
+;;   - new runtimes can be created having different kinds of
+;;     behaviour depending on where it is targetting
+;;     - js has graal and webview runtimes
+;;     - lua has redis and openresty runtimes
+;;     - c has jocl runtime
+;;     - python has
+;;     - postgres is it's own runtime
+;;
+;; - basically, the more finer grain testing gets, the less errors
+;;   can cause uncertainty and the quicker code can be produced,
+;;   refactored and hardened.
+;;

--- a/src/bb/lang/strict/base_state.clj
+++ b/src/bb/lang/strict/base_state.clj
@@ -1,0 +1,4 @@
+(ns bb.lang.strict.base-state)
+
+(def +registry+
+  (atom {}))

--- a/src/bb/lib.clj
+++ b/src/bb/lib.clj
@@ -1,0 +1,94 @@
+(ns bb.lib)
+
+(defn intern-in
+  "adds a function to current"
+  {:added "3.0"}
+  ([ns? & syms]
+   (let [[ns syms] (if (or (vector? ns?)
+                           (namespace ns?))
+                     [(.getName clojure.core/*ns*) (cons ns? syms)]
+                     [ns? syms])]
+     (mapv (fn [sym]
+             (let [[to from] (if (vector? sym)
+                               sym
+                               [sym sym])]
+               (intern ns (symbol (name to)) (resolve from))))
+           syms))))
+
+(defmacro template-entries
+  "uses a template function to produce entries"
+  {:added "3.0" :style/indent 1}
+  ([[tmpl-fn & [tmpl-meta]] & entries]
+   (let [tmpl-fn (cond (symbol? tmpl-fn)
+                       (resolve tmpl-fn)
+
+                       (list? tmpl-fn)
+                       (eval tmpl-fn))
+         entries (mapcat (fn [entry]
+                           (cond (symbol? entry)
+                                 @(resolve entry)
+
+                                 (list? entry)
+                                 (eval entry)
+
+                                 :else entry))
+                         entries)]
+     (mapv (fn [e]
+             (try (tmpl-fn e)
+                  (catch Throwable t
+                    (throw t))))
+           entries))))
+
+(defn map-keys [f m]
+  (reduce-kv (fn [m k v]
+               (assoc m (f k) v))
+             {}
+             m))
+
+(defn map-vals [f m]
+  (reduce-kv (fn [m k v]
+               (assoc m k (f v)))
+             {}
+             m))
+
+(defn filter-keys [f m]
+  (reduce-kv (fn [m k v]
+               (if (f k)
+                 (assoc m k v)
+                 m))
+             {}
+             m))
+
+(defn filter-vals [f m]
+  (reduce-kv (fn [m k v]
+               (if (f v)
+                 (assoc m k v)
+                 m))
+             {}
+             m))
+
+(defn prewalk [f form]
+  (clojure.walk/prewalk f form))
+
+(defn postwalk [f form]
+  (clojure.walk/postwalk f form))
+
+(defmacro suppress
+  "Suppresses any errors thrown in the body."
+  {:added "3.0"}
+  ([body]
+   `(try ~body (catch Throwable ~'t)))
+  ([body catch-val]
+   `(try ~body (catch Throwable ~'t
+                 (cond (fn? ~catch-val)
+                       (~catch-val ~'t)
+                       :else ~catch-val)))))
+
+(defmacro const [body]
+  (eval body))
+
+(defmacro error
+  ([message]
+   `(throw (ex-info ~message {})))
+  ([message data]
+   `(throw (ex-info ~message ~data))))

--- a/src/bb/lib/collection.clj
+++ b/src/bb/lib/collection.clj
@@ -1,0 +1,759 @@
+(ns bb.lib.collection
+  (:require [bb.lib.foundation :as h]
+            [bb.string.common :as str]))
+
+(defn hash-map?
+  "Returns `true` if `x` implements `clojure.lang.APersistentMap`.
+
+   (hash-map? {})    => true
+   (hash-map? [])    => false"
+  {:added "3.0"}
+  ([x] (instance? clojure.lang.APersistentMap x)))
+
+(defn lazy-seq?
+  "Returns `true` if `x` implements `clojure.lang.LazySeq`.
+
+   (lazy-seq? (map inc [1 2 3]))  => true
+   (lazy-seq? ())    => false"
+  {:added "3.0"}
+  ([x] (instance? clojure.lang.LazySeq x)))
+
+(defn cons?
+  "checks if object is instance of `clojure.lang.Cons`
+
+   (cons? (cons 1 [1 2 3])) => true"
+  {:added "3.0"}
+  ([x] (instance? clojure.lang.Cons x)))
+
+(defn form?
+  "checks if object is a lisp form"
+  {:added "3.0"}
+  ([form]
+   (or (cons? form)
+       (list? form)
+       (lazy-seq? form))))
+
+(defn queue
+  "returns a `clojure.lang.PersistentQueue` object.
+
+   (pop a) => [2 3 4]"
+  {:added "3.0"}
+  ([] (clojure.lang.PersistentQueue/EMPTY))
+  ([x] (conj (queue) x))
+  ([x & xs] (apply conj (queue) x xs)))
+
+(defmethod print-method clojure.lang.PersistentQueue
+  ([v ^java.io.Writer w]
+   (.write w (str (into [] v)))))
+
+(defn seqify
+  "if not a sequence, then make one
+
+   (seqify 1)
+   => [1]
+
+   (seqify [1])
+   => [1]"
+  {:added "3.0"}
+  ([x]
+   (if (or (coll? x)
+           (instance? java.util.List x))
+     x
+     [x])))
+
+(defn unseqify
+  "if a sequence, takes first element
+
+   (unseqify [1])
+   => 1
+
+   (unseqify 1)
+   => 1"
+  {:added "3.0"}
+  ([x]
+   (if (coll? x)
+     (first x)
+     x)))
+
+(defn unlazy
+  "works on both lazy seqs and objects"
+  {:added "3.0"}
+  ([x]
+   (if (lazy-seq? x)
+     (doall x)
+     x)))
+
+(defn map-keys
+  "changes the keys of a map
+
+   (map-keys inc {0 :a 1 :b 2 :c})
+   => {1 :a, 2 :b, 3 :c}"
+  {:added "3.0"}
+  ([f m]
+   (reduce (fn [out [k v]]
+             (assoc out (f k) v))
+           {}
+           m)))
+
+(defn map-vals
+  "changes the values of a map
+
+   (map-vals inc {:a 1 :b 2 :c 3})
+   => {:a 2, :b 3, :c 4}"
+  {:added "3.0"}
+  ([f m]
+   (reduce (fn [out [k v]]
+             (assoc out k (f v)))
+           {}
+           m)))
+
+(defn map-juxt
+  "creates a map from sequence with key and val functions
+
+   (map-juxt [str inc] [1 2 3 4 5])
+   => {\"1\" 2, \"2\" 3, \"3\" 4, \"4\" 5, \"5\" 6}"
+  {:added "3.0"}
+  ([[kf vf] arr]
+   (->> (map (juxt kf vf) arr)
+        (into {}))))
+
+(defn pmap-vals
+  "uses pmap across the map values"
+  {:added "3.0"}
+  ([f m]
+   (->> (pmap (fn [[k v]]
+                [k (f v)])
+              m)
+        (into {}))))
+
+(defn map-entries
+  "manipulates a map given the function
+
+   (map-entries (fn [[k v]]
+                  [(keyword (str v)) (name k)])
+                {:a 1 :b 2 :c 3})
+   => {:1 \"a\", :2 \"b\", :3 \"c\"}"
+  {:added "3.0"}
+  ([f m]
+   (->> (map f m)
+        (into {}))))
+
+(defn pmap-entries
+  "uses pmap across the entries"
+  {:added "3.0"}
+  ([f m]
+   (->> (pmap f m)
+        (into {}))))
+
+(defn rename-keys
+  "rename keys in map
+
+   (rename-keys {:a 1} {:a :b})
+   => {:b 1}"
+  {:added "4.0"}
+  ([m trs]
+   (reduce (fn [m [from to]]
+             (if (contains? m from)
+               (assoc (dissoc m from)
+                      to (get m from))
+               m))
+           m
+           trs)))
+
+(defn filter-keys
+  "filters map based upon map keys
+
+   (filter-keys even? {0 :a 1 :b 2 :c})
+   => {0 :a, 2 :c}"
+  {:added "3.0"}
+  ([pred m]
+   (reduce (fn [out [k v]]
+             (if (pred k)
+               (assoc out k v)
+               out))
+           {}
+           m)))
+
+(defn filter-vals
+  "filters map based upon map values
+
+   (filter-vals even? {:a 1 :b 2 :c 3})
+   => {:b 2}"
+  {:added "3.0"}
+  ([pred m]
+   (reduce (fn [out [k v]]
+             (if (pred v)
+               (assoc out k v)
+               out))
+           {}
+           m)))
+
+(defn keep-vals
+  "filters map based upon map values
+
+   (keep-vals even? {:a 1 :b 2 :c 3})
+   => {:b true}"
+  {:added "3.0"}
+  ([f m]
+   (reduce (fn [out [k v]]
+             (if-let [new (f v)]
+               (assoc out k new)
+               out))
+           {}
+           m))
+  ([f pred m]
+   (reduce (fn [out [k v]]
+             (let [new (f v)]
+               (if (pred new)
+                 (assoc out k new)
+                 out)))
+           {}
+           m)))
+
+(defn qualified-keys
+  "takes only the namespaced keys of a map
+
+   (qualified-keys {:a 1 :ns/b 1})
+   => #:ns{:b 1}
+
+   (qualified-keys {:a 1 :ns.1/b 1 :ns.2/c 1}
+                   :ns.1)
+   => #:ns.1{:b 1}"
+  {:added "3.0"}
+  ([m]
+   (filter-keys (fn [k] (and (keyword? k)
+                             (namespace k)))
+                m))
+  ([m ns]
+   (let [pred (set (map h/strn (seqify ns)))]
+     (filter-keys (fn [k] (and (keyword? k)
+                               (pred (namespace k))))
+                  m))))
+
+(defn unqualified-keys
+  "takes only the namespaced keys of a map
+
+   (unqualified-keys {:a 1 :ns/b 1})
+   => {:a 1}"
+  {:added "3.0"}
+  ([m]
+   (filter-keys (fn [k] (and (keyword? k)
+                             (nil? (namespace k))))
+                m)))
+
+(defn qualify-keys
+  "lifts all unqualified keys
+
+   (qualify-keys {:a 1} :ns.1)
+   => #:ns.1{:a 1}
+
+   (qualify-keys {:a 1 :ns.2/c 1} :ns.1)
+   => {:ns.1/a 1, :ns.2/c 1}"
+  {:added "3.0"}
+  ([m ns]
+   (let [ns (h/strn ns)]
+     (map-keys (fn [k]
+                 (if (and (keyword? k)
+                          (not (namespace k)))
+                   (keyword ns (name k))
+                   k))
+               m))))
+
+(defn unqualify-keys
+  "unqualifies keys in the map
+
+   (unqualify-keys {:a 1 :ns.1/b 1 :ns.2/c 1})
+   => {:a 1, :b 1, :c 1}
+
+   (unqualify-keys {:a 1 :ns.1/b 1 :ns.2/c 1} :ns.1)
+   => {:a 1, :b 1, :ns.2/c 1}"
+  {:added "3.0"}
+  ([m]
+   (map-keys (fn [k] (keyword (name k))) m))
+  ([m ns]
+   (let [ns (h/strn ns)]
+     (map-keys (fn [k]
+                 (if (and (keyword? k)
+                          (= (namespace k) ns))
+                   (keyword (name k))
+                   k))
+               m))))
+
+(defn assoc-new
+  "only assoc if the value in the original map is nil
+
+   (assoc-new {:a 1} :b 2)
+   => {:a 1 :b 2}
+
+   (assoc-new {:a 1} :a 2 :b 2)
+   => {:a 1 :b 2}"
+  {:added "3.0"}
+  ([m k v]
+   (if (contains? m k) m (assoc m k v)))
+  ([m k v & more]
+   (apply assoc-new (assoc-new m k v) more)))
+
+(defn merge-nested
+  "Merges nested values from left to right.
+
+   (merge-nested {:a {:b {:c 3}}} {:a {:b 3}})
+   => {:a {:b 3}}
+
+   (merge-nested {:a {:b {:c 1 :d 2}}}
+                 {:a {:b {:c 3}}})
+   => {:a {:b {:c 3 :d 2}}}"
+  {:added "3.0"}
+  ([& maps]
+   (apply merge-with (fn [& args]
+                       (if (every? #(or (map? %) (nil? %)) args)
+                         (apply merge-nested args)
+                         (last args)))
+          maps)))
+
+(defn merge-nested-new
+  "Merges nested values from left to right, provided the merged value does not exist
+
+   (merge-nested-new {:a {:b 2}} {:a {:c 2}})
+   => {:a {:b 2 :c 2}}
+
+   (merge-nested-new {:b {:c :old}} {:b {:c :new}})
+   => {:b {:c :old}}"
+  {:added "3.0"}
+  ([& maps]
+   (apply merge-nested (reverse maps))))
+
+(defn dissoc-nested
+  "dissocs recursively into a map removing empty entries
+
+   (dissoc-nested {:a {:b {:c 1}}}
+                  [:a :b :c])
+   => {}"
+  {:added "3.0"}
+  ([m [k & ks]]
+   (if-not ks
+     (dissoc m k)
+     (let [nm (dissoc-nested ((or m {}) k) ks)]
+       (cond (empty? nm) (dissoc m k)
+             :else (assoc m k nm))))))
+
+(defn flatten-nested
+  "flattens all elements the collection
+
+   (flatten-nested [1 2 #{3 {4 5}}])
+   => [1 2 3 4 5]"
+  {:added "3.0"}
+  ([x]
+   (filter (complement coll?)
+           (rest (tree-seq coll? seq x)))))
+
+(def re-create
+  (memoize (fn [^String s]
+             (if (h/regexp? s)
+               s
+               (-> (str s)
+                   (.replaceAll "\\." "\\\\\\.")
+                   (.replaceAll "\\*" "\\\\\\*")
+                   (re-pattern))))))
+
+(defn tree-flatten
+  "flattens the entire map tree
+
+   (->> (tree-flatten {\"a\" {\"b\" {\"c\" 3 \"d\" 4}
+                            \"e\" {\"f\" 5 \"g\" 6}}
+                       \"h\" {\"i\" {}}})
+        (map-keys h/strn))
+   => {\"a/b/c\" 3, \"a/b/d\" 4, \"a/e/f\" 5, \"a/e/g\" 6}"
+  {:added "3.0"}
+  ([m]
+   (tree-flatten m h/*sep*))
+  ([m sep]
+   (tree-flatten m sep []))
+  ([m sep path]
+   (->> (keep (fn [[k v]]
+                (if (and (map? v) (not-empty v))
+                  (tree-flatten v sep (conj path k))
+                  (if (or (not (coll? v))
+                          (not-empty v))
+                    [(->> (conj path k)
+                          (map h/strn)
+                          (str/join sep)
+                          keyword) v])))
+              m)
+        (into {}))))
+
+(defn tree-nestify
+  "nests keys in the map
+
+   (tree-nestify {:a/b 2 :a/c 3})
+   => {:a {:b 2 :c 3}}
+
+   (tree-nestify {:a/b {:e/f 1} :a/c {:g/h 1}})
+   => {:a {:b {:e/f 1}
+           :c {:g/h 1}}}"
+  {:added "3.0"}
+  ([m]
+   (tree-nestify m h/*sep*))
+  ([m sep]
+   (tree-nestify m sep identity))
+  ([m sep f]
+   (let [pattern (re-create sep)]
+     (reduce-kv (fn [m k v]
+                  (let [path (->> (str/split (h/strn k) pattern)
+                                  (map keyword))
+                        v  (f v)]
+                    (update-in m path
+                               (fnil (fn [p]
+                                       (cond (and (map? p) (map? v))
+                                             (merge p v)
+                                             :else v))
+                                     v))))
+                {}
+                m))))
+
+(defn tree-nestify:all
+  "nests keys in the map and all submaps
+
+   (tree-nestify:all {:a/b 2 :a/c 3})
+   => {:a {:b 2 :c 3}}
+
+   (tree-nestify:all {:a/b {:e/f 1} :a/c {:g/h 1}})
+   => {:a {:b {:e {:f 1}}
+           :c {:g {:h 1}}}}"
+  {:added "3.0"}
+  ([m]
+   (tree-nestify:all m h/*sep*))
+  ([m sep]
+   (tree-nestify m sep
+                 (fn [v] (if (hash-map? v)
+                           (tree-nestify:all v sep)
+                           v)))))
+
+(defn reshape
+  "moves values around in a map according to a table
+
+   (reshape {:a 1 :b 2}
+            {[:c :d] [:a]})
+   => {:b 2, :c {:d 1}}"
+  {:added "3.0"}
+  ([m rels]
+   (reduce (fn [out [to from]]
+             (if (= to from)
+               out
+               (let [v (get-in m from)]
+                 (-> out
+                     (dissoc-nested from)
+                     (assoc-in to v)))))
+           m
+           rels)))
+
+(defn find-templates
+  "finds the template with associated path"
+  {:added "3.0"}
+  ([m]
+   (find-templates m [] {}))
+  ([m path saved]
+   (let [template? (fn [^String s]
+                     (and (string? s)
+                          (.startsWith s "{{")
+                          (.endsWith s "}}")))]
+     (reduce-kv (fn [out k v]
+                  (cond (template? v)
+                        (assoc out v (conj path k))
+
+                        (map? v)
+                        (find-templates v (conj path k) out)
+
+                        :else
+                        out))
+                saved
+                m))))
+
+(defn transform-fn
+  "creates a transformation function
+   ((transform-fn {:keystore {:hash  \"{{hash}}\"
+                              :salt  \"{{salt}}\"
+                              :email \"{{email}}\"}
+
+                   :db       {:login {:user {:hash \"{{hash}}\"
+                                             :salt \"{{salt}}\"}
+                                      :value \"{{email}}\"}}}
+                  [:keystore :db]) ^:hidden
+   {:type :email,
+     :hash \"1234\"
+     :salt \"ABCD\"
+     :email \"a@a.com\"})
+   => {:type :email
+       :login {:user {:hash \"1234\",
+                      :salt \"ABCD\"},
+               :value \"a@a.com\"}}"
+  {:added "3.0"}
+  ([schema [from to]]
+   (let [from-template (find-templates (get schema from))
+         to-template   (find-templates (get schema to))
+         move-template (map-keys to-template from-template)]
+     (fn [data]
+       (reshape data move-template)))))
+
+(def transform-fn* (memoize transform-fn))
+
+(defn transform
+  "creates a transformation function"
+  {:added "3.0"}
+  ([schema [from to] data]
+   (let [f (transform-fn* schema [from to])]
+     (f data))))
+
+(defn empty-record
+  "creates an empty record from an existing one
+
+   (defrecord Database [host port])
+
+   (empty-record (Database. \"localhost\" 8080))
+   => (just {:host nil :port nil})"
+  {:added "3.0"}
+  ([v]
+   (.invoke ^java.lang.reflect.Method
+    (.getMethod ^Class (type v) "create"
+                (into-array Class [clojure.lang.IPersistentMap]))
+            nil
+            (object-array [{}]))))
+
+(defn transpose
+  "sets the vals and keys and vice-versa
+
+   (transpose {:a 1 :b 2 :c 3})
+   => {1 :a, 2 :b, 3 :c}"
+  {:added "3.0"}
+  ([m]
+   (reduce (fn [out [k v]]
+             (assoc out v k))
+           {}
+           m)))
+
+(defn index-at
+  "finds the index of the first matching element in an array
+
+   (index-at even? [1 2 3 4]) => 1
+
+   (index-at keyword? [1 2 :hello 4]) => 2"
+  {:added "3.0"}
+  ([pred coll]
+   (loop [[x & more :as coll] coll
+          i 0]
+     (cond (empty? coll) -1
+
+           (pred x) i
+
+           :else
+           (recur more (inc i))))))
+
+(defn element-at
+  "finds the element within an array
+
+   (element-at keyword? [1 2 :hello 4])
+   => :hello"
+  {:added "3.0"}
+  ([pred coll]
+   (loop [[x & more :as coll] coll]
+     (cond (empty? coll) nil
+
+           (pred x) x
+
+           :else
+           (recur more)))))
+
+(defn insert-at
+  "insert one or more elements at the given index
+
+   (insert-at [:a :b] 1 :b :c)
+   => [:a :b :c :b]"
+  {:added "3.0"}
+  ([coll i new]
+   (apply conj (subvec coll 0 i) new (subvec coll i)))
+  ([coll i new & more]
+   (apply conj (subvec coll 0 i) new (concat more (subvec coll i)))))
+
+(defn remove-at
+  "removes element at the specified index
+
+   (remove-at [:a :b :c :d] 2)
+   => [:a :b :d]"
+  {:added "3.0"}
+  ([coll i]
+   (remove-at coll i 1))
+  ([coll i n]
+   (cond (vector? coll)
+         (reduce conj
+                 (subvec coll 0 i)
+                 (subvec coll (+ i n) (count coll)))
+
+         :else
+         (keep-indexed #(if (not (and (>= %1 i)
+                                      (< %1 (+ i n)))) %2) coll))))
+
+(defn split-by
+  "splits a sequences using a predicate"
+  {:added "4.0"}
+  [pred coll]
+  (loop [remaining coll
+         current-chunk []
+         result []]
+    (if (empty? remaining)
+      (if (empty? current-chunk)
+        result
+        (conj result current-chunk))
+      (let [item (first remaining)]
+        (if (pred item)
+          (recur (rest remaining)
+                 []
+                 (conj result current-chunk))
+          (recur (rest remaining)
+                 (conj current-chunk item)
+                 result))))))
+
+(defn deduped?
+  "checks if elements in the collection are unique
+
+   (deduped? [1 2 3 4])
+   => true
+
+   (deduped? [1 2 1 4])
+   => false"
+  {:added "3.0"}
+  [coll]
+  (= (count (set coll))
+     (count coll)))
+
+(defn unfold
+  "unfolds using a generated function
+
+   (unfold (fn [[i :as seed]]
+             (if i
+               (if-not (neg? i)
+                 [(* i 2) [(dec i)]])))
+           [10])
+   => [20 18 16 14 12 10 8 6 4 2 0]"
+  {:added "3.0"}
+  ([f coll]
+   (->> coll
+        (list nil)
+        (iterate (comp f second))
+        rest
+        (take-while some?)
+        (map first))))
+
+(defn diff:changes
+  "Finds changes in nested maps, does not consider new elements"
+  {:added "3.0"}
+  ([m1 m2]
+   (diff:changes m1 m2 [] =))
+  ([m1 m2 arr equal-fn]
+   (reduce-kv (fn [out k1 v1]
+                (if (contains? m2 k1)
+                  (let [v2 (get m2 k1)]
+                    (cond (and (hash-map? v1) (hash-map? v2))
+                          (merge out (diff:changes v1 v2 (conj arr k1) equal-fn))
+
+                          (equal-fn v1 v2)
+                          out
+
+                          :else
+                          (assoc out (conj arr k1) v1)))
+                  out))
+              {}
+              m1)))
+
+(defn diff:new
+  "Finds new elements in nested maps, does not consider changes"
+  {:added "3.0"}
+  ([m1 m2]
+   (diff:new m1 m2 []))
+  ([m1 m2 arr]
+   (reduce-kv (fn [out k1 v1]
+                (let [v2 (get m2 k1)]
+                  (cond (and (hash-map? v1) (hash-map? v2))
+                        (merge out (diff:new v1 v2 (conj arr k1)))
+
+                        (not (contains? m2 k1))
+                        (assoc out (conj arr k1) v1)
+
+                        :else out)))
+              {}
+              m1)))
+
+(defn diff
+  "Finds the difference between two maps"
+  {:added "3.0"}
+  ([m1 m2] (diff m1 m2 false))
+  ([m1 m2 reversible]
+   (let [diff (hash-map :+ (diff:new m1 m2)
+                        :- (diff:new m2 m1)
+                        :> (diff:changes m1 m2))]
+     (if reversible
+       (assoc diff :< (diff:changes m2 m1))
+       diff))))
+
+(defn- merge-or-replace
+  "If both are maps then merge, otherwis replace
+
+   (merge-or-replace {:a {:b {:c 2}}} {:a {:b {:c 3 :d 4}}})
+   => {:a {:b {:c 3 :d 4}}}"
+  {:added "3.0"}
+  ([x v]
+   (cond (and (hash-map? x)
+              (hash-map? v))
+         (merge-nested x v)
+
+         :else v)))
+
+(defn diff:changed
+  "Outputs what has changed between the two maps
+
+   (diff:changed {:a {:b {:c 3 :d 4}}}
+                 {:a {:b {:c 3}}})
+   => {:a {:b {:d 4}}}"
+  {:added "3.0"}
+  ([new old]
+   (->> (diff new old)
+        ((juxt :> :+))
+        (apply merge)
+        (reduce-kv (fn [out ks v]
+                     (assoc-in out ks v))
+                   {}))))
+
+(defn diff:patch
+  "patch from old to new"
+  {:added "3.0"}
+  ([m diff]
+   (->> m
+        (#(reduce-kv (fn [m arr v]
+                       (update-in m arr merge-or-replace v))
+                     %
+                     (merge (:+ diff) (:> diff))))
+        (#(reduce (fn [m arr]
+                    (dissoc-nested m arr))
+                  %
+                  (keys (:- diff)))))))
+
+(defn diff:unpatch
+  "unpatch from new to old"
+  {:added "3.0"}
+  ([m diff]
+   (->> m
+        (#(reduce-kv (fn [m arr v]
+                       (update-in m arr merge-or-replace v))
+                     %
+                     (merge (:- diff) (:< diff))))
+        (#(reduce (fn [m arr]
+                    (dissoc-nested m arr))
+                  %
+                  (keys (:+ diff)))))))
+
+
+;;
+;;
+
+(defn merge-meta
+  [obj metadata]
+  (with-meta obj (merge-nested (meta obj)
+                               metadata)))

--- a/src/bb/lib/foundation.clj
+++ b/src/bb/lib/foundation.clj
@@ -1,0 +1,961 @@
+(ns bb.lib.foundation
+  (:require [clojure.set])
+  (:import (java.util Date))
+  (:refer-clojure :exclude [-> ->> keyword reset! aget set! assert
+                            parse-long parse-double]))
+
+(def +init+ find-ns)
+
+(def ^:dynamic *sep* "/")
+
+(defn T
+  "returns `true` for any combination of input `args`
+
+   (T) => true"
+  {:added "3.0"}
+  ([& args]
+   true))
+
+(defn F
+  "returns `false` for any combination of input `args`
+
+   (F) => false"
+  {:added "3.0"}
+  ([& args]
+   false))
+
+(defn NIL
+  "returns `nil` for any combination of input `args`
+
+   (NIL) => nil"
+  {:added "3.0"}
+  ([& args]
+   nil))
+
+(defn U
+  "U Combinator
+
+   ((U factorial) 5) => 120"
+  {:added "3.0"}
+  ([f] (fn [x] ((f f) x))))
+
+(defn Z
+  "Z combinator
+
+   ((Z factorial) 5) => 120"
+  {:added "3.0"}
+  ([f] (let [A (fn [x] (f (U x)))] (A A))))
+
+(defmacro xor
+  "performs xor comparison
+
+   (xor true false) => true"
+  {:added "3.0"}
+  ([] nil)
+  ([a] a)
+  ([a b]
+   `(let [a# ~a
+          b# ~b]
+      (if a#
+        (if b# nil a#)
+        (if b# b# nil)))))
+
+(defn sid
+  "returns a short id string
+
+   (sid)
+   ;; \"t8a6euzk9usy\"
+   => string?"
+  {:added "3.0"}
+  ([]
+   (clojure.core/-> (str (java.util.UUID/randomUUID))
+                    (.getBytes)
+                    (java.nio.ByteBuffer/wrap)
+                    (.getLong)
+                    (Long/toString Character/MAX_RADIX))))
+
+
+(def ^{:arglists '[[tag]]}
+  sid-tag
+  (memoize (fn [tag]
+             (sid))))
+
+(defn uuid
+  "returns a `java.util.UUID` object
+
+   (uuid) => #(instance? java.util.UUID %)
+
+   (uuid \"00000000-0000-0000-0000-000000000000\")
+   => #uuid \"00000000-0000-0000-0000-000000000000\""
+  {:added "3.0"}
+  ([] (java.util.UUID/randomUUID))
+  ([id]
+   (cond (string? id)
+         (java.util.UUID/fromString id)
+
+         (instance? (Class/forName "[B") id)
+         (java.util.UUID/nameUUIDFromBytes id)
+
+         (keyword? id)
+         (java.util.UUID. (.hashCode ^Object id)
+                          (.hashCode (name id)))
+
+         :else
+         (throw (ex-info (str id " can only be a string or byte array")))))
+  ([^Long msb ^Long lsb]
+   (java.util.UUID. msb lsb)))
+
+(defn uuid-nil
+  "constructs a nil uuid"
+  {:added "4.0"}
+  ([]
+   (java.util.UUID/fromString "00000000-0000-0000-0000-000000000000")))
+
+(defn instant
+  "returns a `java.util.Date` object
+
+   (instant) => #(instance? java.util.Date %)
+
+   (instant 0) => #inst \"1970-01-01T00:00:00.000-00:00\""
+  {:added "3.0"}
+  ([] (java.util.Date.))
+  ([^Long val] (java.util.Date. val)))
+
+(defn uri
+  "returns a `java.net.UrI` object
+
+   (uri \"http://www.google.com\")
+   => java.net.URI"
+  {:added "3.0"}
+  ([path]
+   (java.net.URI/create path)))
+
+(defn url
+  "retruns a `java.net.URL` object
+
+   (url \"http://www.google.com\")
+   => java.net.URL"
+  {:added "3.0"}
+  ([path]
+   (java.net.URL. path)))
+
+(defn date
+  "creates a new date
+
+   (date 1000)
+   => #inst \"1970-01-01T00:00:01.000-00:00\""
+  {:added "3.0"}
+  ([]  (Date.))
+  ([^long t] (Date. t)))
+
+(defn strn
+  "returns the strn value
+
+   (strn :hello) => \"hello\"
+
+   (strn \"hello\") => \"hello\""
+  {:added "3.0"}
+  (^String
+   [obj]
+   (cond (bytes? obj)
+         (String. ^bytes obj)
+
+         (keyword? obj)
+         (subs (str obj) 1)
+
+         (string? obj)
+         obj
+
+         :else
+         (pr-str obj)))
+  (^String
+   [obj & more]
+   (apply str (strn obj) (map strn more))))
+
+(defn lsubs
+  "substring from last
+
+   (lsubs \"hello-world\" 4)
+   => \"hello-w\""
+  {:added "4.0"}
+  [s n]
+  (let [l (count s)]
+    (subs s 0 (- l n))))
+
+(defn keyword
+  "returns the keyword value
+
+   (keyword :hello) => :hello
+
+   (keyword \"hello\") => :hello"
+  {:added "3.0"}
+  ([obj]
+   (cond (keyword? obj)
+         obj
+
+         (string? obj)
+         (clojure.core/keyword obj)
+
+         :else
+         (throw (ex-info "Cannot process obj" {:input obj})))))
+
+(defn string
+  "creates a string from a byte array
+
+   (string (.getBytes \"Hello\"))
+   => \"Hello\""
+  {:added "3.0"}
+  ([obj]
+   (cond (bytes? obj)
+         (String. ^bytes obj)
+
+         :else
+         (str obj))))
+
+(defn concatv
+  "concats two seqs as vector"
+  {:added "4.0"}
+  [& args]
+  (vec (apply concat args)))
+
+(defn edn
+  "prints then reads back the string
+
+   ((juxt type
+          (comp type edn)) (symbol \":hello\"))
+   => [clojure.lang.Symbol
+       clojure.lang.Keyword]"
+  {:added "3.0"}
+  ([obj]
+   (read-string (pr-str obj))))
+
+(defprotocol ICounter
+  (-inc [_])
+  (-inc [_ n])
+  (-dec [_])
+  (-dec [_ n])
+  (-reset [_ n]))
+
+(defrecord BBCounter [v]
+  clojure.lang.IDeref
+  (deref [_] @v)
+  ICounter
+  (-inc [_] (swap! v clojure.core/inc))
+  (-inc [_ n] (swap! v + n))
+  (-dec [_] (swap! v clojure.core/dec))
+  (-dec [_ n] (swap! v - n))
+  (-reset [_ n] (clojure.core/reset! v n)))
+
+(defmethod print-method BBCounter
+  ([v ^java.io.Writer w]
+   (.write w (format "#counter{%d}" @v))))
+
+(defn counter
+  "creates a counter
+
+   (pr-str (counter))
+   => \"#counter{-1}\""
+  {:added "3.0"}
+  ([] (counter -1))
+  ([n]
+   (->BBCounter (atom n))))
+
+(defmacro inc!
+  "increments the counter
+
+   @(doto (counter)
+      (inc!)
+      (inc! 10))
+   => 10"
+  {:added "3.0"}
+  ([counter]
+   `(-inc ~counter))
+  ([counter n]
+   `(-inc ~counter ~n)))
+
+(defmacro dec!
+  "decrements the counter
+
+   @(doto (counter 10)
+      (dec! 10))
+   => 0"
+  {:added "3.0"}
+  ([counter]
+   `(-dec ~counter))
+  ([counter n]
+   `(-dec ~counter ~n)))
+
+(defn reset!
+  "resets a counter to the given value
+
+   (reset! (counter 10) 5)
+   => 5"
+  {:added "3.0"}
+  ([counter n]
+   (-reset counter n)))
+
+(defn flake
+  "returns a unique, time incremental id
+
+   (flake)
+   ;; \"4Wv-T47LftnVlHhhh00JYuU15NCuNLcr\"
+   => string?"
+  {:added "3.0"}
+  ([]
+   (clojure.core/-> (str (java.util.UUID/randomUUID))
+                    (.replaceAll "-" "")
+                    (subs 0 24))))
+
+(defn invoke
+  "provides a caller for the `IFn`
+
+   (invoke (fn [] (+ 1 2 3)))
+   => 6"
+  {:added "3.0"}
+  ([^clojure.lang.IFn f]
+   (.invoke f))
+  ([^clojure.lang.IFn f & args]
+   (.applyTo f args)))
+
+(defn call
+  "like `invoke` but reverses the function and first argument
+
+   (call 2) => 2
+
+   (call 2 + 1 2 3) => 8"
+  {:added "3.0"}
+  ([obj] obj)
+  ([obj f] (if (nil? f) obj (f obj)))
+  ([obj f v1] (if (nil? f) obj (f obj v1)))
+  ([obj f v1 v2] (if (nil? f) obj (f obj v1 v2)))
+  ([obj f v1 v2 v3] (if (nil? f) obj (f obj v1 v2 v3)))
+  ([obj f v1 v2 v3 v4] (if (nil? f) obj (f obj v1 v2 v3 v4)))
+  ([obj f v1 v2 v3 v4 & vs] (if (nil? f) obj (apply f obj v1 v2 v3 v4 vs))))
+
+(defmacro const
+  "converts an expression into a constant at compile time
+
+   (const (+ 1 2)) => 3
+
+   (macroexpand '(const (+ 1 2))) => 3"
+  {:added "3.0"}
+  ([body]
+   (eval body)))
+
+(defmacro applym
+  "Allow macros to be applied to arguments just like functions
+
+   (applym const '((+ 1 2))) => 3
+
+   (macroexpand '(applym const '((+ 1 2))))
+   => 3"
+  {:added "3.0"}
+  ([macro & args]
+   (cons macro (apply concat (butlast (map eval args)) (last (map eval args))))))
+
+(defmacro code-ns
+  "returns the current namespace the code is in
+
+   (code-ns)
+   => 'bb.lib.foundation_test"
+  {:added "3.0"}
+  ([]
+   `(clojure.core/-> ^String (re-find #"^.*?(?=\$|$)"
+                                      (str (fn [])))
+                     (.replaceAll "_" "-")
+                     symbol)))
+
+(defmacro code-line
+  "gets the current code line
+
+   (code-line)
+   => number?"
+  {:added "3.0"}
+  ([]
+   (:line (meta &form))))
+
+(defmacro code-column
+  "gets the current code column
+
+   (code-column)
+   => 3"
+  {:added "3.0"}
+  ([]
+   (:column (meta &form))))
+
+(defn thread-form
+  "helper function to '->' and '->>'
+
+   (thread-form '[(+ 1) dec]
+                (fn [form] (concat form ['%])))
+   => '(% (+ 1 %) % (dec %))"
+  {:added "3.0"}
+  ([forms transform-fn]
+   (interleave (repeat '%)
+               (map (fn [form]
+                      (cond (list? form)
+                            (if (some (fn [v] (= v '%)) (flatten form))
+                              form
+                              (transform-fn form))
+
+                            :else
+                            (transform-fn (list form))))
+                    forms))))
+
+(defmacro ->
+  "like -> but with % as placeholder
+
+   (-> 1
+       inc
+       (- 10 %))
+   => 8"
+  {:added "3.0"}
+  ([expr & forms]
+   `(let [~'% ~expr
+          ~@(thread-form forms (fn [form] (concat [(first form) '%] (rest form))))]
+      ~'%)))
+
+(defmacro ->>
+  "like ->> but with % as placeholder
+
+   (-> 1
+       inc
+       (- % 10))
+   => -8"
+  {:added "3.0"}
+  ([expr & forms]
+   `(let [~'% ~expr
+          ~@(thread-form forms (fn [form] (concat form ['%])))]
+      ~'%)))
+
+(defn var-sym
+  "converts a var to a symbol
+
+   (var-sym #'var-sym)
+   => 'bb.lib.foundation/var-sym"
+  {:added "3.0"}
+  ([^clojure.lang.Var var]
+   (symbol (str (.getName (.ns var)))
+           (str (.sym var)))))
+
+(defn unbound?
+  "checks if a variable is unbound
+
+   (declare -lost-)
+
+   (unbound? -lost-)
+   = true"
+  {:added "3.0"}
+  ([obj]
+   (= (str (type obj)) "class sci.impl.vars.SciUnbound")))
+
+(defmacro set!
+  "sets a var without changing current meta
+
+   (bb.lib.foundation/set! -lost- 1)"
+  {:added "3.0"}
+  ([sym val]
+   (let [mt (meta sym)]
+     (if-not (resolve sym)
+       `(def ~(with-meta sym mt) ~val)
+       `(do (alter-var-root (var ~sym) (constantly ~val))
+            ~@(if (not-empty mt) [`(alter-meta! (var ~sym) merge ~mt)])
+            (var ~sym))))))
+
+(defmacro suppress
+  "Suppresses any errors thrown in the body.
+
+   (suppress (throw (ex-info \"Error\" {}))) => nil
+
+   (suppress (throw (ex-info \"Error\" {})) :error) => :error
+
+   (suppress (throw (ex-info \"Error\" {}))
+             (fn [^Throwable e]
+               (.getMessage e))) => \"Error\""
+  {:added "3.0"}
+  ([body]
+   `(try ~body (catch Throwable ~'t)))
+  ([body catch-val]
+   `(try ~body (catch Throwable ~'t
+                 (cond (fn? ~catch-val)
+                       (~catch-val ~'t)
+                       :else ~catch-val)))))
+
+(defmacro with-thrown
+  "gets the exception data in a form
+
+   (ex-data (with-thrown (throw (ex-info \"Error\" {:hello \"1\"}))))
+   => {:hello \"1\"}"
+  {:added "4.0"}
+  [& body]
+  `(try ~@body (catch Throwable ~'t ~'t)))
+
+(defmacro with-ex
+  "gets the exception data in a form
+
+   (with-ex (throw (ex-info \"Error\" {:hello \"1\"})))
+   => {:hello \"1\"}"
+  {:added "4.0"}
+  [& body]
+  `(ex-data (try ~@body (catch Throwable ~'t ~'t))))
+
+(defn with-retry-fn
+  "with a retry function"
+  {:added "4.0"}
+  [limit sleep f]
+  (loop [limit limit
+         cause nil]
+    (when (< 0 limit)
+      (throw (ex-info "Retries all failed" {} cause)))
+    (let [[res ex] (try [(f) nil]
+                        (catch Throwable t [nil t]))]
+      (cond res res
+
+            :else
+            (do (Thread/sleep (long (or sleep 500)))
+                (recur (- limit 1) ex))))))
+
+(defmacro with-retry
+  "with retry macro"
+  {:added "4.0"}
+  [[limit sleep] & body]
+  (list `with-retry-fn limit sleep (apply list 'fn [] body)))
+
+(defmacro error
+  "throws an error with message
+
+   (error \"Error\")
+   => (throws)"
+  {:added "3.0"}
+  ([message]
+   `(throw (ex-info ~message {})))
+  ([message data]
+   `(throw (ex-info ~message ~data))))
+
+(defmacro trace
+  "prints out the item and a program trace
+
+   (trace \"Error\")
+   => Throwable"
+  {:added "3.0"}
+  ([]
+   '(try (ex-info "TRACE" {})
+         (catch Throwable t t)))
+  ([val]
+   (list 'try (list 'throw (list 'ex-info "TRACE" {:val val}))
+         '(catch Throwable t t))))
+
+(defn throwable?
+  "checks that object is a `Throwable`
+
+   (throwable? (ex-info \"hello\" {}))
+   => true"
+  {:added "3.0"}
+  ([obj]
+   (instance? Throwable obj)))
+
+(defn byte?
+  "Returns `true` if `x` is of type `java.lang.Byte`
+
+   (byte? (byte 1)) => true"
+  {:added "3.0"}
+  ([x] (instance? java.lang.Byte x)))
+
+(defn short?
+  "Returns `true` if `x` is of type `java.lang.Short`
+
+   (short? (short 1)) => true"
+  {:added "3.0"}
+  ([x]
+   (instance? java.lang.Short x)))
+
+(defn long?
+  "Returns `true` if `x` is of type `java.lang.Long`
+
+   (long? 1)          => true
+   (long? 1N)         => false"
+  {:added "3.0"}
+  ([x]
+   (instance? java.lang.Long x)))
+
+(defn bigint?
+  "Returns `true` if `x` is of type `clojure.lang.BigInt`.
+
+   (bigint? 1N)       => true
+   (bigint? 1)        =>  false"
+  {:added "3.0"}
+  ([x]
+   (instance? clojure.lang.BigInt x)))
+
+(defn bigdec?
+  "Returns `true` if `x` is of type `java.math.BigDecimal`.
+
+   (bigdec? 1M)       => true
+   (bigdec? 1.0)      => false"
+  {:added "3.0"}
+  ([x]
+   (instance? java.math.BigDecimal x)))
+
+(defn regexp?
+  "Returns `true` if `x` implements `clojure.lang.IPersistentMap`.
+
+   (regexp? #\"\\d+\") => true"
+  {:added "3.0"}
+  ([x] (instance? java.util.regex.Pattern x)))
+
+(defn iobj?
+  "checks if a component is instance of `clojure.lang.IObj`
+
+   (iobj? 1) => false
+
+   (iobj? {}) => true"
+  {:added "3.0"}
+  ([x]
+   (instance? clojure.lang.IObj x)))
+
+(defn iref?
+  "Returns `true` if `x` is of type `clojure.lang.IRef`.
+
+   (iref? (atom 0))  => true"
+  {:added "3.0"}
+  ([obj]
+   (instance? clojure.lang.IRef obj)))
+
+(defn ideref?
+  "checks if
+
+   (ideref? (volatile! 0)) => true
+   (ideref? (promise)) => true"
+  {:added "3.0"}
+  ([obj]
+   (instance? clojure.lang.IDeref obj)))
+
+(defn thread?
+  "Returns `true` is `x` is a thread
+
+   (thread? (Thread/currentThread)) => true"
+  {:added "3.0"}
+  ([obj]
+   (instance? java.lang.Thread obj)))
+
+(defn url?
+  "Returns `true` if `x` is of type `java.net.URL`.
+
+   (url? (java.net.URL. \"file:/Users/chris/Development\")) => true"
+  {:added "3.0"}
+  ([x] (instance? java.net.URL x)))
+
+(defn atom?
+  "Returns `true` if `x` is of type `clojure.lang.Atom`.
+
+   (atom? (atom nil)) => true"
+  {:added "3.0"}
+  ([obj]
+   (instance? clojure.lang.Atom obj)))
+
+(defn comparable?
+  "Returns `true` if `x` and `y` both implements `java.lang.Comparable`.
+
+   (comparable? 1 1) => true"
+  {:added "3.0"}
+  ([x y]
+   (and (instance? Comparable x)
+        (instance? Comparable y)
+        (= (type x) (type y)))))
+
+(defn array?
+  "checks if object is a primitive array
+
+   (array? (into-array []))
+   => true
+
+   (array? String (into-array [\"a\" \"b\" \"c\"]))
+   => true"
+  {:added "3.0"}
+  ([x]
+   (.isArray ^Class (type x)))
+  ([cls x]
+   (and (array? x)
+        (= cls (.getComponentType ^Class (type x))))))
+
+(defn parse-long
+  "parses a long from string
+
+   (parse-long \"100\")
+   => 100"
+  {:added "3.0"}
+  ([s]
+   (Long/parseLong s)))
+
+(defn parse-double
+  "parses a double from string
+
+   (parse-double \"100\")
+   => 100.0
+
+   (parse-double \"100.123\")
+   => 100.123"
+  {:added "3.0"}
+  ([s]
+   (Double/parseDouble s)))
+
+(defn edn?
+  "checks if an entry is valid edn
+
+   (edn? 1) => true
+
+   (edn? {}) => true
+
+   (edn? (java.util.Date.))
+   => false"
+  {:added "3.0"}
+  ([x]
+   (or (nil? x)
+       (boolean? x)
+       (string? x)
+       (char? x)
+       (symbol? x)
+       (keyword? x)
+       (number? x)
+       (seq? x)
+       (vector? x)
+       (record? x)
+       (map? x)
+       (set? x)
+       (tagged-literal? x)
+       (var? x)
+       (regexp? x))))
+
+(defn hash-id
+  "returns the actual memory related id for an object"
+  {:added "3.0"}
+  ([obj]
+   (System/identityHashCode obj)))
+
+(defn hash-code
+  "returns the hash code of an object"
+  {:added "3.0"}
+  ([^Object obj]
+   (.hashCode obj)))
+
+(defn aget
+  "typesafe aget
+
+   (aget (int-array [1 2 3]) 2)
+   => 3"
+  {:added "3.0"}
+  ([arr i]
+   (case (.getName ^Class (type arr))
+     "[J" (clojure.core/aget ^longs arr i)
+     "[I" (clojure.core/aget ^ints arr i)
+     "[S" (clojure.core/aget ^shorts arr i)
+     "[B" (clojure.core/aget ^bytes arr i)
+     "[Z" (clojure.core/aget ^booleans arr i)
+     "[F" (clojure.core/aget ^floats arr i)
+     "[D" (clojure.core/aget ^doubles arr i))))
+
+(defn demunge
+  "demunges an input to be nicer looking
+
+   (demunge ;;; (munge \"+test!\")
+    \"_PLUS_test_BANG_\")
+   => \"+test!\""
+  {:added "3.0"}
+  ([name]
+   (clojure.lang.Compiler/demunge name)))
+
+(def re-create
+  (memoize (fn [^String s]
+             (if (regexp? s)
+               s
+               (-> (str s)
+                   (.replaceAll "\\." "\\\\\\.")
+                   (.replaceAll "\\*" "\\\\\\*")
+                   (.replaceAll "\\?" "\\\\\\?")
+                   (re-pattern))))))
+
+(defn intern-var
+  "interns a var in sym"
+  {:added "3.0"}
+  ([ns sym var]
+   (intern-var ns sym var nil))
+  ([ns sym var ext]
+   (let [out (intern ns sym  (deref var))]
+     (alter-meta! out merge (meta var) ext)
+     out)))
+
+(defn intern-form
+  "creates base form for `intern-in` and `intern-all`
+
+   (intern-form 'bb.lib 'bb.lib.foundation/unfold)"
+  {:added "3.0"}
+  ([ns sym]
+   (intern-form ns sym nil))
+  ([ns sym meta]
+   (let [[to from] (if (vector? sym)
+                     sym
+                     [sym sym])]
+     `(intern-var (quote ~ns) (quote ~(symbol (name to)))
+                  (var ~from)
+                  (quote ~meta)))))
+
+(defmacro intern-in
+  "adds a function to current"
+  {:added "3.0"}
+  ([ns? & syms]
+   (let [[ns syms] (if (or (vector? ns?)
+                           (namespace ns?))
+                     [(.getName clojure.core/*ns*) (cons ns? syms)]
+                     [ns? syms])]
+     (mapv (partial intern-form ns) syms))))
+
+(defmacro intern-all
+  "adds a namespace to current"
+  {:added "3.0"}
+  [& nss]
+  (->> nss
+       (mapcat (fn [ns]
+                 (->> (ns-publics ns)
+                      (vals)
+                      (map (fn [^clojure.lang.Var var]
+                             (let [sym (.toSymbol var)]
+                               (intern-form (.getName clojure.core/*ns*)
+                                            sym)))))))
+       (vec)))
+
+(def ^:private ^:dynamic *template-meta* nil)
+
+(defmacro ^{:style/indent 1}
+  with:template-meta
+  "binds the template meta (for testing purposes)"
+  {:added "3.0"}
+  [meta & body]
+  `(binding [*template-meta* ~meta]
+     ~@body))
+
+(defn template-meta
+  "returns the intern template meta"
+  {:added "3.0"}
+  ([]
+   *template-meta*))
+
+(defmacro template-vars
+  "adds a function to current given var and arguments"
+  {:added "3.0" :style/indent 1}
+  ([[tmpl-fn & [tmpl-meta]] & syms]
+   (let [tmpl-fn (resolve tmpl-fn)]
+     (binding [*template-meta* tmpl-meta]
+       (mapv (fn [sym]
+               (let [[to from & args] (if (symbol? sym)
+                                        [(symbol (name sym)) sym]
+                                        sym)]
+                 (apply tmpl-fn to
+                        (if from (resolve from)) args)))
+             syms)))))
+
+(defmacro ^{:style/indent 1}
+  template-entries
+  "uses a template function to produce entries"
+  {:added "3.0" :style/indent 1}
+  ([[tmpl-fn & [tmpl-meta]] & entries]
+   (let [tmpl-fn (cond (symbol? tmpl-fn)
+                       (resolve tmpl-fn)
+
+                       (list? tmpl-fn)
+                       (eval tmpl-fn))
+         entries (mapcat (fn [entry]
+                           (cond (symbol? entry)
+                                 @(resolve entry)
+
+                                 (list? entry)
+                                 (eval entry)
+
+                                 :else entry))
+                         entries)]
+     (binding [*template-meta* (merge tmpl-meta (meta &form))]
+       (mapv (fn [e]
+               (try (tmpl-fn e)
+                    (catch Throwable t
+                      (eval (list 'bb.lib/prn (list 'quote e)))
+                      (throw t))))
+             entries)))))
+
+(defmacro ^{:style/indent 1}
+  template-bulk
+  "template-entries but for heavy usage"
+  {:added "4.0"}
+  [[tmpl-fn & [tmpl-meta]]
+   entries]
+  (let [tmeta (meta &form)]
+    `(binding [*template-meta* (merge ~tmpl-meta ~tmeta)]
+       (mapv (comp eval ~tmpl-fn) ~entries))))
+
+(defn template-ensure
+  "ensures that the templated entries are the same as the input"
+  {:added "4.0"}
+  [syms vars]
+  (let [diff (clojure.set/difference (set (map (fn [[sym _]]
+                                                 (symbol (str (.getName *ns*))
+                                                         (name sym)))
+                                               syms))
+                                     (set (map var-sym vars)))]
+    (when (not-empty diff)
+      (eval (list 'do
+                  (list 'bb.lib/beep)
+                  (list 'bb.lib/prn diff))))
+    vars))
+
+(deftype Wrapped [val show type display]
+  java.lang.Object
+  (toString [_]
+    (cond display
+          (display val)
+
+          :else
+          (str (if type
+                 (str "<" type ">"))
+               "\n"
+               ((or show identity) (str val)))))
+
+  clojure.lang.IDeref
+  (deref [_] val))
+
+(defmethod print-method Wrapped
+  [v ^java.io.Writer w]
+  (.write w (str v)))
+
+(defn wrapped
+  "object to display shell result"
+  {:added "4.0"}
+  ([val]
+   (wrapped val identity nil))
+  ([val show]
+   (wrapped val show nil nil))
+  ([val show type]
+   (Wrapped. val show type nil))
+  ([val show type display]
+   (Wrapped. val show type display)))
+
+(defn wrapped?
+  "checks that an object is wrapped"
+  {:added "4.0"}
+  [val]
+  (instance? Wrapped val))
+
+(defn resolve-namespaced
+  "resolves a namespaced symbol"
+  {:added "4.0"}
+  [x]
+  (if (and (symbol? x)
+           (namespace x))
+    (var-sym (resolve x))
+    x))
+
+(defmacro def.m
+  "defs multiple vars"
+  {:added "4.0"}
+  [syms call]
+  `(let [~'out ~call]
+     ~@(map-indexed (fn [i sym]
+                      `(def ~sym (nth ~'out ~i)))
+                    syms)))

--- a/src/bb/lib/function.clj
+++ b/src/bb/lib/function.clj
@@ -1,0 +1,210 @@
+(ns bb.lib.function
+  (:import (clojure.lang Fn)
+           (java.lang.reflect Method)))
+
+(def +specialized+
+  '{int "Int"
+    long "Long"
+    double "Double"
+    boolean "Boolean"})
+
+(defn fn-form
+  "creates a lambda form"
+  {:added "3.0"}
+  [cls method bindings body]
+  `(reify ~(symbol (str "java.util.function." cls))
+     (~(symbol method) [~'_ ~@(map #(with-meta % {}) bindings)] ~@body)))
+
+(defn fn-tags
+  "creates tags for fn
+
+   (fn-tags ^{:tag 'long} [])
+   => [\"Long\" nil nil]
+
+   (fn-tags ^{:tag 'long} [^{:tag 'long} [] ^{:tag 'int} []])
+   => [\"Long\" \"Long\" \"Int\"]"
+  {:added "3.0"}
+  [bindings]
+  (let [tag-fn (fn [form]
+                 (if form
+                   (if-let [tag (get (meta form) :tag)]
+                     (get +specialized+ tag))))]
+    [(tag-fn bindings)
+     (tag-fn (first bindings))
+     (tag-fn (second bindings))]))
+
+(defmacro fn:supplier
+  "creates a java supplier"
+  {:added "3.0" :style/indent 1}
+  ([bindings & body]
+   (let [[return] (fn-tags bindings)
+         [cls method] (if return
+                        [(str return "Supplier") (str "getAs" return)]
+                        ["Supplier" "get"])]
+     (fn-form cls method bindings body))))
+
+(defmacro fn:predicate
+  "creates a java predicate
+
+   (-> (fn:predicate [^long a] (< a 10))
+       (.test 3))
+   => true"
+  {:added "3.0" :style/indent 1}
+  ([bindings & body]
+   (let [len (count bindings)
+         [_ a0] (fn-tags bindings)
+         cls (case len
+               1 (if a0
+                   (str a0 "Predicate")
+                   "Predicate")
+               2 "BiPredicate")]
+     (fn-form cls "test" bindings body))))
+
+(defmacro fn:lambda
+  "creates java unary/binary functions"
+  {:added "3.0" :style/indent 1}
+  ([bindings & body]
+   (let [len (count bindings)
+         [return a0] (fn-tags bindings)
+         [cls method] (case len
+                        1 (cond (and return a0)
+                                [(str a0 "To" return "Function") (str "applyAs" return)]
+
+                                return
+                                [(str "To" return "Function") (str "applyAs" return)]
+
+                                a0
+                                [(str a0 "Function") "apply"]
+
+                                :else ["Function" "apply"])
+                        2 ["BiFunction" "apply"])]
+     (fn-form cls method bindings body))))
+
+(defmacro fn:consumer
+  "creates a java unary function"
+  {:added "3.0" :style/indent 1}
+  ([bindings & body]
+   (let [len (count bindings)
+         [_ a0] (fn-tags bindings)
+         cls (case len
+               1 (if a0
+                   (str a0 "Consumer")
+                   "Consumer")
+               2 "BiConsumer")]
+     (fn-form cls "accept" bindings `[(do ~@body nil)]))))
+
+(defn vargs?
+  "checks that function contain variable arguments
+
+   (vargs? (fn [x])) => false
+
+   (vargs? (fn [x & xs])) => true"
+  {:added "3.0"}
+  ([^Fn f]
+   (if (some (fn [^Method mthd]
+               (= "getRequiredArity" (.getName mthd)))
+             (.getDeclaredMethods (class f)))
+     true
+     false)))
+
+(defn varg-count
+  "counts the number of arguments types before variable arguments
+
+   (varg-count (fn [x y & xs])) => 2
+
+   (varg-count (fn [x])) => nil"
+  {:added "3.0"}
+  ([f]
+   (if (some (fn [^Method mthd]
+               (= "getRequiredArity" (.getName mthd)))
+             (.getDeclaredMethods (class f)))
+     (.getRequiredArity f))))
+
+(defn arg-count
+  "counts the number of non-varidic argument types
+
+   (arg-count (fn [x])) => [1]
+
+   (arg-count (fn [x & xs])) => []
+
+   (arg-count (fn ([x]) ([x y]))) => [1 2]"
+  {:added "3.0"}
+  ([f]
+   (let [ms (filter (fn [^Method mthd]
+                      (= "invoke" (.getName mthd)))
+                    (.getDeclaredMethods (class f)))
+         ps (map (fn [^Method m]
+                   (.getParameterTypes m)) ms)]
+     (map alength ps))))
+
+(defn arg-check
+  "counts the number of non-varidic argument types
+
+   (arg-check (fn [x]) 1) => true
+
+   (arg-check (fn [x & xs]) 1) => true
+
+   (arg-check (fn [x & xs]) 0)
+   => (throws-info {:required 0 :actual [() 1]})"
+  {:added "3.0"}
+  ([f num]
+   (arg-check f num "Wrong number of arguments"))
+  ([f num message]
+   (or (if-let [vc (varg-count f)]
+         (<= vc num))
+       (boolean (some #{num} (arg-count f)))
+       (throw (ex-info message
+                       {:function f
+                        :required num
+                        :actual [(arg-count f) (varg-count f)]})))))
+
+(defn fn:init-args
+  "creates init args
+
+   (fn:init-args '[x] '(inc x) [])
+   => '[\"\" {} ([x] (inc x))]"
+  {:added "3.0"}
+  [doc? attr? more]
+  (let [[doc attr? more] (if (string? doc?)
+                           [doc? attr? more]
+                           (if (nil? attr?)
+                             ["" doc? more]
+                             ["" doc? (cons attr? more)]))
+        [attr more] (if (map? attr?)
+                      [attr? more]
+                      [{} (cons attr? more)])]
+    [doc attr more]))
+
+(defn fn:create-args
+  "creates args for the body
+
+   (fn:create-args '[[x] (inc x) nil nil])
+   => '(\"\" {} [x] (inc x))"
+  {:added "3.0"}
+  ([[doc? attr? & more :as arglist]]
+   (let [[doc attr more] (fn:init-args doc? attr? more)]
+     (->> more
+          (cons attr)
+          (cons doc)
+          (keep identity)))))
+
+(defn fn:def-form
+  "creates a def form"
+  {:added "3.0"}
+  ([name attrs body]
+   (let [name (with-meta name attrs)]
+     `(def ~name ~body)))
+  ([name doc attrs arglist body]
+   (let [arglists (cond (nil? arglist)
+                        nil
+
+                        (vector? arglist)
+                        `(quote ~(list arglist))
+
+                        :else
+                        `(quote ~arglist))]
+     (fn:def-form name
+                  (merge attrs
+                         {:doc doc}
+                         (if arglists {:arglists arglists}))
+                  body))))

--- a/src/bb/lib/impl.clj
+++ b/src/bb/lib/impl.clj
@@ -1,0 +1,559 @@
+(ns bb.lib.impl
+  (:require [bb.lib.foundation :as h]
+            [bb.lib.collection :as c]
+            [bb.lib.walk :as walk]
+            [clojure.set :as set]))
+
+(def ^:dynamic *self* false)
+
+(def ^:dynamic *override* nil)
+
+(defn split-body
+  "splits a body depending on keyword pairs
+
+   (split-body [:a 1 :b 2 '[hello] '[there]])
+   => [{:a 1, :b 2} '([hello] [there])]"
+  {:added "3.0"}
+  ([body]
+   (let [params (->> (partition 2 body)
+                     (take-while (comp keyword? first))
+                     (map vec))
+         len (* 2 (count params))
+         body (drop len body)]
+     [(into {} params) body])))
+
+(defn split-single
+  "splits out a given entry"
+  {:added "3.0"}
+  ([forms]
+   (split-single forms :tag))
+  ([forms tag-key]
+   (let [ptl (first forms)
+         [params body] (split-body (rest forms))]
+     [(assoc params tag-key ptl) body])))
+
+(defn split-all
+  "splits all entries
+
+   (split-all '[ITest
+                :include [-test]
+                :body {-val 3}
+                IMore
+                IProtocols
+                :exclude []]
+              :protocol
+              {:prefix \"test/\"})
+  => '[{:prefix \"test/\", :include [-test], :body {-val 3}, :protocol ITest}
+        {:prefix \"test/\", :protocol IMore}
+        {:prefix \"test/\", :exclude [], :protocol IProtocols}]"
+  {:added "3.0"}
+  ([forms]
+   (split-all forms :tag))
+  ([forms tag-key]
+   (split-all forms tag-key {}))
+  ([forms tag-key params]
+   (cond (empty? forms)
+         []
+
+         :else
+         (loop [forms forms
+                acc []]
+           (let [[ptl more] (split-single forms tag-key)
+                 ptl (merge params ptl)
+                 acc (conj acc ptl)]
+             (if (empty? more)
+               acc
+               (recur more acc)))))))
+
+(defn impl:unwrap-sym
+  "unwraps the protocol symbol
+
+   (impl:unwrap-sym {:name '-val :prefix \"test/\" :suffix \"-mock\"})
+   => 'test/val-mock"
+  {:added "3.0"}
+  ([{:keys [name prefix suffix]
+     :or {prefix "" suffix ""}}]
+   (symbol (str prefix (subs (h/strn name) 1) suffix))))
+
+(defn impl:wrap-sym
+  "wraps the protocol symbol
+
+   (impl:wrap-sym {:protocol 'protocol.test/ITest :name '-val})
+   => 'protocol.test/-val"
+  {:added "3.0"}
+  ([{:keys [protocol name]}]
+   (symbol (namespace protocol) (h/strn name))))
+
+(defn standard-body-input-fn
+  "creates a standard input function"
+  {:added "3.0"}
+  ([_]
+   (fn [{:keys [arglist]}] arglist)))
+
+(defn standard-body-output-fn
+  "creates a standard output function"
+  {:added "3.0"}
+  ([{:keys [body-sym-fn body-arg-fn]
+     :or {body-sym-fn :name
+          body-arg-fn identity}}]
+   (fn [{:keys [arglist] :as signature}]
+     (let [body `(~(body-sym-fn signature)
+                  ~(body-arg-fn (first arglist))
+                  ~@(rest arglist))]
+       (if *self*
+         `(do ~body ~(first arglist))
+         body)))))
+
+(defn create-body-fn
+  "creates a body function
+
+   ((create-body-fn {:body-sym-fn impl:unwrap-sym})
+    {:name '-val :arglist '[cache val] :prefix \"test/\"})
+   => '([cache val] (test/val cache val))"
+  {:added "3.0"}
+  ([{:keys [body-fn] :as fns}]
+   (cond body-fn
+         body-fn
+
+         :else
+         (let [{:keys [body-input-fn body-output-fn]
+                :or {body-input-fn  (standard-body-input-fn fns)
+                     body-output-fn (standard-body-output-fn fns)}} fns]
+           (fn [{:keys [self] :as signature}]
+             (let [input  (body-input-fn signature)
+                   output (body-output-fn signature)]
+               (if self
+                 `(~input ~output ~(first input))
+                 `(~input ~output))))))))
+
+(defn template-signatures
+  "finds template signatures for a protocol"
+  {:added "3.0"}
+  ([protocol]
+   (template-signatures protocol {}))
+  ([protocol params]
+   (let [sigs (if-let [var (-> protocol resolve)]
+                (-> var deref :sigs)
+                (throw (ex-info "Cannot find protocol" {:input protocol})))]
+     (mapcat (fn [{:keys [arglists] :as m}]
+               (let [m (-> (merge params m)
+                           (dissoc :arglists))]
+                 (map (fn [arglist]
+                        (assoc m :arglist arglist))
+                      arglists)))
+             (vals sigs)))))
+
+(defn template-transform
+  "transforms all functions"
+  {:added "3.0"}
+  ([signatures {:keys [template-fn] :as fns
+                :or {template-fn identity}}]
+   (let [body-fn  (create-body-fn fns)
+         sym-fn   (fn [{:keys [name] :as m}] (with-meta name m))
+         all (map (juxt sym-fn body-fn)
+                  signatures)]
+     (template-fn all))))
+
+(defn parse-impl
+  "parses the different transform types
+
+   (parse-impl (template-signatures 'IHello {:prefix \"impl/\"})
+               {:body '{-hi \"Hi There\"}})
+   => '{:method #{},
+        :body #{-hi},
+        :default #{-delete}}"
+  {:added "3.0"}
+  ([signatures {:keys [method body include exclude] :as params}]
+   (let [include-syms (if include (set include))
+         exclude-syms (set exclude)
+         method-syms  (set (keys method))
+         body-syms    (set (keys body))
+         default-syms (set/difference (or include-syms
+                                          (set (map :name signatures)))
+                                      (set/union method-syms
+                                                 body-syms
+                                                 exclude-syms))]
+     {:method method-syms
+      :body body-syms
+      :default default-syms})))
+
+(defn template-gen
+  "generates forms given various formats
+
+   (template-gen protocol-fns [:default]
+                 (template-signatures 'ITest) {} {})
+   => '([-val ([obj] (val obj))]
+        [-val ([obj k] (val obj k))]
+        [-get ([obj] (get obj))])"
+  {:added "3.0"}
+  ([type-fn types signatures params fns]
+   (let [syms (parse-impl signatures params)]
+     (mapcat (fn [type]
+               (let [fns (merge (type-fn type (get params type))
+                                fns
+                                (get *override* type))]
+                 (h/->> signatures
+                        (filter (fn [{:keys [name]}]
+                                  ((get syms type) name)))
+                        (template-transform % (or (get fns type)
+                                                  fns)))))
+             types))))
+
+(defn protocol-fns
+  "helpers for protocol forms
+
+   (protocol-fns :body {})
+   => (contains {:body-output-fn fn?})"
+  {:added "3.0"}
+  ([type template]
+   (case type
+     :default {:body-sym-fn impl:unwrap-sym}
+     :method  {:body-sym-fn (fn [{:keys [name]}] (get template name))}
+     :body    {:body-output-fn (fn [{:keys [name]}] (get template name))})))
+
+(defn dimpl-template-fn
+  "helper function for defimpl"
+  {:added "3.0"}
+  ([inputs]
+   (map (fn [[name body]]
+          (apply list name body))
+        inputs)))
+
+(defn dimpl-template-protocol
+  "coverts the entry into a template
+
+   (dimpl-template-protocol {:protocol 'ITest :prefix \"impl/\" :suffix \"-test\"})
+   => '(ITest (-val [obj] (impl/val-test obj))
+              (-val [obj k] (impl/val-test obj k))
+              (-get [obj] (impl/get-test obj)))"
+  {:added "3.0"}
+  ([{:keys [protocol prefix suffix fns custom] :as params}]
+   (let [signatures (template-signatures protocol {:prefix prefix :suffix suffix})
+         types [:default :method :body]]
+     (h/-> (template-gen protocol-fns types signatures params
+                         (merge {:template-fn dimpl-template-fn}
+                                (c/map-vals eval fns)))
+           (concat custom)
+           (cons protocol %)))))
+
+(defn interface-fns
+  "helper for interface forms
+
+   (interface-fns :body {})
+   => (contains {:body-output-fn fn?})"
+  {:added "3.0"}
+  ([type template]
+   (case type
+     :method  {:body-sym-fn (fn [{:keys [name arglist]}] (get-in template [name arglist]))}
+     :body    {:body-output-fn (fn [{:keys [name arglist]}]
+                                 (get-in template [name arglist]))})))
+
+(defn dimpl-template-interface
+  "creates forms for the interface
+
+   (dimpl-template-interface {:interface 'ITest
+                              :method '{invoke {[entry] submit-invoke}}
+                              :body   '{bulk? {[entry] false}}})
+   => '(ITest (invoke [entry] (submit-invoke entry))
+              (bulk? [entry] false))"
+  {:added "3.0"}
+  ([{:keys [interface method body] :as params}]
+   (let [all  (merge-with merge method body)
+         signatures (mapcat (fn [[name methods]]
+                              (map (fn [[args _]]
+                                     (merge {:arglist args
+                                             :name name}
+                                            (dissoc params :method body)))
+                                   methods))
+                            all)
+         body-sym    (fn [{:keys [name arglist] :as params}]
+                       (get-in method [name arglist]))
+         body-output (fn [{:keys [name arglist] :as params}]
+                       (get-in body [name arglist]))
+         types [:method :body]]
+     (->> (template-gen interface-fns types signatures params {:template-fn dimpl-template-fn})
+          (cons interface)))))
+
+(defn dimpl-print-method
+  "creates a print method form"
+  {:added "3.0"}
+  ([sym]
+   `(defmethod print-method (Class/forName ~(str (munge *ns*) "." sym))
+      ([~'v ~(with-meta 'w {:tag 'java.io.Writer})]
+       (.write ~'w (str ~'v))))))
+
+(defonce +dimpl-fn-args+ 21)
+
+(defn dimpl-fn-invoke
+  "creates an invoke method"
+  {:added "3.0"}
+  ([method n]
+   (let [args (map #(symbol (str "a" %)) (range n))]
+     `(~'invoke [~'obj ~@args] (~method ~'obj ~@args)))))
+
+(defn dimpl-fn-forms
+  "creates the `IFn` forms"
+  {:added "3.0"}
+  ([invoke]
+   (let [[invoke num] (c/seqify invoke)
+         num (or num +dimpl-fn-args+)]
+     `[clojure.lang.IFn
+       ~@(map (fn [n] (dimpl-fn-invoke invoke n)) (range num))
+       (~'applyTo ~'[obj args]
+                  (~'apply ~invoke ~'obj ~'args))])))
+
+(defn dimpl-form
+  "helper for `defimpl`"
+  {:added "3.0"}
+  ([sym bindings body]
+   (let [[params body] (split-body body)
+         {:keys [type prefix suffix string protocols interfaces invoke fns final]
+          :or {type 'defrecord prefix "" suffix "" interfaces ()}} params
+         protocols   (split-all protocols :protocol {:prefix prefix
+                                                     :suffix suffix
+                                                     :fns fns})
+         protocol-forms (mapcat dimpl-template-protocol protocols)
+         interfaces  (if string
+                       (concat ['Object :method {'toString {'[obj] string}}] interfaces)
+                       interfaces)
+         interfaces  (split-all interfaces :interface {:prefix prefix
+                                                       :suffix suffix
+                                                       :fns fns})
+         interfaces-forms (mapcat dimpl-template-interface interfaces)
+         invoke-forms  (if invoke (dimpl-fn-forms invoke))]
+     (if-not (and final
+                  (resolve sym))
+       `[(~type ~sym ~bindings ~@(concat protocol-forms
+                                         (keep identity interfaces-forms)
+                                         invoke-forms
+                                         body))
+         ~@(if string
+             [(dimpl-print-method sym)]
+             [])]))))
+
+(defmacro defimpl
+  "creates a high level `deftype` or `defrecord` interface"
+  {:added "3.0"}
+  ([sym bindings & body]
+   (dimpl-form sym bindings body)))
+
+;;;;
+;;;;
+;;;;
+
+(defn eimpl-template-fn
+  "creates forms compatible with `extend-type` and `extend-protocol`
+
+   (eimpl-template-fn '([-val ([obj] (val obj))]
+                        [-val ([obj k] (val obj k))]
+                        [-get ([obj] (get obj))]))
+   => '((-val ([obj] (val obj))
+              ([obj k] (val obj k)))
+        (-get ([obj] (get obj))))"
+  {:added "3.0"}
+  ([inputs]
+   (->> (group-by first inputs)
+        (map (fn [[name arr]]
+               `(~name ~@(map second arr)))))))
+
+(defn eimpl-template-protocol
+  "helper for eimpl-form
+
+   (eimpl-template-protocol {:protocol 'ITest :prefix \"impl/\" :suffix \"-test\"})
+   => '(ITest
+        (-val ([obj] (impl/val-test obj))
+              ([obj k] (impl/val-test obj k)))
+        (-get ([obj] (impl/get-test obj))))"
+  {:added "3.0"}
+  ([{:keys [protocol prefix suffix fns custom] :as params}]
+   (let [signatures (template-signatures protocol {:prefix prefix :suffix suffix})
+         types [:default :method :body]]
+     (h/-> (template-gen protocol-fns types signatures params
+                         (merge {:template-fn eimpl-template-fn}
+                                (c/map-vals eval fns)))
+           (concat custom)
+           (cons protocol %)))))
+
+(defn eimpl-print-method
+  "creates a print method form"
+  {:added "3.0"}
+  ([type string]
+   `(defmethod print-method ~type
+      ([~'v ~(with-meta 'w {:tag 'java.io.Writer})]
+       (.write ~'w ~(with-meta `(~string ~'v) {:tag 'String}))))))
+
+(defn eimpl-form
+  "creates the extend-impl form"
+  {:added "3.0"}
+  ([class body]
+   (let [[params _] (split-body body)
+         {:keys [prefix suffix string protocols fns]
+          :or {prefix "" suffix ""}} params
+         protocols   (split-all protocols :protocol {:prefix prefix
+                                                     :suffix suffix
+                                                     :class class
+                                                     :fns fns})
+         protocol-forms (mapcat eimpl-template-protocol protocols)]
+     `[(extend-type ~class ~@protocol-forms)
+       ~@(if string
+           [(eimpl-print-method class string)])])))
+
+(defmacro extend-impl
+  "extends a class with the protocols"
+  {:added "3.0" :style/indent 1}
+  ([type & body]
+   (cond (vector? type)
+         (mapv #(eimpl-form % body) type)
+
+         :else
+         (eimpl-form type body))))
+
+;;;;
+;;;;
+;;;;
+
+(defn build-with-opts-fn
+  "builds a function with an optional component"
+  {:added "3.0"}
+  ([fsym arr]
+   (let [arr (sort-by (comp count first) arr)
+         [arglist & body] (last arr)
+         optsym (last arglist)
+         full  `(~arglist ~@body)
+         sbody (walk/postwalk-replace {optsym {}}
+                                      body)]
+     `(defn ~fsym
+        ~@(butlast arr)
+        (~(vec (butlast arglist)) ~@sbody)
+        ~full))))
+
+(defn build-variadic-fn
+  "builds a variadic function if indicated"
+  {:added "3.0"}
+  ([fsym arr]
+   (let [arr (sort-by (comp count first) arr)
+         [arglist & body] (last arr)
+         arglist (vec (concat (butlast arglist)
+                              ['& (last arglist)]))]
+     `(defn ~fsym
+        ~@(rest arr)
+        (~arglist ~@body)))))
+
+(defn build-template-fn
+  "contructs a template from returned vals with support for variadic
+
+   ((build-template-fn {}) '([-val ([obj] (val obj))]
+                             [-val ([obj k] (val obj k))]
+                             [-get ([obj] (get obj))]))
+   => '((clojure.core/defn val
+          ([obj] (val obj))
+          ([obj k] (val obj k)))
+        (clojure.core/defn get ([obj] (get obj))))
+
+   ((build-template-fn {:variadic '#{-mul}}) '([-mul ([obj ks] (mul obj ks))]))
+   => '((clojure.core/defn
+          mul
+          ([obj & ks] (mul obj ks))))"
+  {:added "3.0"}
+  ([{:keys [variadic with-opts] :as opts}]
+   (fn [inputs]
+     (->> (group-by first inputs)
+          (map (fn [[name arr]]
+                 (let [fsym (impl:unwrap-sym (assoc opts :name name))]
+                   (cond (and variadic
+                              (or (= variadic :all)
+                                  (variadic name)))
+                         (build-variadic-fn fsym (map second arr))
+
+                         (and with-opts
+                              (or (= with-opts :all)
+                                  (with-opts name)))
+                         (build-with-opts-fn fsym (map second arr))
+
+                         :else
+                         `(defn ~fsym ~@(map second arr))))))))))
+
+(defn build-template-protocol
+  "helper for build
+
+   (build-template-protocol '{:protocol ITest
+                              :outer {:suffix \"-outer\"}
+                              :inner {:prefix \"inner-\"}
+                              :fns {:default {:body-sym-fn impl:unwrap-sym}}})
+
+   => '((clojure.core/defn val-outer
+          ([obj] (inner-val obj))
+          ([obj k] (inner-val obj k)))
+        (clojure.core/defn get-outer ([obj] (inner-get obj))))"
+  {:added "3.0"}
+  ([{:keys [protocol inner outer fns variadic with-opts] :as params}]
+   (let [variadic  (if (sequential? variadic)  (set variadic) variadic)
+         with-opts (if (sequential? with-opts) (set with-opts) with-opts)
+         inner (merge inner {:protocol protocol :variadic variadic :with-opts with-opts})
+         outer (merge outer {:protocol protocol :variadic variadic :with-opts with-opts})
+         signatures (template-signatures protocol inner)
+         types [:default :method :body]
+         fns (c/map-vals (fn [val] (cond (symbol? val)
+                                         @(resolve val)
+
+                                         :else
+                                         (eval val)))
+                         fns)
+         template-fn (build-template-fn outer)
+         forms (template-gen protocol-fns types signatures params
+                             (c/merge-nested {:template-fn template-fn
+                                              :default {:body-sym-fn impl:wrap-sym
+                                                        :template-fn template-fn}}
+                                             fns))]
+     forms)))
+
+(defn build-form
+  "allows multiple forms to be built"
+  {:added "3.0"}
+  ([body]
+   (let [[global body] (if (map? (first body))
+                         [(first body) (rest body)]
+                         [{} body])
+         protocols  (split-all body :protocol global)
+         forms      (mapcat build-template-protocol protocols)]
+     forms)))
+
+(defmacro build-impl
+  "build macro for generating functions from protocols"
+  {:added "3.0" :style/indent 1}
+  ([& body]
+   (vec (build-form body))))
+
+(defn impl:proxy
+  "creates a proxy template given a symbol
+
+   ((impl:proxy :<state>)
+    '[(-add-channel ([mq] (add-channel-atom mq) mq))])
+   => '((-add-channel [mq] (add-channel-atom :<state>) mq))"
+  {:added "3.0"}
+  ([sym]
+   (fn [inputs]
+     (map (fn [[name body]]
+            (let [[arglist form & more] body
+                  [f self & rest] form
+                  form (apply list f sym rest)]
+              (apply list name
+                     arglist form more)))
+          inputs))))
+
+(defn impl:doto
+  "operates on a proxy and returns object
+
+   ((impl:doto :<state>)
+    '[(-add-channel ([mq] (add-channel-atom mq)))])
+   => '((-add-channel [mq] (do (add-channel-atom :<state>) mq)))"
+  {:added "3.0"}
+  ([sym]
+   (fn [inputs]
+     (map (fn [[name body]]
+            (let [[arglist form & more] body
+                  [f self & rest] form
+                  form (list 'do (apply list f sym rest) self)]
+              (apply list name
+                     arglist form more)))
+          inputs))))

--- a/src/bb/lib/invoke.clj
+++ b/src/bb/lib/invoke.clj
@@ -1,0 +1,399 @@
+(ns bb.lib.invoke
+  (:require [bb.protocol-invoke :as protocol.invoke]
+            [bb.lib.function :as fn]
+            [clojure.core :as clojure]
+            [clojure.set :as set])
+  (:import (clojure.lang MultiFn))
+  (:refer-clojure :exclude [fn]))
+
+(def ^:dynamic *force* false)
+
+(def +default-packages+
+  '{:fn        {:ns clojure.core}
+    :multi     {:ns clojure.core}
+    :method    {:ns clojure.core}
+    :dynamic   {:ns clojure.core}
+    :protocol  {:ns clojure.core}
+    :compose   {:ns bb.lib.invoke}
+    :recent    {:ns bb.lib.invoke}
+    :memoize   {:ns bb.lib.memoize}
+    :element   {:ns std.object.query}
+    :task      {:ns std.task}
+    :opencl    {:ns hara.lib.opencl}})
+
+(defn multi?
+  "returns `true` if `obj` is a multimethod
+
+   (multi? print-method) => true
+
+   (multi? println) => false"
+  {:added "3.0"}
+  ([obj]
+   (instance? MultiFn obj)))
+
+(defn multi:clone
+  "creates a multimethod from an existing one"
+  {:added "3.0"}
+  ([^MultiFn source name]
+   (let [table (.getMethodTable source)
+         clone (MultiFn. name
+                         (.dispatchFn source)
+                         (.defaultDispatchVal source)
+                         (.hierarchy source))]
+     (doseq [[dispatch-val method] table]
+       (.addMethod clone dispatch-val method))
+     clone)))
+
+(defn multi:match?
+  "checks if the multi dispatch matches the arguments
+
+   (multi:match? (.dispatchFn ^MultiFn hello) (clojure.core/fn [_]))
+   => true"
+  {:added "3.0"}
+  ([multi method]
+   (multi:match? multi method false))
+  ([multi method throw?]
+   true))
+
+(defn multi:get
+  "returns all entries in the multimethod
+
+   (multi:get hello :a)
+   => fn?"
+  {:added "3.0"}
+  ([^MultiFn multi dispatch]
+   (get (methods multi) dispatch)))
+
+(defn multi:add
+  "adds an entry to the multimethod
+
+   (multi:add hello :c (clojure.core/fn [m] (assoc m :c 3)))
+   => hello"
+  {:added "3.0"}
+  ([^MultiFn multi dispatch-val method]
+   (let [dispatch-fn (.-dispatchFn multi)]
+     (if (multi:match? dispatch-fn method true)
+       (do (defmethod multi dispatch-val [m] (method m))
+           multi)))))
+
+(defn multi:list
+  "returns all entries in the multimethod
+
+   (keys (multi:list world))
+   => (contains [:a :b]
+                :in-any-order)"
+  {:added "3.0"}
+  ([^MultiFn multi]
+   (methods multi)))
+
+(defn multi:remove
+  "removes an entry
+
+   (multi:remove world :b)
+   => ifn?"
+  {:added "3.0"}
+  ([^MultiFn multi val]
+   (remove-method multi val)))
+
+(defn invoke:arglists
+  "returns the arglists of a form
+
+   (invoke:arglists '([x] x))
+   => '(quote ([x]))
+
+   (invoke:arglists '(([x] x) ([x y] (+ x y))))
+   => '(quote ([x] [x y]))"
+  {:added "3.0"}
+  ([body]
+   (cond (list? (first body))
+         `(quote ~(map first body))
+
+         (vector? (first body))
+         `(quote ~(list (first body)))
+
+         :else
+         (throw (ex-info "Cannot find arglists." {:body body})))))
+
+(defn invoke-intern-method
+  "creates a `:method` form, similar to `defmethod`
+
+   (defmulti -hello-multi- identity)
+   (invoke-intern-method '-hello-method-
+                         {:multi '-hello-multi-
+                          :val :apple}
+                         '([x] x))"
+  {:added "3.0"}
+  ([name {:keys [multi val] :as config} body]
+   (let [arglists (invoke:arglists body)
+         [mm-name method-name] (cond (nil? multi)
+                                     (if (resolve name)
+                                       [name name]
+                                       (throw (ex-info "Cannot resolve multimethod." {:name name})))
+
+                                     :else
+                                     (if (or (not (symbol? multi)) (resolve multi))
+                                       [multi name]
+                                       (throw (ex-info "Cannot resolve multimethod." {:name multi}))))]
+     (if-not (= mm-name method-name)
+       (let [method-name (with-meta method-name (merge config {:arglists arglists}))]
+         `(let [~'v (def ~method-name (clojure/fn ~method-name ~@body))]
+            [(multi:add ~mm-name ~val ~method-name)
+             ~'v]))
+       `[(multi:add ~mm-name ~val (clojure/fn ~@body))
+         nil]))))
+
+(defmethod bb.protocol-invoke/-invoke-intern :method
+  [label name {:keys [multi val] :as config} body]
+  (invoke-intern-method name config body))
+
+(defn resolve-method
+  "resolves a package related to a label
+
+   (resolve-method bb.protocol-invoke/-invoke-intern
+                   bb.protocol-invoke/-invoke-package
+                   :fn
+                   +default-packages+)
+   => nil"
+  {:added "3.0"}
+  ([mmethod pkgmethod label lookup]
+   (let [exists? (multi:get mmethod label)]
+     (when (not exists?)
+       (let [{:keys [ns]} (or (get lookup label)
+                              (if (multi:get pkgmethod label)
+                                (pkgmethod label)))]
+         (if ns
+           (require ns)
+           (throw (ex-info "resolve package does not exist" {:label label}))))))))
+
+(defn invoke-intern
+  "main function to call for `definvoke`
+
+   (invoke-intern :method
+                  '-hello-method-
+                  {:multi '-hello-multi-
+                   :val :apple}
+                  '([x] x))
+   => '(clojure.core/let [v (def -hello-method- (clojure.core/fn -hello-method- [x] x))]
+         [(bb.lib.invoke/multi:add -hello-multi- :apple -hello-method-) v])"
+  {:added "3.0"}
+  ([label name config body]
+   (let [_ (resolve-method bb.protocol-invoke/-invoke-intern
+                           bb.protocol-invoke/-invoke-package
+                           label
+                           +default-packages+)]
+     (bb.protocol-invoke/-invoke-intern label name config body))))
+
+(defmacro definvoke
+  "customisable invocation forms
+
+   (definvoke -another-
+     [:compose {:val (partial + 10)
+               :arglists '([& more])}])"
+  {:added "3.0"}
+  ([name doc? & [attrs? & [params & body :as more]]]
+   (let [[doc attrs [label {:keys [refresh stable] :as config}] & body]
+         (fn/fn:create-args (concat [doc? attrs?] more))]
+     (if (or refresh
+             (not (true? stable))
+             (not (resolve name)))
+       `(invoke-intern ~label '~name ~(assoc (merge config attrs) :doc doc) '~body)))))
+
+;; Using definvoke
+
+(definvoke invoke-intern-fn
+  "method body for `:fn` invoke
+
+   (invoke-intern-fn :fn '-fn-form- {} '([x] x))"
+  {:added "3.0"}
+  [:method {:multi bb.protocol-invoke/-invoke-intern
+            :val :fn}]
+  ([_ name config body]
+   (let [arglists (invoke:arglists body)
+         name (with-meta name (merge config {:arglists arglists}))]
+     `(def ~name (clojure/fn ~(symbol (str name)) ~@body)))))
+
+(definvoke invoke-intern-dynamic
+  "constructs a body for the :dynamic keyword
+
+   (invoke-intern-dynamic nil '-hello- {:val :world} nil)"
+  {:added "3.0"}
+  [:method {:multi bb.protocol-invoke/-invoke-intern
+            :val :dynamic}]
+  ([_ name config _]
+   (let [earmuff  (with-meta (symbol (str "*" name "*"))
+                    {:dynamic true})
+         name     (with-meta name
+                    (dissoc config :val))]
+     `(do
+        (def ~earmuff ~(:val config))
+        (defn ~name
+          ([] ~earmuff)
+          ([~'v]
+           (alter-var-root (var ~earmuff) (clojure.core/fn [~'_] ~'v))))))))
+
+(definvoke invoke-intern-multi
+  "method body for `:multi` form
+
+   (invoke-intern-multi :multi '-multi-form- {} '([x] x))"
+  {:added "3.0"}
+  [:method {:multi bb.protocol-invoke/-invoke-intern
+            :val :multi}]
+  ([_ ^clojure.lang.Symbol name {:keys [refresh default hierarchy] :as config} body]
+   (let [[dispatch arglists]
+         (if (seq body)
+           [`(clojure/fn ~(symbol (str name)) ~@body)
+            (invoke:arglists body)]
+           [(:dispatch config)
+            (or (:arglists config) ())])
+         options   (select-keys config [:default :hierarchy])
+         default   (or default :default)
+         hierarchy (or hierarchy '(var clojure.core/global-hierarchy))]
+     `(do (@#'clojure.core/check-valid-options ~options :default :hierarchy)
+          (let [~'v (def ~name)]
+            (if (or (not (and (.hasRoot ~'v)
+                              (instance? clojure.lang.MultiFn (deref ~'v))))
+                    ~refresh)
+              (doto (def ~name
+                      (new clojure.lang.MultiFn ~(.getName name) ~dispatch ~default ~hierarchy))
+                (alter-meta! merge ~config {:arglists ~arglists}))))))))
+
+(definvoke invoke-intern-compose
+  "method body for `:compose` form
+
+   (invoke-intern-compose :compose
+                          '-compose-form-
+                          {:val '(partial + 1 2)
+                          :arglists ''([& more])} nil)"
+  {:added "3.0"}
+  [:method {:multi bb.protocol-invoke/-invoke-intern
+            :val :compose}]
+  ([_ name {:keys [val arglists] :as config} _]
+   (let [name (with-meta name
+                (dissoc config :val))]
+     `(def ~name ~val))))
+
+(definvoke invoke-intern-macro
+  "method body for `:macro` form
+
+   (defn -macro-fn- [] '[(clojure.core/fn [x] x)
+                         {:arglists ([x])}])
+
+   (invoke-intern-macro :macro
+                        '-macro-form-
+                        {:fn '-macro-fn-
+                         :args []}
+                        nil)"
+  {:added "3.0"}
+  [:method {:multi bb.protocol-invoke/-invoke-intern
+            :val :macro}]
+  ([_ name {:keys [args fn] :as config} _]
+   (let [func (resolve fn)
+         [val meta] (apply func args)
+         name (with-meta name (dissoc config :fn :args))]
+     `(def ~name ~val))))
+
+(defn recent-fn
+  "creates a recent function"
+  {:added "3.0"}
+  ([{:keys [key compare op cache]}]
+   (clojure.core/fn
+     [obj & args]
+     (let [k   (key obj)
+           tag (compare obj)
+           do-update (clojure.core/fn
+                       []
+                       (let [return (op obj)]
+                         (swap! cache assoc k {:tag tag :return return})
+                         return))]
+       (cond *force*
+             (do-update)
+
+             :else
+             (let [rec (get @cache k)]
+               (if  (or (nil? rec)
+                        (not= (:tag rec) tag))
+                 (do-update)
+                 (:return rec))))))))
+
+(definvoke invoke-intern-recent
+  "creates a body for `recent`"
+  {:added "3.0"}
+  [:method {:multi bb.protocol-invoke/-invoke-intern
+            :val :recent}]
+  ([_ name {:keys [key compare function cache] :as config} body]
+   (let [arglists (if (seq body)
+                    (invoke:arglists body)
+                    (or (:arglists config) ()))
+
+         [cache-name cache-form]
+         (if (or (map? cache)
+                 (nil? cache))
+           (let [prefix (or (:prefix cache) "+")
+                 cache-name (symbol (str prefix name))]
+             [cache-name [`(def ~cache-name (atom {}))]])
+           [cache []])
+
+         [function-name function-form]
+         (if (or (map? function)
+                 (nil? function))
+           (let [suffix (or (:suffix function) "-raw")
+                 function-name (symbol (str name suffix))]
+             [function-name [`(defn ~function-name
+                                ~(str "helper function for " *ns* "/" name)
+                                ~@body)]])
+           [function []])
+
+         name (with-meta name (assoc (dissoc config :key :compare :op :cache)
+                                     :arglists arglists))]
+     `(do ~@cache-form
+          ~@function-form
+          (def ~name (recent-fn {:key ~(or key `identity)
+                                 :compare ~(or compare `identity)
+                                 :op ~function-name
+                                 :cache ~cache-name}))))))
+
+
+;;
+;; redefine fn
+;;
+
+
+(def +default-fn+
+  '{:function   {:ns bb.lib.lamdba}
+    :predicate  {:ns bb.lib.lamdba}
+    :scala      {:ns std.lang.scala.function}})
+
+(defn fn-body
+  "creates a function body
+
+   (fn-body :clojure '([] (+ 1 1)))
+   => '(clojure.core/fn [] (+ 1 1))"
+  {:added "3.0"}
+  ([label body]
+   (let [_ (resolve-method protocol.invoke/-fn-body
+                           protocol.invoke/-fn-package
+                           label
+                           +default-fn+)]
+     (protocol.invoke/-fn-body label body))))
+
+(definvoke fn-body-clojure
+  "creates a clojure function body
+
+   (fn-body-clojure nil '([] (+ 1 1)))
+   => '(clojure.core/fn [] (+ 1 1))"
+  {:added "3.0"}
+  [:method {:multi protocol.invoke/-fn-body
+            :val :clojure}]
+  ([body] (fn-body-clojure nil body))
+  ([_ body] `(clojure.core/fn ~@body)))
+
+(defmacro fn
+  "macro body for extensible function
+
+   (fn [x] x)
+   => fn?"
+  {:added "3.0"}
+  ([& body]
+   (let [type (or (:type (meta &form))
+                  :clojure)]
+     (protocol.invoke/-fn-body type body))))

--- a/src/bb/lib/memoize.clj
+++ b/src/bb/lib/memoize.clj
@@ -1,0 +1,277 @@
+(ns bb.lib.memoize
+  (:require [bb.protocol-invoke :as protocol.invoke]
+            [bb.lib.impl :refer [defimpl]]
+            [bb.lib.invoke :as invoke :refer [definvoke]]
+            [bb.lib.function :as fn])
+  (:refer-clojure :exclude [memoize]))
+
+(defonce ^:dynamic *registry* (atom {}))
+
+(declare memoize:info
+         memoize:invoke
+         memoize:enabled?
+         memoize:disabled?)
+
+(defn- memoize-string
+  ([mem]
+   (str "#memoize" (memoize:info mem))))
+
+(defprotocol IMemoize
+  (call [_])
+  (call [_ a])
+  (call [_ a b])
+  (call [_ a b c])
+  (call [_ a b c d])
+  (call [_ a b c d e])
+  (call [_ a b c d e f])
+  (call [_ a b c d e f g])
+  (call [_ a b c d e f g h])
+  (call [_ a b c d e f g h i])
+  (call [_ a b c d e f g h i j])
+  (call [_ a b c d e f g h i j k])
+  (call [_ a b c d e f g h i j k l])
+  (call [_ a b c d e f g h i j k l m])
+  (call [_ a b c d e f g h i j k l m n])
+  (call [_ a b c d e f g h i j k l m n o])
+  (call [_ a b c d e f g h i j k l m n o p])
+  (call [_ a b c d e f g h i j k l m n o p q])
+  (call [_ a b c d e f g h i j k l m n o p q r])
+  (call [_ a b c d e f g h i j k l m n o p q r s])
+  (call [_ a b c d e f g h i j k l m n o p q r s t])
+  (applyTo [_ args]))
+
+(defrecord Memoize [function memfunction cache var registry status]
+  IMemoize
+  (call [_] (memfunction))
+  (call [_ a] (memfunction a))
+  (call [_ a b] (memfunction a b))
+  (call [_ a b c] (memfunction a b c))
+  (call [_ a b c d] (memfunction a b c d))
+  (call [_ a b c d e] (memfunction a b c d e))
+  (call [_ a b c d e f] (memfunction a b c d e f))
+  (call [_ a b c d e f g] (memfunction a b c d e f g))
+  (call [_ a b c d e f g h] (memfunction a b c d e f g h))
+  (call [_ a b c d e f g h i] (memfunction a b c d e f g h i))
+  (call [_ a b c d e f g h i j] (memfunction a b c d e f g h i j))
+  (call [_ a b c d e f g h i j k] (memfunction a b c d e f g h i j k))
+  (call [_ a b c d e f g h i j k l] (memfunction a b c d e f g h i j k l))
+  (call [_ a b c d e f g h i j k l m] (memfunction a b c d e f g h i j k l m))
+  (call [_ a b c d e f g h i j k l m n] (memfunction a b c d e f g h i j k l m n))
+  (call [_ a b c d e f g h i j k l m n o] (memfunction a b c d e f g h i j k l m n o))
+  (call [_ a b c d e f g h i j k l m n o p] (memfunction a b c d e f g h i j k l m n o p))
+  (call [_ a b c d e f g h i j k l m n o p q] (memfunction a b c d e f g h i j k l m n o p q))
+  (call [_ a b c d e f g h i j k l m n o p q r] (memfunction a b c d e f g h i j k l m n o p q r))
+  (call [_ a b c d e f g h i j k l m n o p q r s] (memfunction a b c d e f g h i j k l m n o p q r s))
+  (call [_ a b c d e f g h i j k l m n o p q r s t] (memfunction a b c d e f g h i j k l m n o p q r s t))
+  (applyTo [_ args] (apply memfunction args)))
+
+(defmethod print-method Memoize
+  [v ^java.io.Writer w]
+  (.write w (memoize-string v)))
+
+(defn memoize
+  "caches the result of a function
+   (ns-unmap *ns* '+-inc-)
+   (ns-unmap *ns* '-inc-)
+   (def +-inc- (atom {}))
+   (declare -inc-)
+   (def -inc-  (memoize inc +-inc- #'-inc-))
+
+   (-inc- 1) => 2
+   (-inc- 2) => 3"
+  {:added "3.0"}
+  ([function cache var]
+   (memoize function cache var *registry* (volatile! :enabled)))
+  ([function cache var registry status]
+   (let [memfunction (fn [& args]
+                       (if-let [e (find @cache args)]
+                         (val e)
+                         (when-let [ret (apply function args)]
+                           (swap! cache assoc args ret)
+                           ret)))]
+     (Memoize. function memfunction cache var registry status))))
+
+(defn register-memoize
+  "registers the memoize function
+
+   (register-memoize -inc-)"
+  {:added "3.0"}
+  ([^Memoize mem]
+   (let [var (.var mem)
+         registry (.registry mem)]
+     (register-memoize mem var registry)))
+  ([^Memoize mem var registry]
+   (swap! registry assoc var mem)))
+
+(defn deregister-memoize
+  "deregisters the memoize function
+
+   (deregister-memoize -inc-)"
+  {:added "3.0"}
+  ([^Memoize mem]
+   (let [var (.var mem)
+         registry (.registry mem)]
+     (deregister-memoize mem var registry)))
+  ([^Memoize mem var registry]
+   (swap! registry dissoc var)))
+
+(defn registered-memoizes
+  "lists all registered memoizes
+
+   (registered-memoizes)"
+  {:added "3.0"}
+  ([] (registered-memoizes nil))
+  ([status] (registered-memoizes status *registry*))
+  ([status registry]
+   (let [pred (case status
+                :enabled  memoize:enabled?
+                :disabled memoize:disabled?
+                identity)]
+     (keys (cond->> @registry
+             status (keep (fn [[var mem]]
+                            (if (memoize:disabled? mem)
+                              [var mem])))
+             :then (into {}))))))
+
+(defn registered-memoize?
+  "checks if a memoize function is registered
+
+   (registered-memoize? -mem-)
+   => false"
+  {:added "3.0"}
+  ([^Memoize mem]
+   (let [var      (.var mem)
+         registry (.registry mem)]
+     (= mem (get @registry var)))))
+
+(defn memoize:status
+  "returns the status of the object
+
+   (memoize:status -inc-)
+   => :enabled"
+  {:added "3.0"}
+  ([^Memoize mem]
+   @(.status mem)))
+
+(defn memoize:info
+  "formats the memoize object
+
+   (def +-plus- (atom {}))
+   (declare -plus-)
+   (def -plus- (memoize + +-plus- #'-plus-))
+   (memoize:info -plus-)
+   => (contains {:status :enabled, :registered false, :items number?})
+   ;; {:fn +, :cache #atom {(1 1) 2}}"
+  {:added "3.0"}
+  ([^Memoize mem]
+   {:status (memoize:status mem)
+    :registered (registered-memoize? mem)
+    :items (count @(.cache mem))}))
+
+(defn memoize:disable
+  "disables the usage of the cache
+
+   (memoize:disable -inc-)
+   => :disabled"
+  {:added "3.0"}
+  ([^Memoize mem]
+   (vreset! (.status mem) :disabled)))
+
+(defn memoize:disabled?
+  "checks if the memoized function is disabled
+
+   (memoize:disabled? -inc-)
+   => true"
+  {:added "3.0"}
+  ([^Memoize mem]
+   (= @(.status mem) :disabled)))
+
+(defn memoize:enable
+  "enables the usage of the cache
+
+   (memoize:enable -inc-)
+   => :enabled"
+  {:added "3.0"}
+  ([^Memoize mem]
+   (vreset! (.status mem) :enabled)))
+
+(defn memoize:enabled?
+  "checks if the memoized function is disabled
+
+   (memoize:enabled? -inc-)
+   => true"
+  {:added "3.0"}
+  ([^Memoize mem]
+   (= @(.status mem) :enabled)))
+
+(defn memoize:invoke
+  "invokes the function with arguments
+
+   (memoize:invoke -plus- 1 2 3)
+   => 6"
+  {:added "3.0"}
+  ([^Memoize mem & args]
+   (if (memoize:enabled? mem)
+     (apply (.memfunction mem) args)
+     (apply (.function mem) args))))
+
+(defn memoize:remove
+  "removes a cached result
+
+   (memoize:remove -inc- 1)
+   => 2"
+  {:added "3.0"}
+  ([^Memoize mem & args]
+   (let [cache (.cache mem)
+         v (get @cache args)]
+     (swap! cache dissoc args)
+     v)))
+
+(defn memoize:clear
+  "clears all results
+
+   (memoize:clear -inc-)
+   => '{(2) 3}"
+  {:added "3.0"}
+  ([^Memoize mem]
+   (let [cache (.cache mem)
+         v @cache]
+     (reset! cache {})
+     v)))
+
+(defmethod bb.protocol-invoke/-invoke-intern :memoize
+  [_ name {:keys [function cache] :as config} body]
+   (let [arglists (if (seq body)
+                    (invoke/invoke:arglists body)
+                    (or (:arglists config) ()))
+
+         [cache-name cache-form]
+         (if (or (map? cache)
+                 (nil? cache))
+           (let [prefix (or (:prefix cache) "+")
+                 cache-name (symbol (str prefix name))]
+             [cache-name [`(def ~cache-name (atom {}))]])
+           [cache []])
+
+         [function-name function-form]
+         (if (or (map? function)
+                 (nil? function))
+           (let [suffix (or (:suffix function) "-raw")
+                 function-name (symbol (str name suffix))]
+             [function-name [`(defn ~function-name
+                                ~(str "helper function for " *ns* "/" name)
+                                ~@body)]])
+           [function []])
+
+         name (with-meta name (assoc (dissoc config :function :cache)
+                                     :arglists arglists))
+
+         membody `(memoize ~function-name ~cache-name (var ~name))]
+     `(do (declare ~name)
+          ~@cache-form
+          ~@function-form
+          (def ~name ~membody)
+          (doto ~name
+            (register-memoize)
+            (memoize:clear))
+          (var ~name))))

--- a/src/bb/lib/walk.clj
+++ b/src/bb/lib/walk.clj
@@ -1,0 +1,129 @@
+(ns bb.lib.walk)
+
+(defn walk
+  "Traverses form, an arbitrary data structure"
+  {:added "3.0"}
+  [inner outer form]
+  (cond
+    (list? form) (outer (with-meta (apply list (map inner form)) (meta form)))
+
+    (instance? clojure.lang.IMapEntry form) (outer (vec (map inner form)))
+    (seq? form) (outer (doall (with-meta (map inner form) (meta form))))
+
+    (set? form) (outer (with-meta (into (empty form) (map inner form)) (meta form)))
+    (map? form) (outer (with-meta (into (empty form) (map inner form)) (meta form)))
+    (vector? form) (outer (with-meta (mapv inner form) (meta form)))
+
+    (instance? clojure.lang.IRecord form)
+    (outer (reduce (fn [r x] (conj r (inner x))) form form))
+    (coll? form) (outer (into (empty form) (map inner form)))
+    :else (outer form)))
+
+(defn postwalk
+  "Performs a depth-first, post-order traversal of form"
+  {:added "3.0"}
+  ([f form]
+   (walk (partial postwalk f) f form)))
+
+(defn prewalk
+  "Like postwalk, but does pre-order traversal."
+  {:added "3.0"}
+  ([f form]
+   (walk (partial prewalk f) identity (f form))))
+
+(defn keywordize-keys
+  "Recursively transforms all map keys from strings to keywords."
+  {:added "3.0"}
+  ([m]
+   (let [f (fn [[k v]] (if (or (string? k)
+                               (symbol? k))
+                         [(keyword k) v] [k v]))]
+    ;; only apply to maps
+     (postwalk (fn [x] (if (map? x) (into {} (map f x)) x)) m))))
+
+(defn keyword-spearify-keys
+  "recursively transfroms all map keys to spearcase
+
+   (keyword-spearify-keys  {\"a_b_c\" [{\"e_f_g\" 1}]})
+   => {:a-b-c [{:e-f-g 1}]}"
+  {:added "4.0"}
+  ([m]
+   (let [f (fn [[k v]] (if (string? k) [(keyword (.replaceAll ^String k "_" "-")) v] [k v]))]
+    ;; only apply to maps
+     (postwalk (fn [x] (if (map? x) (into {} (map f x)) x)) m))))
+
+(defn stringify-keys
+  "Recursively transforms all map keys from keywords to strings."
+  {:added "3.0"}
+  ([m]
+   (let [f (fn [[k v]] (if (keyword? k) [(name k) v] [k v]))]
+    ;; only apply to maps
+     (postwalk (fn [x] (if (map? x) (into {} (map f x)) x)) m))))
+
+(defn string-snakify-keys
+  "recursively transforms keyword to string keys
+
+   (string-snakify-keys
+    {:a-b-c [{:e-f-g 1}]})
+   => {\"a_b_c\" [{\"e_f_g\" 1}]}"
+  {:added "4.0"}
+  ([m]
+   (let [f (fn [[k v]] (if (keyword? k) [(.replaceAll ^String (name k) "-" "_") v] [k v]))]
+    ;; only apply to maps
+     (postwalk (fn [x] (if (map? x) (into {} (map f x)) x)) m))))
+
+(defn prewalk-replace
+  "Recursively transforms form by replacing keys in smap with their values."
+  {:added "3.0"}
+  ([smap form]
+   (prewalk (fn [x] (if (contains? smap x) (smap x) x)) form)))
+
+(defn postwalk-replace
+  "Recursively transforms form by replacing keys in smap with their values."
+  {:added "3.0"}
+  ([smap form]
+   (postwalk (fn [x] (if (contains? smap x) (smap x) x)) form)))
+
+(defn macroexpand-all
+  "Recursively performs all possible macroexpansions in form."
+  {:added "3.0"}
+  ([form]
+   (prewalk (fn [x] (if (seq? x) (macroexpand x) x)) form)))
+
+
+(defn walk:contains
+  "recursively walks form to check for containment"
+  {:added "4.0"}
+  ([pred form]
+   (let [found (volatile! false)]
+     (prewalk (fn [x]
+                (if (try (pred x) (catch Throwable t))
+                  (vreset! found true))
+                x)
+              form)
+     @found)))
+
+(defn walk:find
+  "recursively walks to find all matching forms"
+  {:added "4.0"}
+  ([pred form]
+   (let [found (volatile! #{})]
+     (postwalk (fn [x]
+                 (if (try (pred x) (catch Throwable t))
+                   (vswap! found conj x))
+                 x)
+               form)
+     @found)))
+
+(defn walk:keep
+  "recursively walks and keeps all processed forms"
+  {:added "4.0"}
+  ([f form]
+   (let [found (volatile! #{})]
+     (postwalk (fn [x]
+                 (try (let [val (f x)]
+                        (if val (vswap! found conj val)))
+                      (catch Throwable t))
+                 x)
+               form)
+     @found)))

--- a/src/bb/protocol_invoke.clj
+++ b/src/bb/protocol_invoke.clj
@@ -1,0 +1,21 @@
+(ns bb.protocol-invoke)
+
+(defmulti -invoke-intern
+  "extendable function for loading invoke form constructors"
+  {:added "3.0"}
+  (fn [label & _] label))
+
+(defmulti -invoke-package
+  "extendable function for loading invoke-intern types"
+  {:added "3.0"}
+  identity)
+
+(defmulti -fn-body
+  "multimethod for defining anonymous function body"
+  {:added "3.0"}
+  (fn [label body] label))
+
+(defmulti -fn-package
+  "extendable function for loading fn-body types"
+  {:added "3.0"}
+  identity)

--- a/src/bb/string.clj
+++ b/src/bb/string.clj
@@ -1,0 +1,35 @@
+(ns bb.string
+  (:require [bb.string.coerce]
+            [bb.string.common]
+            [bb.string.case]
+            [bb.string.path]
+            [bb.string.prose]
+            [bb.string.wrap :as wrap]
+            [bb.lib.foundation :as h])
+  (:refer-clojure :exclude [reverse replace]))
+
+(h/intern-all bb.string.common
+              bb.string.case
+              bb.string.path
+              bb.string.coerce
+              bb.string.prose)
+
+(h/intern-in wrap/wrap)
+
+(defn |
+  "shortcut for join lines
+
+   (| \"abc\" \"def\")
+   => \"abc\\ndef\""
+  {:added "3.0"}
+  [& args]
+  (join "\n" args))
+
+(defn lines
+  "transforms string to seperated newlines
+
+   (lines \"abc\\ndef\")
+   => '(bb.string/| \"abc\" \"def\")"
+  {:added "3.0"}
+  [s]
+  (cons `| (split-lines s)))

--- a/src/bb/string/case.clj
+++ b/src/bb/string/case.clj
@@ -1,0 +1,194 @@
+(ns bb.string.case
+  (:require [bb.string.common :as common]))
+
+(defn- ^String re-sub
+  "substitute a pattern by applying a function
+
+   (re-sub \"aTa\" +hump-pattern+ (fn [_] \"$\"))
+   => \"$a\""
+  {:added "3.0"}
+  ([^String value pattern sub-func]
+   (loop [matcher (re-matcher pattern value)
+          result []
+          last-end 0]
+     (if (.find matcher)
+       (recur matcher
+              (conj result
+                    (.substring value last-end (.start matcher))
+                    (sub-func (re-groups matcher)))
+              (.end matcher))
+       (apply str (conj result (.substring value last-end)))))))
+
+(def ^:private +hump-pattern+ #"[a-z0-9][A-Z]")
+(def ^:private +non-camel-pattern+ #"[_| |\-][A-Za-z]")
+(def ^:private +non-snake-pattern+ #"[ |\-]")
+(def ^:private +non-spear-pattern+ #"[ |\_]")
+(def ^:private +non-dot-pattern+ #"[ |\-\_]")
+
+(defn- ^String separate-humps
+  "separate words that are camel cased
+
+   (separate-humps \"aTaTa\")
+   => \"a Ta Ta\""
+  {:added "3.0"}
+  ([^String value]
+   (re-sub value +hump-pattern+ #(common/joinl (seq %) " "))))
+
+(defn ^String camel-case
+  "converts a string-like object to camel case representation
+
+   (camel-case \"hello-world\")
+   => \"helloWorld\"
+
+   ((wrap camel-case) 'hello_world)
+   => 'helloWorld"
+  {:added "3.0"}
+  ([^String value]
+   (let [s (re-sub value
+                   +non-camel-pattern+
+                   (fn [s] (common/upper-case (apply str (rest s)))))]
+     (str (.toLowerCase (subs s 0 1))
+          (subs s 1)))))
+
+
+(defn ^String upper-camel-case
+  "convert string to uppercase camel
+
+   (upper-camel-case \"hello-world\")
+   => \"HelloWorld\""
+  {:added "4.0"}
+  ([^String value]
+   (let [s (re-sub value
+                   +non-camel-pattern+
+                   (fn [s] (common/upper-case (apply str (rest s)))))]
+     (str (.toUpperCase (subs s 0 1))
+          (subs s 1)))))
+
+(defn ^String capital-sep-case
+  "converts a string-like object to captital case representation
+
+   (capital-sep-case \"hello world\")
+   => \"Hello World\"
+
+   (str ((wrap capital-sep-case) :hello-world))
+   => \":Hello World\""
+  {:added "3.0"}
+  ([^String value]
+   (-> (separate-humps value)
+       (common/split #"[ |\-|_]")
+       (->> (map common/capital-case))
+       (common/joinl " "))))
+
+(defn ^String lower-sep-case
+  "converts a string-like object to a lower case representation
+
+   (lower-sep-case \"helloWorld\")
+   => \"hello world\"
+
+   ((wrap lower-sep-case) 'hello-world)
+   => (symbol \"hello world\")"
+  {:added "3.0"}
+  ([^String value]
+   (-> (separate-humps value)
+       (common/split #"[ |\-|_]")
+       (->> (map common/lower-case))
+       (common/joinl " "))))
+
+(defn ^String pascal-case
+  "converts a string-like object to a pascal case representation
+
+   (pascal-case \"helloWorld\")
+   => \"HelloWorld\"
+
+   ((wrap pascal-case) :hello-world)
+   => :HelloWorld"
+  {:added "3.0"}
+  ([^String value]
+   (let [s (re-sub value +non-camel-pattern+
+                   (fn [s] (common/upper-case (apply str (rest s)))))]
+     (str (.toUpperCase (subs s 0 1))
+          (subs s 1)))))
+
+(defn ^String phrase-case
+  "converts a string-like object to snake case representation
+
+   (phrase-case \"hello-world\")
+   => \"Hello world\""
+  {:added "3.0"}
+  ([^String value]
+   (let [s (lower-sep-case value)]
+     (str (.toUpperCase (subs s 0 1))
+          (subs s 1)))))
+
+(defn ^String dot-case
+  "creates a dot-case representation
+
+   (dot-case \"hello-world\")
+   => \"hello.world\"
+
+   ((wrap dot-case) 'helloWorld)
+   => 'hello.world"
+  {:added "3.0"}
+  ([value]
+   (-> (separate-humps value)
+       (common/lower-case)
+       (common/replace +non-dot-pattern+ "."))))
+
+(defn ^String snake-case
+  "converts a string-like object to snake case representation
+
+   (snake-case \"hello-world\")
+   => \"hello_world\"
+
+   ((wrap snake-case) 'helloWorld)
+   => 'hello_world"
+  {:added "3.0"}
+  ([value]
+   (-> (separate-humps value)
+       (common/lower-case)
+       (common/replace +non-snake-pattern+ "_"))))
+
+(defn ^String spear-case
+  "converts a string-like object to spear case representation
+
+   (spear-case \"hello_world\")
+   => \"hello-world\"
+
+   ((wrap spear-case) 'helloWorld)
+   => 'hello-world"
+  {:added "3.0"}
+  ([value]
+   (-> (separate-humps value)
+       (common/lower-case)
+       (common/replace +non-spear-pattern+ "-"))))
+
+(defn ^String upper-sep-case
+  "converts a string-like object to upper case representation
+
+   (upper-sep-case \"hello world\")
+   => \"HELLO WORLD\"
+
+   (str ((wrap upper-sep-case) 'hello-world))
+   => \"HELLO WORLD\""
+  {:added "3.0"}
+  ([^String value]
+   (-> (separate-humps value)
+       (common/split #"[ |\-|_]")
+       (->> (map common/upper-case))
+       (common/joinl " "))))
+
+(defn ^String typeless=
+  "compares two representations
+
+   (typeless= \"helloWorld\" \"hello_world\")
+   => true
+
+   ((wrap typeless=) :a-b-c \"a b c\")
+   => true
+
+   ((wrap typeless=) 'getMethod :get-method)
+   => true"
+  {:added "3.0"}
+  ([x y]
+   (= (lower-sep-case x)
+      (lower-sep-case y))))

--- a/src/bb/string/coerce.clj
+++ b/src/bb/string/coerce.clj
@@ -1,0 +1,189 @@
+(ns bb.string.coerce
+  (:require [std.protocol.string :as protocol.string]
+            [bb.lib.foundation :as h]
+            [bb.lib.memoize :as memoize]
+            [bb.lib.invoke :refer [definvoke]]))
+
+(defn from-string
+  "converts a string to an object
+
+   (from-string \"a\" clojure.lang.Symbol)
+   => 'a
+
+   (from-string \"bb.string\" clojure.lang.Namespace)
+   => (find-ns 'bb.string)"
+  {:added "3.0"}
+  ([string type]
+   (from-string string type nil))
+  ([string type opts]
+   (protocol.string/-from-string string type opts)))
+
+(defn ^String to-string
+  "converts an object to a string
+
+   (to-string :hello/world)
+   => \"hello/world\"
+
+   (to-string *ns*)
+   => \"bb.string.coerce-test\""
+  {:added "3.0"}
+  ([string]
+   (protocol.string/-to-string string)))
+
+(def path-separator (clojure.core/memoize protocol.string/-path-separator))
+
+(defn str:op
+  "wraps a string function such that it can take any string-like input
+
+   ((str:op str false) :hello 'hello)
+   => :hellohello
+
+   ((str:op str true) :hello 'hello)
+   => \"hellohello\""
+  {:added "3.0"}
+  ([f]
+   (str:op f false))
+  ([f return]
+   (fn [input & args]
+     (let [[isample iarr?] (if (sequential? input)
+                             [(first input) true]
+                             [input false])
+           class   (type isample)]
+       (binding [h/*sep* (path-separator class)]
+         (let [interim (cond (= class String)
+                             (apply f input args)
+
+                             iarr?
+                             (apply f (map to-string input) args)
+
+                             :else
+                             (apply f (to-string input) args))
+               oarr?   (sequential? interim)
+               output  (cond return
+                             interim
+
+                             (= class String)
+                             interim
+
+                             oarr?
+                             (mapv #(from-string % class) interim)
+
+                             :else
+                             (from-string interim class))]
+           output))))))
+
+(defn str:compare
+  "wraps a function so that it can compare any two string-like inputs
+
+   ((str:compare =) :hello 'hello)
+   => true"
+  {:added "3.0"}
+  ([f]
+   (fn [x y & args]
+     (binding [h/*sep* (path-separator (type x))]
+       (apply f (to-string x) (to-string y) args)))))
+
+;;  ------------------
+;;   java.lang.Object
+;;  ------------------
+
+(extend-type nil
+  protocol.string/IString
+  (-to-string [x] ""))
+
+(extend-type Object
+  protocol.string/IString
+  (-to-string [x] (.toString x)))
+
+(defmethod protocol.string/-from-string nil
+  ([_ _ _]
+   nil))
+
+(defmethod protocol.string/-path-separator :default
+  ([_]
+   "/"))
+
+;;  ------------------
+;;   java.lang.String
+;;  ------------------
+
+(extend-type String
+  protocol.string/IString
+  (-to-string [x] x))
+
+(defmethod protocol.string/-from-string String
+  ([string _ _]
+   string))
+
+;;  ------------------
+;;   byte[]
+;;  ------------------
+
+(extend-type (Class/forName "[B")
+  protocol.string/IString
+  (-to-string [^bytes x] (String. ^bytes x)))
+
+(defmethod protocol.string/-from-string (Class/forName "[B")
+  ([^String string _ _]
+   (.getBytes string)))
+
+;;  ------------------
+;;   char[]
+;;  ------------------
+
+(extend-type (Class/forName "[C")
+  protocol.string/IString
+  (-to-string [x] (String. ^chars x)))
+
+(defmethod protocol.string/-from-string (Class/forName "[C")
+  ([^String string _ _]
+   (.toCharArray string)))
+
+;;  ------------------
+;;   java.lang.Class
+;;  ------------------
+
+(extend-type Class
+  protocol.string/IString
+  (-to-string [^Class x] (.getName x)))
+
+(defmethod protocol.string/-from-string Class
+  ([string _ _]
+   (Class/forName string)))
+
+(defmethod protocol.string/-path-separator Class
+  ([_]
+   "."))
+
+;;  ----------------------
+;;   clojure.lang.Keyword
+;;  ----------------------
+
+(extend-type clojure.lang.Keyword
+  protocol.string/IString
+  (-to-string [x]
+    (if (nil? x) "" (.replaceFirst (str x) ":" ""))))
+
+(defmethod protocol.string/-from-string clojure.lang.Keyword
+  ([string _ _]
+   (keyword string)))
+
+;;  ---------------------
+;;   clojure.lang.Symbol
+;;  ---------------------
+
+(defmethod protocol.string/-from-string clojure.lang.Symbol
+  ([string _ _]
+   (symbol string)))
+
+;;  ------------------------
+;;   clojure.lang.Namespace
+;;  ------------------------
+
+(defmethod protocol.string/-from-string clojure.lang.Namespace
+  ([string _ _]
+   (find-ns (symbol string))))
+
+(defmethod protocol.string/-path-separator clojure.lang.Namespace
+  ([_]
+   "."))

--- a/src/bb/string/common.clj
+++ b/src/bb/string/common.clj
@@ -1,0 +1,348 @@
+(ns bb.string.common
+  (:import (java.util.regex Pattern Matcher))
+  (:refer-clojure :exclude [replace reverse]))
+
+(defn blank?
+  "checks if string is empty or nil
+
+   (blank? nil)
+   => true
+
+   (blank? \"\")
+   => true"
+  {:added "3.0"}
+  ([^CharSequence s]
+   (if s
+     (loop [index (int 0)]
+       (if (= (.length s) index)
+         true
+         (if (Character/isWhitespace (.charAt s index))
+           (recur (inc index))
+           false)))
+     true)))
+
+(defn ^String split
+  "splits the string into tokens
+
+   (split \"a b c\" #\" \")
+   => [\"a\" \"b\" \"c\"]
+
+   ((wrap split) :a.b.c (re-pattern \"\\.\"))
+   => [:a :b :c]"
+  {:added "3.0"}
+  ([^CharSequence s ^Pattern re]
+   (vec (.split re s -1))))
+
+(defn split-lines
+  "splits the string into separate lines
+
+   (split-lines \"a\\nb\\nc\")
+   => [\"a\" \"b\" \"c\"]"
+  {:added "3.0"}
+  ([^String s]
+   (if (not-empty s)
+     (vec (.split s "[\\r\\n]", -1))
+     [])))
+
+(defn ^String joinl
+  "joins an array using a separator
+
+   (joinl [\"a\" \"b\" \"c\"] \".\")
+   => \"a.b.c\"
+
+   (joinl [\"a\" \"b\" \"c\"])
+   => \"abc\"
+
+   ((wrap joinl) [:a :b :c] \"-\")
+   => :a-b-c"
+  {:added "3.0"}
+  ([coll]
+   (apply str coll))
+  ([coll separator]
+   (loop [sb (StringBuilder. (str (first coll)))
+          more (next coll)
+          sep (str separator)]
+     (if more
+       (recur (-> sb (.append sep) (.append (str (first more))))
+              (next more)
+              sep)
+       (str sb)))))
+
+(defn ^String join
+  "like `join` but used with `->>` opts
+
+   (join \".\" [\"a\" \"b\" \"c\"])
+   => \"a.b.c\"
+
+   ;;(join \".\" '[a b c])
+   ;;=> 'a.b.c"
+  {:added "3.0"}
+  ([coll]
+   (apply str coll))
+  ([seperator coll]
+   (joinl coll seperator)))
+
+(defn ^String upper-case
+  "converts a string object to upper case
+
+   (upper-case \"hello-world\")
+   => \"HELLO-WORLD\"
+
+   ((wrap upper-case) :hello-world)
+   => :HELLO-WORLD"
+  {:added "3.0"}
+  ([^CharSequence s]
+   (.. s toString toUpperCase)))
+
+(defn ^String lower-case
+  "converts a string object to lower case
+
+   (lower-case \"Hello.World\")
+   => \"hello.world\"
+
+   ((wrap lower-case) 'Hello.World)
+   => 'hello.world"
+  {:added "3.0"}
+  ([^CharSequence s]
+   (.. s toString toLowerCase)))
+
+(defn ^String capital-case
+  "converts a string object to capital case
+
+   (capital-case \"hello.World\")
+   => \"Hello.world\"
+
+   ((wrap capital-case) 'hello.World)
+   => 'Hello.world"
+  {:added "3.0"}
+  ([^CharSequence s]
+   (let [s (.toString s)]
+     (if (< (count s) 2)
+       (.toUpperCase s)
+       (str (.toUpperCase (subs s 0 1))
+            (.toLowerCase (subs s 1)))))))
+
+(defn ^String reverse
+  "reverses the string
+
+   (reverse \"hello\")
+   => \"olleh\"
+
+   ((wrap reverse) :hello)
+   => :olleh"
+  {:added "3.0"}
+  ([^CharSequence s]
+   (.toString (.reverse (StringBuilder. s)))))
+
+(defn starts-with?
+  "checks if string starts with another
+
+   (starts-with? \"hello\" \"hel\")
+   => true
+
+   ((wrap starts-with?) 'hello 'hel)
+   => true"
+  {:added "3.0"}
+  ([^CharSequence s ^String substr]
+   (.startsWith (.toString s) substr)))
+
+(defn ends-with?
+  "checks if string ends with another
+
+   (ends-with? \"hello\" \"lo\")
+   => true
+
+   ((wrap ends-with?) 'hello 'lo)
+   => true"
+  {:added "3.0"}
+  ([^CharSequence s ^String substr]
+   (.endsWith (.toString s) substr)))
+
+(defn includes?
+  "checks if first string contains the second
+
+   (includes? \"hello\" \"ell\")
+   => true
+
+   ((wrap includes?) 'hello 'ell)
+   => true"
+  {:added "3.0"}
+  ([^CharSequence s ^CharSequence substr]
+   (.contains (.toString s) substr)))
+
+(defn ^String trim
+  "trims the string of whitespace
+
+   (trim \"   hello   \")
+   => \"hello\""
+  {:added "3.0"}
+  ([^CharSequence s]
+   (let [len (.length s)]
+     (loop [rindex len]
+       (if (zero? rindex)
+         ""
+         (if (Character/isWhitespace (.charAt s (dec rindex)))
+           (recur (dec rindex))
+          ;; there is at least one non-whitespace char in the string,
+          ;; so no need to check for lindex reaching len.
+           (loop [lindex 0]
+             (if (Character/isWhitespace (.charAt s lindex))
+               (recur (inc lindex))
+               (.. s (subSequence lindex rindex) toString)))))))))
+
+(defn ^String trim-left
+  "trims the string of whitespace on left
+
+   (trim-left \"   hello   \")
+   => \"hello   \""
+  {:added "3.0"}
+  ([^CharSequence s]
+   (let [len (.length s)]
+     (loop [index 0]
+       (if (= len index)
+         ""
+         (if (Character/isWhitespace (.charAt s index))
+           (recur (unchecked-inc index))
+           (.. s (subSequence index len) toString)))))))
+
+(defn ^String trim-right
+  "trims the string of whitespace on right
+
+   (trim-right \"   hello   \")
+   => \"hello\""
+  {:added "3.0"}
+  ([^CharSequence s]
+   (loop [index (.length s)]
+     (if (zero? index)
+       ""
+       (if (Character/isWhitespace (.charAt s (unchecked-dec index)))
+         (recur (unchecked-dec index))
+         (.. s (subSequence 0 index) toString))))))
+
+(defn ^String trim-newlines
+  "removes newlines from right
+
+   (trim-newlines  \"\\n\\n    hello   \\n\\n\")
+   => \"\\n\\n    hello   \""
+  {:added "3.0"}
+  ([^CharSequence s]
+   (loop [index (.length s)]
+     (if (zero? index)
+       ""
+       (let [ch (.charAt s (dec index))]
+         (if (or (= ch \newline) (= ch \return))
+           (recur (dec index))
+           (.. s (subSequence 0 index) toString)))))))
+
+(defn- replace-by
+  [^CharSequence s re f]
+  (let [m (re-matcher re s)]
+    (if (.find m)
+      (let [buffer (StringBuilder. (.length s))]
+        (loop [found true]
+          (if found
+            (do (.appendReplacement m buffer (Matcher/quoteReplacement (f (re-groups m))))
+                (recur (.find m)))
+            (do (.appendTail m buffer)
+                (.toString buffer)))))
+      s)))
+
+(defn ^String escape
+  "uses a map to replace chars"
+  {:added "3.0"}
+  ([^CharSequence s cmap]
+   (loop [index (int 0)
+          buffer (StringBuilder. (.length s))]
+     (if (= (.length s) index)
+       (.toString buffer)
+       (let [ch (.charAt s index)]
+         (if-let [replacement (cmap ch)]
+           (.append buffer replacement)
+           (.append buffer ch))
+         (recur (inc index) buffer))))))
+
+(defn ^String replace
+  "replace value in string with another
+
+   (replace \"hello\" \"el\" \"AL\")
+   => \"hALlo\"
+
+   ((wrap replace) :hello \"el\" \"AL\")
+   => :hALlo"
+  {:added "3.0"}
+  ([^CharSequence s match replacement]
+   (let [s (.toString s)]
+     (cond
+       (instance? Character match) (.replace s ^Character match ^Character replacement)
+       (instance? CharSequence match) (.replace s ^CharSequence match ^CharSequence replacement)
+       (instance? Pattern match) (if (instance? CharSequence replacement)
+                                   (.replaceAll (re-matcher ^Pattern match s)
+                                                (.toString ^CharSequence replacement))
+                                   (replace-by s match replacement))
+       :else (throw (IllegalArgumentException. (str "Invalid match arg: " match)))))))
+
+(defn caseless=
+  "compares two values ignoring case
+
+   (caseless= \"heLLo\" \"HellO\")
+   => true
+
+   ((wrap caseless=) 'heLLo :HellO)
+   => true"
+  {:added "3.0"}
+  ([x y]
+   (= (lower-case x)
+      (lower-case y))))
+
+(defn ^String truncate
+  "truncates a word
+
+   (truncate \"hello there\" 5)
+   => \"hello\""
+  {:added "3.0"}
+  ([s limit]
+   (let [len (count s)]
+     (if (> len limit)
+       (subs s 0 limit)
+       s))))
+
+(defn ^String capitalize
+  "capitalize the first letter
+
+   (capitalize \"hello\")
+   => \"Hello\""
+  {:added "4.0"}
+  [^String s]
+  (str (.toUpperCase (subs s 0 1))
+       (subs s 1)))
+
+(defn ^String decapitalize
+  "lowercase the first letter
+
+   (decapitalize \"HELLO\")
+   => \"hELLO\""
+  {:added "4.0"}
+  [^String s]
+  (str (.toLowerCase (subs s 0 1))
+       (subs s 1)))
+
+(defn ^String replace-all
+  "shortcut for ``.replaceAll``
+
+   (replace-all \"hello\" \"l\" \"o\")
+   => \"heooo\""
+  {:added "4.0"}
+  [^String s match re]
+  (.replaceAll s match re))
+
+(defn ^String replace-at
+  [^String s i new]
+  (str (subs s 0 i)
+       new
+       (subs s (+ i 1))))
+
+(defn ^String insert-at
+  [^String s i new]
+  (str (subs s 0 i)
+       new
+       (subs s i)))

--- a/src/bb/string/path.clj
+++ b/src/bb/string/path.clj
@@ -1,0 +1,184 @@
+(ns bb.string.path
+  (:require [bb.lib.foundation :as h]
+            [bb.string.common :as common]))
+
+(defn path-join
+  "joins a sequence of elements into a path separated value
+
+   (path/path-join [\"a\" \"b\" \"c\"])
+   => \"a/b/c\"
+
+   ((wrap path/path-join) '[:a :b :c] \"-\")
+   => :a-b-c
+
+   ((wrap path/path-join) '[a b c] '-)
+   => 'a-b-c"
+  {:added "3.0"}
+  ([arr] (path-join arr h/*sep*))
+  ([arr sep]
+   (if (seq arr)
+     (-> (filter identity arr)
+         (common/joinl sep)))))
+
+(defn path-split
+  "splits a sequence of elements into a path separated value
+
+   (path/path-split \"a/b/c/d\")
+   => '[\"a\" \"b\" \"c\" \"d\"]
+
+   (path/path-split \"a.b.c.d\" \".\")
+   => [\"a\" \"b\" \"c\" \"d\"]
+
+   ((wrap path/path-split) :hello/world)
+   => [:hello :world]
+
+   ((wrap path/path-split) :hello.world \".\")
+   => [:hello :world]"
+  {:added "3.0"}
+  ([s] (path-split s h/*sep*))
+  ([s sep]
+   (common/split s (h/re-create sep))))
+
+(defn path-ns-array
+  "returns the path vector of the string
+
+   (path/path-ns-array \"a/b/c/d\")
+   => [\"a\" \"b\" \"c\"]
+
+   ((wrap path/path-ns-array) (keyword \"a/b/c/d\"))
+   => [:a :b :c]"
+  {:added "3.0"}
+  ([s]
+   (path-ns-array s h/*sep*))
+  ([s sep]
+   (or (butlast (path-split s sep)) [])))
+
+(defn path-ns
+  "returns the path namespace of the string
+
+   (path/path-ns \"a/b/c/d\")
+   => \"a/b/c\"
+
+   ((wrap path/path-ns) :a.b.c \".\")
+   => :a.b"
+  {:added "3.0"}
+  ([s]
+   (path-ns s h/*sep*))
+  ([s sep]
+   (-> s
+       (path-ns-array sep)
+       (path-join sep))))
+
+(defn path-root
+  "returns the path root of the string
+
+   (path/path-root \"a/b/c/d\")
+   => \"a\"
+
+   ((wrap path/path-root) 'a.b.c \".\")
+   => 'a"
+  {:added "3.0"}
+  ([s]
+   (path-root s h/*sep*))
+  ([s sep]
+   (first (path-ns-array s sep))))
+
+(defn path-stem-array
+  "returns the path stem vector of the string
+
+   (path/path-stem-array \"a/b/c/d\")
+   =>  [\"b\" \"c\" \"d\"]
+
+   ((wrap path/path-stem-array) 'a.b.c.d \".\")
+   => '[b c d]"
+  {:added "3.0"}
+  ([s]
+   (path-stem-array s h/*sep*))
+  ([s sep]
+   (rest (path-split s sep))))
+
+(defn path-stem
+  "returns the path stem of the string
+
+   (path/path-stem \"a/b/c/d\")
+   => \"b/c/d\"
+
+   ((wrap path/path-stem) 'a.b.c.d \".\")
+   => 'b.c.d"
+  {:added "3.0"}
+  ([s]
+   (path-stem s h/*sep*))
+  ([s sep]
+   (-> s
+       (path-stem-array sep)
+       (path-join sep))))
+
+(defn path-val
+  "returns the val of the string
+
+   (path/path-val \"a/b/c/d\")
+   => \"d\"
+
+   ((wrap path/path-val) 'a.b.c.d \".\")
+   => 'd"
+  {:added "3.0"}
+  ([s]
+   (path-val s h/*sep*))
+  ([s sep]
+   (last (path-split s sep))))
+
+(defn path-nth
+  "check for the val of the string
+
+   (path/path-nth \"a/b/c/d\" 2)
+   => \"c\""
+  {:added "3.0"}
+  ([s n]
+   (path-nth s n h/*sep*))
+  ([s n sep]
+   (nth (path-split s sep) n)))
+
+(defn path-sub-array
+  "returns a sub array of the path within the string
+
+   (path/path-sub-array \"a/b/c/d\" 1 2)
+   => [\"b\" \"c\"]
+
+   ((wrap path/path-sub-array) (symbol \"a/b/c/d\") 1 2)
+   => '[b c]"
+  {:added "3.0"}
+  ([s start num]
+   (path-sub-array s start num h/*sep*))
+  ([s start num sep]
+   (->> (path-split s sep)
+        (drop start)
+        (take num))))
+
+(defn path-sub
+  "returns a subsection of the path within the string
+
+   (path/path-sub \"a/b/c/d\" 1 2)
+   => \"b/c\"
+
+   ((wrap path/path-sub) (symbol \"a/b/c/d\") 1 2)
+   => 'b/c"
+  {:added "3.0"}
+  ([s start num]
+   (path-sub s start num h/*sep*))
+  ([s start num sep]
+   (-> (path-sub-array s start num sep)
+       (path-join sep))))
+
+(defn path-count
+  "counts the number of elements in a given path
+
+   (path/path-count \"a/b/c\")
+   => 3
+
+   ((wrap path/path-count) *ns*)
+   => 3"
+  {:added "3.0"}
+  ([s]
+   (path-count s h/*sep*))
+  ([s sep]
+   (count (path-split s sep))))


### PR DESCRIPTION
The user wants to port `std.lang` for use with Babashka. Since `std.lang` relies heavily on Java-backed classes (`hara.lib.foundation.*`) and complex metaprogramming via `std.lib.invoke` (including records implementing `clojure.lang.IFn` which Babashka does not support), the chosen approach is to create a lightweight standalone namespace tree starting at `src/bb/lang`.

This PR is a work-in-progress checkpoint that:
- Copies `std.lang` to `bb.lang` and updates basic namespace references.
- Creates `bb.lib` and `bb.string` with simplified, plain-Clojure implementations of functions needed by `bb.lang` (e.g. replacing `std.lib.memoize`'s custom `Memoize` record with a native protocol approach and replacing `StringBuffer` with `StringBuilder`).
- Reverts early attempts to use reader conditionals directly in `std.*`.
- Documents the remaining tasks (untangling the remaining `definvoke` usage and copying/refactoring tests) in `TODO_BBLANG.md`.

---
*PR created automatically by Jules for task [10298975275043784026](https://jules.google.com/task/10298975275043784026) started by @hoebat*