### PR TITLE
Add Go & Dart typed declaration emitters, Dart target/grammar, and include functions/values in TS emitter

### DIFF
--- a/plans/spec-model-audit-2026-03-28.md
+++ b/plans/spec-model-audit-2026-03-28.md
@@ -1,0 +1,47 @@
+# spec_* model audit (2026-03-28)
+
+This pass reviewed `src/std/lang/model/spec_*` files with a focus on consistency, typed-support readiness, and testability.
+
+## Completed in this PR
+
+1. **TypeScript declarations now include functions and values**
+   - Updated `spec_js/ts.clj` so namespace declaration output emits `specs + functions + values`.
+   - Import reference collection now includes function signatures and value types, not just spec types.
+
+2. **Dart target now has a language grammar and xtalk helper rewrites**
+   - Added base Dart grammar install (`:dart`) and helper fn mappings in `spec_xtalk/fn_dart.clj`.
+
+3. **Go and Dart typed declaration backends added**
+   - Added typed emitters that consume the normalized xtalk typed analysis for Go and Dart declarations.
+
+4. **Strict/lossy conversion option added for Go and Dart typed emitters**
+   - Both typed emitters now support `{:strict? true}` to throw when lossy mappings (union/intersection/tuple/apply) are encountered.
+
+## Additional improvement opportunities found
+
+### 1) `spec_rust.clj` has many placeholder docstrings (`"TODO"`)
+
+The Rust backend has several public helper functions with no descriptive docstrings yet (`rst-typesystem`, `rst-vector`, `rst-defenum`, etc.). Replacing these with concrete behavior docs would substantially improve maintainability and onboarding.
+
+### 2) fn mapping modules duplicate the same `add-sym` utility pattern
+
+Files under `spec_xtalk/fn_*` repeat near-identical symbol-registration glue. A shared helper namespace for `add-sym` and common x-* wrappers would reduce drift and make adding future language backends faster.
+
+### 3) typed declaration emitters should likely share a small common core
+
+`spec_js/ts.clj`, `spec_go/typed.clj`, and `spec_dart/typed.clj` now each perform:
+- identifier sanitization,
+- named-type namespace disambiguation,
+- declaration section assembly.
+
+A shared `typed emit core` would reduce copy/paste and keep behavior aligned (especially around fallback policies for unions/intersections and maybe/nullability handling).
+
+### 4) golden fixtures for cross-language parity
+
+A single typed fixture namespace rendered through TS/Go/Dart emitters with snapshot assertions would help prevent regressions and ensure consistent naming/import/nullability policies across backends.
+
+## Suggested next step order
+
+1. Extract shared typed-emitter core utilities.
+2. Add multi-backend golden fixture snapshots.
+3. Replace Rust placeholder docstrings with concrete docs.

--- a/plans/xtalk-go-dart-typed-targeting-plan.md
+++ b/plans/xtalk-go-dart-typed-targeting-plan.md
@@ -1,0 +1,137 @@
+# xtalk typed expansion plan: Go and Dart
+
+## Context
+
+`xtalk` already has a typed layer (`defspec.xt`, parser/analysis/checking, and a TypeScript declaration emitter). The main opportunity is to reuse the type graph for **language-specific declaration output** and then optionally guide code generation/interop.
+
+## Current capabilities (what we can leverage)
+
+1. **Typed AST/registry and namespace analysis already exist**
+   - `std.lang.typed.xtalk` exposes registration and analysis APIs (`analyze-namespace`, `analyze-and-register!`, registry lookups).
+   - Parsed analysis includes `:specs`, `:functions`, `:macros`, and `:values` in a normalized type form.
+
+2. **Type normalization already supports a useful common subset**
+   - Primitive, named, maybe, union, intersection, tuple, array, dict, record, function, and generic application are all represented in the typed model.
+   - This is enough to map to both Go and Dart with a few language-specific constraints.
+
+3. **A working declaration backend exists (TypeScript)**
+   - `std.lang.model.spec-js.ts` already demonstrates:
+     - import/reference collection,
+     - identifier sanitization,
+     - type rendering,
+     - namespace-level declaration generation.
+   - This file is the best template for additional target backends.
+
+4. **Go runtime/codegen already exists for xtalk language model**
+   - `std.lang.model.spec-go` and `std.lang.model.spec-xtalk.fn-go` already provide syntax/runtime mappings for xtalk -> Go code generation.
+   - Typed output can piggyback on this existing target instead of creating a net-new language pipeline.
+
+## Recommended strategy
+
+Use a **declaration-first approach** for both Go and Dart, then add optional runtime/codegen typing improvements.
+
+### Phase 1: Shared typed declaration core (high ROI)
+
+Create a small common module (e.g. `std.lang.model.spec-xtalk.typed.emit`) that encapsulates:
+
+- namespace traversal and dependency grouping,
+- symbol sanitization hooks,
+- emitted declaration ordering,
+- optional handling policies for unsupported type constructs.
+
+Keep per-language files focused on rendering.
+
+Why first: this minimizes duplicated logic currently embedded in `spec_js/ts.clj` and makes Go/Dart additions straightforward.
+
+### Phase 2: Add Go typed declaration backend
+
+Add a backend file (suggestion: `src/std/lang/model/spec_go/typed.clj`) implementing:
+
+- `emit-go-type` for the normalized xtalk type tree,
+- `emit-spec-declaration` as `type ...` aliases/structs/interfaces,
+- `emit-function-signature` for function specs,
+- `emit-namespace-declarations` as the public entrypoint.
+
+Suggested type mapping policy:
+
+- `:xt/str` -> `string`
+- `:xt/bool` -> `bool`
+- `:xt/int` -> `int`
+- `:xt/num` -> `float64` (or configurable)
+- `:xt/nil` -> `nil` only in pointer/interface contexts
+- `:xt/any` / `:xt/unknown` -> `any` (Go 1.18+)
+- `:xt/obj` -> `map[string]any`
+- `:xt/fn` -> `func(...any) any`
+- `[:xt/maybe T]` -> pointer form when possible (`*T`), else `interface{}`/`any` fallback
+- `[:xt/record ...]` -> `struct`
+- `[:xt/dict K V]` -> `map[K]V` (restrict `K` to comparable primitives)
+- union/intersection -> fallback strategy (`any`) with generated comments for traceability.
+
+### Phase 3: Add Dart typed declaration backend
+
+Add backend file (suggestion: `src/std/lang/model/spec_dart/typed.clj`) implementing:
+
+- `emit-dart-type` for normalized types,
+- typedef/class generation,
+- nullable type support (`T?`) for maybe,
+- import generation across namespaces.
+
+Suggested mapping policy:
+
+- `:xt/str` -> `String`
+- `:xt/bool` -> `bool`
+- `:xt/int` -> `int`
+- `:xt/num` -> `double`
+- `:xt/nil` -> `Null`
+- `:xt/any` / `:xt/unknown` -> `dynamic` (or `Object?`, configurable)
+- `:xt/obj` -> `Map<String, Object?>`
+- arrays -> `List<T>`
+- dict -> `Map<K, V>` (prefer `String` keys where possible)
+- records -> generated class with final fields + constructor
+- fn -> `typedef`
+- union/intersection -> sealed-class strategy (later), `Object?` fallback initially.
+
+### Phase 4: Integrate with existing workflows
+
+- Add stable public fns in an obvious namespace:
+  - `emit-go-namespace-declarations`
+  - `emit-dart-namespace-declarations`
+- Optionally wire into `lein manage`/publish tasks after API settles.
+- Add fixture-driven tests mirroring `spec_xtalk_typed_test` style.
+
+## Important design choices
+
+1. **Keep language backends lossy-but-explicit at first**
+   Some xtalk type features (especially unions/intersections) do not map perfectly to Go/Dart without advanced wrappers. Emit safe fallback types plus comments instead of blocking generation.
+
+2. **Separate declaration generation from runtime transpilation**
+   Use typed specs for generated declarations immediately; do not couple this to changes in expression-level xtalk codegen until declarations are stable.
+
+3. **Treat function specs as first-class output**
+   The current TS emitter has helper functions for function/value declarations but only emits specs in the final namespace output path. Expanding declaration output to include functions/values should be part of the shared core.
+
+4. **Add backend options early**
+   Configuration options should include primitive mappings, strictness for unknown/union handling, naming/casing mode, and nullability policy.
+
+## Minimal implementation sequence
+
+1. Refactor reusable logic out of `spec_js/ts.clj` into a typed emit helper namespace.
+2. Keep TS output identical (golden test).
+3. Add Go emitter + tests on existing fixture namespace.
+4. Add Dart emitter + tests on same fixture.
+5. Add one mixed fixture exercising unions, optional fields, and cross-namespace references.
+
+## Risks and mitigations
+
+- **Risk:** Go/Dart mismatch for unions/intersections.
+  - **Mitigation:** explicit fallback policy with comments + strict mode that throws when lossy mappings occur.
+
+- **Risk:** named type collisions across namespaces.
+  - **Mitigation:** keep current ns-prefixed sanitization pattern used by TS emitter.
+
+- **Risk:** declaration drift from runtime semantics.
+  - **Mitigation:** fixture tests that assert both typed analysis and emitted declarations for the same symbols.
+
+## Practical recommendation
+
+If the goal is “target more languages quickly,” start with **typed declaration generation** for Go and Dart first, because this is mostly additive and reuses existing typed infrastructure immediately. After that, incrementally introduce type-aware runtime/codegen rules where language backends benefit most (Go first, since an xtalk Go backend already exists).

--- a/src/std/lang/model/spec_dart.clj
+++ b/src/std/lang/model/spec_dart.clj
@@ -1,0 +1,71 @@
+(ns std.lang.model.spec-dart
+  (:require [std.lang.base.book :as book]
+            [std.lang.base.emit :as emit]
+            [std.lang.base.emit-common :as common]
+            [std.lang.base.emit-data :as data]
+            [std.lang.base.grammar :as grammar]
+            [std.lang.base.script :as script]
+            [std.lang.model.spec-xtalk]
+            [std.lang.model.spec-xtalk.fn-dart :as fn-dart]
+            [std.lib.collection :as collection]))
+
+(defn dart-map-key
+  [key grammar mopts]
+  (cond
+    (or (keyword? key)
+        (string? key)
+        (symbol? key)
+        (number? key)
+        (boolean? key)
+        (nil? key))
+    (data/default-map-key key grammar mopts)
+
+    :else
+    (str "(" (common/*emit-fn* key grammar mopts) ")")))
+
+(def +features+
+  (-> (grammar/build :exclude [:pointer
+                               :block
+                               :data-set])
+      (grammar/build:override
+       {:var        {:symbol '#{var} :raw "var"}
+        :defn       {:symbol '#{defn}}
+        :new        {:symbol '#{new} :raw "new" :emit :call}
+        :with-global {:value true :raw "globalThis"}})
+      (grammar/build:override fn-dart/+dart+)))
+
+(def +template+
+  (-> (emit/default-grammar)
+      (collection/merge-nested
+       {:banned #{:set :regex}
+        :highlight '#{return break continue}
+        :default {:common    {:statement ""}
+                  :function  {:prefix ""
+                              :raw ""
+                              :args {:sep ", "}}
+                  :invoke    {:reversed true :hint ""}
+                  :block     {:start " {" :end "}"}}
+        :token   {:symbol {:replace {\- "_"}}
+                  :nil {:as "null"}}
+        :data    {:vector {:start "[" :end "]" :space ""}
+                  :map    {:space "" :key-fn dart-map-key}}})))
+
+(def +grammar+
+  (grammar/grammar :dart
+    (grammar/to-reserved +features+)
+    +template+))
+
+(def +meta+
+  (book/book-meta
+   {:module-current   (fn [])
+    :module-import    (fn [name _ _]
+                        (list :- "import" (str "'" name "';")))}))
+
+(def +book+
+  (book/book {:lang :dart
+              :parent :xtalk
+              :meta +meta+
+              :grammar +grammar+}))
+
+(def +init+
+  (script/install +book+))

--- a/src/std/lang/model/spec_dart/typed.clj
+++ b/src/std/lang/model/spec_dart/typed.clj
@@ -1,0 +1,201 @@
+(ns std.lang.model.spec-dart.typed
+  (:require [clojure.string :as str]
+            [std.lang.typed.xtalk-analysis :as analysis]))
+
+(declare emit-dart-type)
+(declare lossy-dart-type)
+
+(def ^:dynamic *emit-options*
+  {:strict? false
+   :lossy-fallback "Object?"})
+
+(defn sanitize-ident
+  [s]
+  (-> (str s)
+      (str/replace #"[^A-Za-z0-9_]" "_")
+      (str/replace #"^[0-9]" "_$0")))
+
+(defn lower-camel
+  [s]
+  (let [base (sanitize-ident s)]
+    (if (str/includes? base "_")
+      (let [parts (str/split base #"_")
+            head (str/lower-case (first parts))
+            tail (map str/capitalize (rest parts))]
+        (str (or head "x") (apply str tail)))
+      (str (str/lower-case (subs base 0 1))
+           (subs base 1)))))
+
+(defn upper-camel
+  [s]
+  (let [base (sanitize-ident s)]
+    (if (str/includes? base "_")
+      (->> (str/split base #"_")
+           (map str/capitalize)
+           (apply str))
+      (str (str/upper-case (subs base 0 1))
+           (subs base 1)))))
+
+(defn named-dart-ident
+  [type-name current-ns]
+  (cond
+    (symbol? type-name)
+    (if (= current-ns (some-> type-name namespace symbol))
+      (upper-camel (name type-name))
+      (upper-camel (str (namespace type-name) "_" (name type-name))))
+
+    (string? type-name)
+    (upper-camel type-name)
+
+    :else
+    "Object?"))
+
+(defn emit-dart-type
+  [type current-ns]
+  (case (:kind type)
+    :primitive
+    (case (:name type)
+      :xt/str "String"
+      :xt/bool "bool"
+      :xt/int "int"
+      :xt/num "double"
+      :xt/kw "String"
+      :xt/nil "Null"
+      :xt/any "Object?"
+      :xt/unknown "Object?"
+      :xt/obj "Map<String, Object?>"
+      :xt/fn "Object? Function(List<Object?>)"
+      "Object?")
+
+    :named
+    (named-dart-ident (:name type) current-ns)
+
+    :maybe
+    (str (emit-dart-type (:item type) current-ns) "?")
+
+    :union
+    (lossy-dart-type :union)
+
+    :intersection
+    (lossy-dart-type :intersection)
+
+    :tuple
+    (lossy-dart-type :tuple)
+
+    :array
+    (str "List<" (emit-dart-type (:item type) current-ns) ">")
+
+    :dict
+    (str "Map<" (emit-dart-type (:key type) current-ns)
+         ", " (emit-dart-type (:value type) current-ns) ">")
+
+    :record
+    "Map<String, Object?>"
+
+    :fn
+    (str (emit-dart-type (:output type) current-ns)
+         " Function("
+         (->> (:inputs type)
+              (map #(emit-dart-type % current-ns))
+              (str/join ", "))
+         ")")
+
+    :apply
+    (lossy-dart-type :apply)
+
+    "Object?"))
+
+(defn lossy-dart-type
+  [kind]
+  (if (:strict? *emit-options*)
+    (throw (ex-info "Lossy xtalk->dart type conversion"
+                    {:kind kind
+                     :fallback (:lossy-fallback *emit-options*)}))
+    (:lossy-fallback *emit-options*)))
+
+(defn maybe-unwrapped
+  [type optional?]
+  (if (and optional?
+           (= :maybe (:kind type)))
+    (:item type)
+    type))
+
+(defn emit-class-field
+  [{:keys [name type optional?]} current-ns]
+  (let [base-type (maybe-unwrapped type optional?)]
+    (str "  final "
+         (emit-dart-type base-type current-ns)
+         (when optional? "?")
+         " "
+         (lower-camel name)
+         ";")))
+
+(defn emit-class-constructor
+  [class-name fields]
+  (str "  const " class-name "({"
+       (->> fields
+            (map (fn [{:keys [name optional?]}]
+                   (str (when-not optional? "required ") "this." (lower-camel name))))
+            (str/join ", "))
+       "});"))
+
+(defn emit-record-class
+  [name type current-ns]
+  (str "class " name " {\n"
+       (->> (:fields type)
+            (map #(emit-class-field % current-ns))
+            (str/join "\n"))
+       (when (seq (:fields type)) "\n")
+       (emit-class-constructor name (:fields type))
+       "\n}"))
+
+(defn emit-spec-declaration
+  [spec]
+  (let [current-ns (some-> spec :ns symbol)
+        name (upper-camel (:name spec))
+        type (:type spec)]
+    (if (= :record (:kind type))
+      (emit-record-class name type current-ns)
+      (str "typedef " name " = " (emit-dart-type type current-ns) ";"))))
+
+(defn emit-function-declaration
+  [fn-def]
+  (let [current-ns (some-> fn-def :ns symbol)
+        name (upper-camel (:name fn-def))]
+    (str "typedef " name " = "
+         (emit-dart-type (:output fn-def) current-ns)
+         " Function("
+         (->> (:inputs fn-def)
+              (map-indexed (fn [idx input]
+                             (str (emit-dart-type (:type input) current-ns)
+                                  " arg"
+                                  idx)))
+              (str/join ", "))
+         ");")))
+
+(defn emit-value-declaration
+  [value-def]
+  (let [current-ns (some-> value-def :ns symbol)]
+    (str "late final "
+         (emit-dart-type (:type value-def) current-ns)
+         " "
+         (lower-camel (:name value-def))
+         ";")))
+
+(defn emit-analysis-declarations
+  ([analysis]
+   (emit-analysis-declarations analysis {}))
+  ([{:keys [specs functions values]} opts]
+   (binding [*emit-options* (merge *emit-options* opts)]
+     (->> (concat (map emit-spec-declaration specs)
+                  (map emit-function-declaration functions)
+                  (map emit-value-declaration values))
+          (str/join "\n\n")))))
+
+(defn emit-namespace-declarations
+  ([ns-sym]
+   (emit-namespace-declarations ns-sym {}))
+  ([ns-sym opts]
+   (-> ns-sym
+       analysis/analyze-namespace
+       (emit-analysis-declarations opts))))

--- a/src/std/lang/model/spec_go/typed.clj
+++ b/src/std/lang/model/spec_go/typed.clj
@@ -1,0 +1,176 @@
+(ns std.lang.model.spec-go.typed
+  (:require [clojure.string :as str]
+            [std.lang.typed.xtalk-analysis :as analysis]))
+
+(declare emit-go-type)
+(declare lossy-go-type)
+
+(def ^:dynamic *emit-options*
+  {:strict? false
+   :lossy-fallback "any"})
+
+(defn sanitize-ident
+  [s]
+  (-> (str s)
+      (str/replace #"[^A-Za-z0-9_]" "_")
+      (str/replace #"^[0-9]" "_$0")))
+
+(defn capitalize-ident
+  [s]
+  (let [s (sanitize-ident s)]
+    (if (seq s)
+      (str (str/upper-case (subs s 0 1)) (subs s 1))
+      "X")))
+
+(defn named-go-ident
+  [type-name current-ns]
+  (cond
+    (symbol? type-name)
+    (if (= current-ns (some-> type-name namespace symbol))
+      (sanitize-ident (name type-name))
+      (sanitize-ident (str (namespace type-name) "_" (name type-name))))
+
+    (string? type-name)
+    (sanitize-ident type-name)
+
+    :else
+    "any"))
+
+(defn maybe-go-type
+  [item current-ns]
+  (let [rendered (emit-go-type item current-ns)]
+    (if (#{"string" "bool" "int" "float64" "any"} rendered)
+      "any"
+      (str "*" rendered))))
+
+(defn lossy-go-type
+  [kind]
+  (if (:strict? *emit-options*)
+    (throw (ex-info "Lossy xtalk->go type conversion"
+                    {:kind kind
+                     :fallback (:lossy-fallback *emit-options*)}))
+    (:lossy-fallback *emit-options*)))
+
+(defn emit-go-type
+  [type current-ns]
+  (case (:kind type)
+    :primitive
+    (case (:name type)
+      :xt/str "string"
+      :xt/bool "bool"
+      :xt/int "int"
+      :xt/num "float64"
+      :xt/kw "string"
+      :xt/nil "any"
+      :xt/any "any"
+      :xt/unknown "any"
+      :xt/obj "map[string]any"
+      :xt/fn "func(...any) any"
+      "any")
+
+    :named
+    (named-go-ident (:name type) current-ns)
+
+    :maybe
+    (maybe-go-type (:item type) current-ns)
+
+    :union
+    (lossy-go-type :union)
+
+    :intersection
+    (lossy-go-type :intersection)
+
+    :tuple
+    (lossy-go-type :tuple)
+
+    :array
+    (str "[]" (emit-go-type (:item type) current-ns))
+
+    :dict
+    (str "map[" (emit-go-type (:key type) current-ns) "]"
+         (emit-go-type (:value type) current-ns))
+
+    :record
+    (if (:open type)
+      "map[string]any"
+      "struct")
+
+    :fn
+    (str "func("
+         (->> (:inputs type)
+              (map-indexed (fn [idx input]
+                             (str "arg" idx " " (emit-go-type input current-ns))))
+              (str/join ", "))
+         ") "
+         (emit-go-type (:output type) current-ns))
+
+    :apply
+    (lossy-go-type :apply)
+
+    "any"))
+
+(defn emit-struct-field
+  [{:keys [name type optional?]} current-ns]
+  (let [field-name (capitalize-ident name)
+        field-type (emit-go-type (if (and optional?
+                                          (= :maybe (:kind type)))
+                                   (:item type)
+                                   type)
+                                 current-ns)]
+    (str "  " field-name " " field-type " `json:\"" name "\"`")))
+
+(defn emit-struct-type
+  [type current-ns]
+  (str "struct {\n"
+       (->> (:fields type)
+            (map #(emit-struct-field % current-ns))
+            (str/join "\n"))
+       "\n}"))
+
+(defn emit-spec-declaration
+  [spec]
+  (let [current-ns (some-> spec :ns symbol)
+        name (sanitize-ident (:name spec))
+        type (:type spec)]
+    (str "type " name " "
+         (if (= :record (:kind type))
+           (emit-struct-type type current-ns)
+           (emit-go-type type current-ns)))))
+
+(defn emit-function-declaration
+  [fn-def]
+  (let [current-ns (some-> fn-def :ns symbol)
+        name (sanitize-ident (:name fn-def))]
+    (str "type " name " func("
+         (->> (:inputs fn-def)
+              (map-indexed (fn [idx input]
+                             (str "arg" idx " " (emit-go-type (:type input) current-ns))))
+              (str/join ", "))
+         ") "
+         (emit-go-type (:output fn-def) current-ns))))
+
+(defn emit-value-declaration
+  [value-def]
+  (let [current-ns (some-> value-def :ns symbol)]
+    (str "var "
+         (sanitize-ident (:name value-def))
+         " "
+         (emit-go-type (:type value-def) current-ns))))
+
+(defn emit-analysis-declarations
+  ([analysis]
+   (emit-analysis-declarations analysis {}))
+  ([{:keys [specs functions values]} opts]
+   (binding [*emit-options* (merge *emit-options* opts)]
+     (->> (concat (map emit-spec-declaration specs)
+                  (map emit-function-declaration functions)
+                  (map emit-value-declaration values))
+          (str/join "\n\n")))))
+
+(defn emit-namespace-declarations
+  ([ns-sym]
+   (emit-namespace-declarations ns-sym {}))
+  ([ns-sym opts]
+   (-> ns-sym
+       analysis/analyze-namespace
+       (emit-analysis-declarations opts))))

--- a/src/std/lang/model/spec_js/ts.clj
+++ b/src/std/lang/model/spec_js/ts.clj
@@ -199,8 +199,13 @@
    :output (:output fn-def)})
 
 (defn analysis-import-groups
-  [{:keys [ns specs]}]
-  (let [all-refs (mapcat (comp collect-type-refs :type) specs)]
+  [{:keys [ns specs functions values]}]
+  (let [spec-refs (mapcat (comp collect-type-refs :type) specs)
+        fn-refs (mapcat (fn [fn-def]
+                          (collect-type-refs (fn-type fn-def)))
+                        functions)
+        value-refs (mapcat (comp collect-type-refs :type) values)
+        all-refs (concat spec-refs fn-refs value-refs)]
     (->> all-refs
          set
          (remove #(= ns (some-> % namespace symbol)))
@@ -278,11 +283,13 @@
          ";")))
 
 (defn emit-analysis-declarations
-  [{:keys [specs] :as analysis}]
+  [{:keys [specs functions values] :as analysis}]
   (->> (concat
         (when-let [imports (not-empty (emit-imports analysis))]
           [imports])
-        (map emit-spec-declaration specs))
+        (map emit-spec-declaration specs)
+        (map emit-function-declaration functions)
+        (map emit-value-declaration values))
         (str/join "\n\n")))
 
 (defn emit-namespace-declarations

--- a/src/std/lang/model/spec_xtalk/fn_dart.clj
+++ b/src/std/lang/model/spec_xtalk/fn_dart.clj
@@ -1,0 +1,34 @@
+(ns std.lang.model.spec-xtalk.fn-dart
+  (:require [std.lib.collection :as collection]))
+
+(defn- add-sym
+  [m]
+  (collection/map-entries (fn [[k v]]
+                            [k (assoc v :symbol #{(symbol (name k))})])
+                          m))
+
+(defn dart-tf-x-len
+  [[_ arr]]
+  (list '. arr 'length))
+
+(defn dart-tf-x-cat
+  [[_ & args]]
+  (apply list '+ args))
+
+(defn dart-tf-x-print
+  [[_ & args]]
+  (apply list 'print args))
+
+(defn dart-tf-x-arr-push
+  [[_ arr item]]
+  (list '. arr (list 'add item)))
+
+(def +dart-core+
+  (add-sym
+   {:x-print    {:macro #'dart-tf-x-print    :emit :macro :value true}
+    :x-len      {:macro #'dart-tf-x-len      :emit :macro :value true}
+    :x-cat      {:macro #'dart-tf-x-cat      :emit :macro :value true}
+    :x-arr-push {:macro #'dart-tf-x-arr-push :emit :macro}}))
+
+(def +dart+
+  (merge +dart-core+))

--- a/test/std/lang/model/spec_dart_test.clj
+++ b/test/std/lang/model/spec_dart_test.clj
@@ -1,0 +1,35 @@
+(ns std.lang.model.spec-dart-test
+  (:require [std.lang :as l]
+            [std.lang.model.spec-dart :as spec-dart])
+  (:use code.test))
+
+(fact "basic dart emission"
+  (l/emit-as :dart ['(var greeting "hello")])
+  => "var greeting = \"hello\""
+
+  (l/emit-as :dart ['(defn hello [name] (return (x-cat "hi " name)))])
+  => "hello(name) {\n  return \"hi \" + name\n}"
+
+  (l/emit-as :dart ['(new Person name)])
+  => "new Person(name)"
+
+  (l/emit-as :dart ['{:name "hello" :count 2}])
+  => "{\"name\":\"hello\",\"count\":2}")
+
+(fact "xtalk helper rewrites for dart"
+  (l/emit-as :dart ['(x-print "hello")])
+  => "print(\"hello\")"
+
+  (l/emit-as :dart ['(x-len [1 2 3])])
+  => "[1,2,3].length"
+
+  (l/emit-as :dart ['(x-arr-push items 1)])
+  => "items.add(1)")
+
+^{:refer std.lang.model.spec-dart/dart-map-key :added "4.1"}
+(fact "emits map keys for dart"
+  (spec-dart/dart-map-key :hello spec-dart/+grammar+ {})
+  => "\"hello\""
+
+  (spec-dart/dart-map-key '(+ a 1) spec-dart/+grammar+ {})
+  => "(a + 1)")

--- a/test/std/lang/model/spec_dart_typed_test.clj
+++ b/test/std/lang/model/spec_dart_typed_test.clj
@@ -1,0 +1,76 @@
+(ns std.lang.model.spec-dart-typed-test
+  (:require [clojure.string :as str]
+            [std.lang.model.spec-dart.typed :as dart-typed])
+  (:use code.test))
+
+^{:refer std.lang.model.spec-dart.typed/emit-dart-type :added "4.1"}
+(fact "maps xtalk primitive and container types to dart"
+  [(dart-typed/emit-dart-type {:kind :primitive :name :xt/str} nil)
+   (dart-typed/emit-dart-type {:kind :array
+                               :item {:kind :primitive :name :xt/int}} nil)
+   (dart-typed/emit-dart-type {:kind :dict
+                               :key {:kind :primitive :name :xt/str}
+                               :value {:kind :primitive :name :xt/num}} nil)
+   (dart-typed/emit-dart-type {:kind :maybe
+                               :item {:kind :named :name 'sample.user/User}} 'sample.user)]
+  => ["String" "List<int>" "Map<String, double>" "User?"])
+
+^{:refer std.lang.model.spec-dart.typed/emit-analysis-declarations :added "4.1"}
+(fact "emits spec/function/value declarations in dart syntax"
+  (dart-typed/emit-analysis-declarations
+   {:specs [{:ns "sample.user"
+             :name "User"
+             :type {:kind :record
+                    :fields [{:name "id"
+                              :type {:kind :primitive :name :xt/str}
+                              :optional? false}]}}
+            {:ns "sample.user"
+             :name "UserMap"
+             :type {:kind :dict
+                    :key {:kind :primitive :name :xt/str}
+                    :value {:kind :named :name 'sample.user/User}}}]
+    :functions [{:ns "sample.user"
+                 :name "find-user"
+                 :inputs [{:name 'users
+                           :type {:kind :named :name 'sample.user/UserMap}}
+                          {:name 'id
+                           :type {:kind :primitive :name :xt/str}}]
+                 :output {:kind :maybe :item {:kind :named :name 'sample.user/User}}}]
+    :values [{:ns "sample.user"
+              :name "default-id"
+              :type {:kind :primitive :name :xt/str}}]})
+  => (str "class User {\n"
+          "  final String id;\n"
+          "  const User({required this.id});\n"
+          "}\n\n"
+          "typedef UserMap = Map<String, User>;\n\n"
+          "typedef FindUser = User? Function(UserMap arg0, String arg1);\n\n"
+          "late final String defaultId;"))
+
+(fact "can emit declarations from typed fixture namespace"
+  (let [out (dart-typed/emit-namespace-declarations
+             'std.lang.model.spec-xtalk-typed-fixture)]
+    [(str/includes? out "class User")
+     (str/includes? out "typedef UserMap = Map<String, User>")
+     (str/includes? out "typedef FindUser = User? Function")])
+  => [true true true])
+
+(fact "supports strict mode for lossy type conversions"
+  [(dart-typed/emit-dart-type {:kind :union
+                               :types [{:kind :primitive :name :xt/str}
+                                       {:kind :primitive :name :xt/int}]}
+                              nil)
+   (try
+     (dart-typed/emit-analysis-declarations
+      {:specs [{:ns "sample.user"
+                :name "LooseType"
+                :type {:kind :union
+                       :types [{:kind :primitive :name :xt/str}
+                               {:kind :primitive :name :xt/int}]}}]
+       :functions []
+       :values []}
+      {:strict? true})
+     false
+     (catch Exception _
+       true))]
+  => ["Object?" true])

--- a/test/std/lang/model/spec_go_typed_test.clj
+++ b/test/std/lang/model/spec_go_typed_test.clj
@@ -1,0 +1,75 @@
+(ns std.lang.model.spec-go-typed-test
+  (:require [clojure.string :as str]
+            [std.lang.model.spec-go.typed :as go-typed])
+  (:use code.test))
+
+^{:refer std.lang.model.spec-go.typed/emit-go-type :added "4.1"}
+(fact "maps xtalk primitive and container types to go"
+  [(go-typed/emit-go-type {:kind :primitive :name :xt/str} nil)
+   (go-typed/emit-go-type {:kind :array
+                           :item {:kind :primitive :name :xt/int}} nil)
+   (go-typed/emit-go-type {:kind :dict
+                           :key {:kind :primitive :name :xt/str}
+                           :value {:kind :primitive :name :xt/num}} nil)
+   (go-typed/emit-go-type {:kind :maybe
+                           :item {:kind :named :name 'sample.user/User}} 'sample.user)]
+  => ["string" "[]int" "map[string]float64" "*User"])
+
+^{:refer std.lang.model.spec-go.typed/emit-analysis-declarations :added "4.1"}
+(fact "emits spec/function/value declarations in go syntax"
+  (go-typed/emit-analysis-declarations
+   {:specs [{:ns "sample.user"
+             :name "User"
+             :type {:kind :record
+                    :fields [{:name "id"
+                              :type {:kind :primitive :name :xt/str}
+                              :optional? false}]}}
+            {:ns "sample.user"
+             :name "UserMap"
+             :type {:kind :dict
+                    :key {:kind :primitive :name :xt/str}
+                    :value {:kind :named :name 'sample.user/User}}}]
+    :functions [{:ns "sample.user"
+                 :name "find-user"
+                 :inputs [{:name 'users
+                           :type {:kind :named :name 'sample.user/UserMap}}
+                          {:name 'id
+                           :type {:kind :primitive :name :xt/str}}]
+                 :output {:kind :maybe :item {:kind :named :name 'sample.user/User}}}]
+    :values [{:ns "sample.user"
+              :name "default-id"
+              :type {:kind :primitive :name :xt/str}}]})
+  => (str "type User struct {\n"
+          "  Id string `json:\"id\"`\n"
+          "}\n\n"
+          "type UserMap map[string]User\n\n"
+          "type find_user func(arg0 UserMap, arg1 string) *User\n\n"
+          "var default_id string"))
+
+(fact "can emit declarations from typed fixture namespace"
+  (let [out (go-typed/emit-namespace-declarations
+             'std.lang.model.spec-xtalk-typed-fixture)]
+    [(str/includes? out "type User struct")
+     (str/includes? out "type UserMap map[string]User")
+     (str/includes? out "type find_user func(arg0 UserMap, arg1 string) *User")])
+  => [true true true])
+
+(fact "supports strict mode for lossy type conversions"
+  [(go-typed/emit-go-type {:kind :union
+                           :types [{:kind :primitive :name :xt/str}
+                                   {:kind :primitive :name :xt/int}]}
+                          nil)
+   (try
+     (go-typed/emit-analysis-declarations
+      {:specs [{:ns "sample.user"
+                :name "LooseType"
+                :type {:kind :union
+                       :types [{:kind :primitive :name :xt/str}
+                               {:kind :primitive :name :xt/int}]}}]
+       :functions []
+       :values []}
+      {:strict? true})
+     false
+     (catch Exception _
+       true))]
+  => ["any" true])

--- a/test/std/lang/model/spec_xtalk_typed_test.clj
+++ b/test/std/lang/model/spec_xtalk_typed_test.clj
@@ -1,5 +1,6 @@
 (ns std.lang.model.spec-xtalk-typed-test
-  (:require [std.lang.typed.xtalk :as typed]
+  (:require [clojure.string]
+   [std.lang.typed.xtalk :as typed]
    [std.lang.typed.xtalk-analysis :as analysis]
    [std.lang.typed.xtalk-common :as types]
    [std.lang.typed.xtalk-infer :as infer]
@@ -502,13 +503,13 @@
   => '[true true true true true true])
 
 (fact "emits TypeScript declarations from xtalk specs"
-  (ts/emit-namespace-declarations 'std.lang.model.spec-xtalk-typed-fixture)
-  => (str "export interface User {\n"
-          "  id: string;\n"
-          "  name: string;\n"
-          "}\n\n"
-          "export type UserMap = Record<string, User>;\n\n"
-          "export type find_user = (arg0: UserMap, arg1: string) => User | null;"))
+  (let [out (ts/emit-namespace-declarations 'std.lang.model.spec-xtalk-typed-fixture)]
+    [(clojure.string/includes? out "export interface User")
+     (clojure.string/includes? out "export type UserMap = Record<string, User>;")
+     (clojure.string/includes? out "export type find_user = (arg0: UserMap, arg1: string) => User | null;")
+     (clojure.string/includes? out "export type wrong_user_name")
+     (clojure.string/includes? out "export type find_user_wrong_key")])
+  => [true true true true true])
 
 (fact "supports map destructuring in let bindings"
   (-> (infer/infer-type


### PR DESCRIPTION
### Motivation

- Enable typed declaration output for additional language targets (Go and Dart) by reusing the existing xtalk typed analysis and declaration-first approach.
- Provide a Dart language grammar and xtalk helper rewrites so xtalk code can be emitted as Dart source with expected helpers.
- Ensure the TypeScript declaration emitter collects and emits `specs`, `functions`, and `values` (not just specs) and provide strict/lossy conversion control for language backends.

### Description

- Extended the TypeScript emitter in `src/std/lang/model/spec_js/ts.clj` to collect imports from and emit `functions` and `values` alongside `specs` and to output function/value declarations.
- Added a Dart language target with grammar, book, and install in `src/std/lang/model/spec_dart.clj` and helper xtalk rewrites in `src/std/lang/model/spec_xtalk/fn_dart.clj`.
- Implemented a Dart typed declaration backend in `src/std/lang/model/spec_dart/typed.clj` that renders types, records, typedefs, and supports a `{:strict? true}` option to throw on lossy conversions.
- Implemented a Go typed declaration backend in `src/std/lang/model/spec_go/typed.clj` with similar rendering and a `{:strict? true}` lossy policy.
- Added unit tests exercising Dart emission and helpers (`test/std/lang/model/spec_dart_test.clj`), Dart typed emitter (`test/std/lang/model/spec_dart_typed_test.clj`), Go typed emitter (`test/std/lang/model/spec_go_typed_test.clj`), and updated `spec_xtalk` typed tests to validate expanded TS output.
- Added planning documents `plans/spec-model-audit-2026-03-28.md` and `plans/xtalk-go-dart-typed-targeting-plan.md` describing audit findings and a recommended rollout strategy.

### Testing

- Ran the Clojure test suite with `lein test` which included the new tests `std.lang.model.spec-dart-test`, `std.lang.model.spec-dart-typed-test`, and `std.lang.model.spec-go-typed-test`, and the modified `std.lang.model.spec-xtalk-typed-test`, and all tests succeeded.
- Exercised `emit-namespace-declarations` for TS/Go/Dart emitters against the typed fixture namespace and asserted presence of expected fragments in the output, and those assertions passed.
- Exercised strict-mode behavior for lossy type conversions in both Go and Dart emitters and verified that `{:strict? true}` triggers exceptions as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7548ea97483338f397a2f5f9a433e)