### PR TITLE
Introduce xtalk `x:task-*` task-first async ops and language bindings

### DIFF
--- a/plans/xt-lib-cell-port-options.md
+++ b/plans/xt-lib-cell-port-options.md
@@ -1,0 +1,154 @@
+# `xt.lib.cell` Port Plan (Task-First)
+
+## Scope
+
+This plan intentionally narrows the async model to **`x:task-*` only** as the first-class surface.
+
+- No Promise-first API in the core design.
+- Existing `k/for:async` remains a compatibility mechanism during migration.
+- JS/Lua/Python backends implement a common task contract and are free to use host-native primitives internally.
+
+---
+
+## 1) Task contract for xtalk
+
+## Task states
+
+- `"pending"`
+- `"ok"`
+- `"error"`
+- `"cancelled"`
+
+## Proposed xtalk primitives
+
+- `x:task-run`
+- `x:task-then`
+- `x:task-catch`
+- `x:task-finally`
+- `x:task-cancel`
+- `x:task-status`
+- `x:task-await`
+- `x:task-from-async` (bridge for existing `k/for:async`)
+
+## Behavioral contract
+
+- `x:task-run` returns a task handle.
+- `x:task-then`/`x:task-catch` return chained task handles.
+- `x:task-finally` always runs after resolution/rejection.
+- `x:task-status` is query-only and does not mutate.
+- `x:task-cancel` is best-effort/cooperative.
+- `x:task-await` is optional blocking helper where runtime supports it.
+
+---
+
+## 2) Rewriting `k/for:async` call sites
+
+## Why rewrite
+
+`k/for:async` is workable for single success/error branches but is awkward for:
+
+- linear chains
+- fan-in/fan-out (`all`/`race` style)
+- cancellation propagation
+- reusable composition across runtime boundaries
+
+## Rewrite example (`load-tasks-single` pattern)
+
+```clojure
+(defn.xt load-tasks-single-task
+  [loader id hook-fn complete-fn loop-fn]
+  (var #{tasks loading completed} loader)
+  (var task-entry (k/get-key tasks id))
+  (k/set-key loading id true)
+  (return
+   (-> (x:task-run (fn [] (-/task-load task-entry)))
+       (x:task-then
+        (fn [res]
+          (k/del-key loading id)
+          (k/set-key completed id true)
+          (when hook-fn (hook-fn id true))
+          (if loop-fn
+            (loop-fn loader hook-fn complete-fn)
+            res)))
+       (x:task-catch
+        (fn [err]
+          (k/del-key loading id)
+          (k/set-key loader "errored" id)
+          (when hook-fn     (hook-fn id false))
+          (when complete-fn (complete-fn err))
+          nil)))))
+```
+
+## Migration bridge
+
+```clojure
+(x:task-from-async
+  (fn [resolve reject]
+    (k/for:async [[v e] expr]
+      {:success (resolve v)
+       :error   (reject e)})))
+```
+
+---
+
+## 3) Protocol/worker integration
+
+Task operations are normalized into protocol frames:
+
+- accepted: `{:op "task" :ref task-id :status "accepted"}`
+- progress: `{:op "task" :ref task-id :status "pending" :body {...}}`
+- done: `{:op "result" :id call-id :status "ok" :body value}`
+- error: `{:op "result" :id call-id :status "error" :body err}`
+
+Worker abstraction remains transport-level:
+
+- spawn endpoint
+- send/receive frames
+- terminate endpoint
+
+Cell core only sees normalized task lifecycle and protocol frames.
+
+---
+
+## 4) Backend start-point implementations
+
+## JavaScript backend
+
+Implementation strategy:
+
+- `x:task-run` wraps thunk in native `Promise.resolve().then(...)`
+- track task state in an attached `__xt_status` field
+- `x:task-then/catch/finally` chain Promise
+- `x:task-cancel` calls optional `cancel` hook (or no-op)
+
+## Lua backend
+
+Implementation strategy:
+
+- represent task as table with `state/value/error`
+- `x:task-run` executes thunk via `pcall` (phase 1)
+- `x:task-then/catch/finally` dispatch based on task state
+- `x:task-cancel` sets cancelled state cooperatively
+- phase 2 can attach coroutine scheduler for true async continuation
+
+## Python backend
+
+Implementation strategy:
+
+- represent task as dict with `status/value/error`
+- `x:task-run` executes thunk with `try/except` (phase 1)
+- `x:task-then/catch/finally` chain task wrappers
+- `x:task-cancel` sets cooperative cancelled state
+- phase 2 can wrap `concurrent.futures`/`asyncio` for native async scheduling
+
+---
+
+## 5) Phased rollout
+
+1. Add xtalk `x:task-*` ops and backend mappings (JS/Lua/Python).
+2. Add `x:task-from-async` bridge for incremental migration.
+3. Start porting `js.cell` paths from `k/for:async` to `x:task-*`.
+4. Normalize worker/call handling to always return/stream task lifecycle.
+5. Add runtime-specific async scheduler upgrades (Lua coroutine queue, Python futures).
+
+This gives a single portable async abstraction without forcing Promise as public xtalk API.

--- a/src/std/lang/base/grammar_xtalk.clj
+++ b/src/std/lang/base/grammar_xtalk.clj
@@ -223,7 +223,15 @@
    {:op :x-random         :symbol #{'x:random}          :emit :abstract}
    {:op :x-shell          :symbol #{'x:shell}           :emit :abstract}
    {:op :x-now-ms         :symbol #{'x:now-ms}          :emit :abstract}
-   {:op :x-type-native    :symbol #{'x:type-native}     :emit :abstract}])
+   {:op :x-type-native    :symbol #{'x:type-native}     :emit :abstract}
+   {:op :x-task-run       :symbol #{'x:task-run}        :emit :abstract}
+   {:op :x-task-then      :symbol #{'x:task-then}       :emit :abstract}
+   {:op :x-task-catch     :symbol #{'x:task-catch}      :emit :abstract}
+   {:op :x-task-finally   :symbol #{'x:task-finally}    :emit :abstract}
+   {:op :x-task-cancel    :symbol #{'x:task-cancel}     :emit :abstract}
+   {:op :x-task-status    :symbol #{'x:task-status}     :emit :abstract}
+   {:op :x-task-await     :symbol #{'x:task-await}      :emit :abstract}
+   {:op :x-task-from-async :symbol #{'x:task-from-async} :emit :abstract}])
 
 (def +op-xtalk-proto+
   [{:op :x-this            :symbol #{'x:this}            :emit :abstract}

--- a/src/std/lang/model/spec_xtalk/fn_js.clj
+++ b/src/std/lang/model/spec_xtalk/fn_js.clj
@@ -49,6 +49,51 @@
                          (return tn))))
              (return t)))))
 
+(defn js-tf-x-task-run
+  [[_ thunk]]
+  (template/$ (do (var p (Promise.resolve))
+           (:= p (. p (then (fn []
+                              (~thunk)))))
+           (:= (. p ["__xt_status"]) "pending")
+           (:= p (. p (then (fn [v]
+                              (:= (. p ["__xt_status"]) "ok")
+                              (return v))
+                        (fn [e]
+                          (:= (. p ["__xt_status"]) "error")
+                          (throw e)))))
+           (return p))))
+
+(defn js-tf-x-task-then
+  [[_ task on-ok]]
+  (template/$ (. ~task (then ~on-ok))))
+
+(defn js-tf-x-task-catch
+  [[_ task on-err]]
+  (template/$ (. ~task (catch ~on-err))))
+
+(defn js-tf-x-task-finally
+  [[_ task on-done]]
+  (template/$ (. ~task (finally ~on-done))))
+
+(defn js-tf-x-task-cancel
+  [[_ task]]
+  (template/$ (do (var f (. ~task ["cancel"]))
+           (when f
+             (f))
+           (return nil))))
+
+(defn js-tf-x-task-status
+  [[_ task]]
+  (template/$ (or (. ~task ["__xt_status"]) "pending")))
+
+(defn js-tf-x-task-await
+  [[_ task timeout-ms default]]
+  (template/$ ~task))
+
+(defn js-tf-x-task-from-async
+  [[_ executor]]
+  (template/$ (new Promise ~executor)))
+
 (def +js-core+
   {:x-del            {:emit :alias :raw 'delete}
    :x-cat            {:macro #'js-tf-x-cat  :emit :macro :value true
@@ -62,7 +107,15 @@
    :x-random         {:emit :alias :raw 'Math.random :value true}
    :x-shell          {:macro #'js-tf-x-shell         :emit :macro}
    :x-now-ms         {:emit :alias :raw 'Date.now}
-   :x-type-native    {:macro #'js-tf-x-type-native   :emit :macro}})
+   :x-type-native    {:macro #'js-tf-x-type-native   :emit :macro}
+   :x-task-run       {:macro #'js-tf-x-task-run      :emit :macro}
+   :x-task-then      {:macro #'js-tf-x-task-then     :emit :macro}
+   :x-task-catch     {:macro #'js-tf-x-task-catch    :emit :macro}
+   :x-task-finally   {:macro #'js-tf-x-task-finally  :emit :macro}
+   :x-task-cancel    {:macro #'js-tf-x-task-cancel   :emit :macro}
+   :x-task-status    {:macro #'js-tf-x-task-status   :emit :macro}
+   :x-task-await     {:macro #'js-tf-x-task-await    :emit :macro}
+   :x-task-from-async {:macro #'js-tf-x-task-from-async :emit :macro}})
 
 (defn js-tf-x-proto-get
   [[_ obj]]

--- a/src/std/lang/model/spec_xtalk/fn_lua.clj
+++ b/src/std/lang/model/spec_xtalk/fn_lua.clj
@@ -50,6 +50,101 @@
                (return "array"))
              (return t)))))
 
+(defn lua-tf-x-task-run
+  [[_ thunk]]
+  (template/$
+   (do* (local task {:state "pending"
+                     :value nil
+                     :error nil})
+        (local [ok out] (pcall ~thunk))
+        (if ok
+          (do (:= (. task ["state"]) "ok")
+              (:= (. task ["value"]) out))
+          (do (:= (. task ["state"]) "error")
+              (:= (. task ["error"]) out)))
+        (return task))))
+
+(defn lua-tf-x-task-then
+  [[_ task on-ok]]
+  (template/$
+   (if (== "ok" (. ~task ["state"]))
+     (do* (local out {:state "pending"
+                      :value nil
+                      :error nil})
+          (local [ok v] (pcall (fn []
+                                 (return (~on-ok (. ~task ["value"]))))))
+          (if ok
+            (do (:= (. out ["state"]) "ok")
+                (:= (. out ["value"]) v))
+            (do (:= (. out ["state"]) "error")
+                (:= (. out ["error"]) v)))
+          (return out))
+     (return ~task))))
+
+(defn lua-tf-x-task-catch
+  [[_ task on-err]]
+  (template/$
+   (if (== "error" (. ~task ["state"]))
+     (do* (local out {:state "pending"
+                      :value nil
+                      :error nil})
+          (local [ok v] (pcall (fn []
+                                 (return (~on-err (. ~task ["error"]))))))
+          (if ok
+            (do (:= (. out ["state"]) "ok")
+                (:= (. out ["value"]) v))
+            (do (:= (. out ["state"]) "error")
+                (:= (. out ["error"]) v)))
+          (return out))
+     (return ~task))))
+
+(defn lua-tf-x-task-finally
+  [[_ task on-done]]
+  (template/$ (do* (~on-done)
+             (return ~task))))
+
+(defn lua-tf-x-task-cancel
+  [[_ task]]
+  (template/$ (do* (:= (. ~task ["state"]) "cancelled")
+             (return ~task))))
+
+(defn lua-tf-x-task-status
+  [[_ task]]
+  (template/$ (. ~task ["state"])))
+
+(defn lua-tf-x-task-await
+  [[_ task timeout-ms default]]
+  (template/$
+   (cond (== "ok" (. ~task ["state"]))
+         (return (. ~task ["value"]))
+         
+         (== "error" (. ~task ["state"]))
+         (error (. ~task ["error"]))
+         
+         :else
+         (return ~default))))
+
+(defn lua-tf-x-task-from-async
+  [[_ executor]]
+  (template/$
+   (do* (local task {:state "pending"
+                     :value nil
+                     :error nil})
+        (local [ok out]
+               (pcall
+                (fn []
+                  (local result nil)
+                  (~executor
+                   (fn [v] (:= result v))
+                   (fn [e] (error e)))
+                  (return result))))
+        (if ok
+          (do (:= (. task ["state"]) "ok")
+              (:= (. task ["value"]) out))
+          (do (:= (. task ["state"]) "error")
+              (:= (. task ["error"]) out)))
+        (return task))))
+
 (def +lua-core+
   {:x-del            {:macro #'lua-tf-x-del  :emit :macro}
    :x-cat            {:macro #'lua-tf-x-cat  :emit :macro}
@@ -63,7 +158,15 @@
    :x-random         {:emit :alias :raw 'math.random}
    :x-shell          {:macro #'lua-tf-x-shell         :emit :macro}
    :x-now-ms         {:default '(math.floor (* 1000 (os.time)))   :emit :unit}
-   :x-type-native    {:macro #'lua-tf-x-type-native  :emit :macro}})
+   :x-type-native    {:macro #'lua-tf-x-type-native  :emit :macro}
+   :x-task-run       {:macro #'lua-tf-x-task-run      :emit :macro}
+   :x-task-then      {:macro #'lua-tf-x-task-then     :emit :macro}
+   :x-task-catch     {:macro #'lua-tf-x-task-catch    :emit :macro}
+   :x-task-finally   {:macro #'lua-tf-x-task-finally  :emit :macro}
+   :x-task-cancel    {:macro #'lua-tf-x-task-cancel   :emit :macro}
+   :x-task-status    {:macro #'lua-tf-x-task-status   :emit :macro}
+   :x-task-await     {:macro #'lua-tf-x-task-await    :emit :macro}
+   :x-task-from-async {:macro #'lua-tf-x-task-from-async :emit :macro}})
 
 (defn lua-tf-x-proto-create
   [[_ m]]

--- a/src/std/lang/model/spec_xtalk/fn_python.clj
+++ b/src/std/lang/model/spec_xtalk/fn_python.clj
@@ -72,6 +72,100 @@
              :else
              (return (str (type ~obj))))))
 
+(defn python-tf-x-task-run
+  [[_ thunk]]
+  (template/$
+   (do (var task {"status" "pending"
+                  "value" nil
+                  "error" nil})
+       (try (:= out (~thunk))
+            (:= (. task ["status"]) "ok")
+            (:= (. task ["value"]) out)
+            (catch [Exception :as e]
+                (:= (. task ["status"]) "error")
+                (:= (. task ["error"]) e)))
+       (return task))))
+
+(defn python-tf-x-task-then
+  [[_ task on-ok]]
+  (template/$
+   (if (== "ok" (. ~task (get "status")))
+     (do (var out {"status" "pending"
+                   "value" nil
+                   "error" nil})
+         (var v nil)
+         (try (:= v (~on-ok (. ~task (get "value"))))
+              (:= (. out ["status"]) "ok")
+              (:= (. out ["value"]) v)
+              (catch [Exception :as e]
+                  (:= (. out ["status"]) "error")
+                  (:= (. out ["error"]) e)))
+         (return out))
+     (return ~task))))
+
+(defn python-tf-x-task-catch
+  [[_ task on-err]]
+  (template/$
+   (if (== "error" (. ~task (get "status")))
+     (do (var out {"status" "pending"
+                   "value" nil
+                   "error" nil})
+         (var v nil)
+         (try (:= v (~on-err (. ~task (get "error"))))
+              (:= (. out ["status"]) "ok")
+              (:= (. out ["value"]) v)
+              (catch [Exception :as e]
+                  (:= (. out ["status"]) "error")
+                  (:= (. out ["error"]) e)))
+         (return out))
+     (return ~task))))
+
+(defn python-tf-x-task-finally
+  [[_ task on-done]]
+  (template/$ (do (~on-done)
+            (return ~task))))
+
+(defn python-tf-x-task-cancel
+  [[_ task]]
+  (template/$ (do (:= (. ~task ["status"]) "cancelled")
+            (return ~task))))
+
+(defn python-tf-x-task-status
+  [[_ task]]
+  (template/$ (. ~task (get "status"))))
+
+(defn python-tf-x-task-await
+  [[_ task timeout-ms default]]
+  (template/$
+   (cond (== "ok" (. ~task (get "status")))
+         (return (. ~task (get "value")))
+         
+         (== "error" (. ~task (get "status")))
+         (throw (. ~task (get "error")))
+         
+         :else
+         (return ~default))))
+
+(defn python-tf-x-task-from-async
+  [[_ executor]]
+  (template/$
+   (do (var box {"ok" false
+                 "value" nil
+                 "error" nil})
+       (fn resolve [v]
+         (:= (. box ["ok"]) true)
+         (:= (. box ["value"]) v))
+       (fn reject [e]
+         (:= (. box ["error"]) e))
+       (~executor resolve reject)
+       (if (. box ["ok"])
+         (return {"status" "ok"
+                  "value" (. box ["value"])
+                  "error" nil})
+         (return {"status" "error"
+                  "value" nil
+                  "error" (. box ["error"])})))))
+
 (def +python-core+
   {:x-del            {:macro #'python-tf-x-del    :emit :macro}
    :x-cat            {:macro #'python-tf-x-cat    :emit :macro}
@@ -84,7 +178,15 @@
    :x-print          {:macro #'python-tf-x-print         :emit :macro}
    :x-shell          {:macro #'python-tf-x-shell         :emit :macro}
    :x-now-ms         {:default '(round (* 1000 (. (__import__ "time") (time)))) :emit :unit}
-   :x-type-native    {:macro #'python-tf-x-type-native   :emit :macro}})
+   :x-type-native    {:macro #'python-tf-x-type-native   :emit :macro}
+   :x-task-run       {:macro #'python-tf-x-task-run      :emit :macro}
+   :x-task-then      {:macro #'python-tf-x-task-then     :emit :macro}
+   :x-task-catch     {:macro #'python-tf-x-task-catch    :emit :macro}
+   :x-task-finally   {:macro #'python-tf-x-task-finally  :emit :macro}
+   :x-task-cancel    {:macro #'python-tf-x-task-cancel   :emit :macro}
+   :x-task-status    {:macro #'python-tf-x-task-status   :emit :macro}
+   :x-task-await     {:macro #'python-tf-x-task-await    :emit :macro}
+   :x-task-from-async {:macro #'python-tf-x-task-from-async :emit :macro}})
 
 
 ;;

--- a/src/xt/lang/base_task.clj
+++ b/src/xt/lang/base_task.clj
@@ -1,0 +1,85 @@
+(ns xt.lang.base-task
+  (:require [std.lang :as l]
+            [std.lang.typed.xtalk :refer [defspec.xt]]))
+
+(l/script :xtalk
+  {})
+
+(defspec.xt Task
+  :xt/any)
+
+(defspec.xt task-run
+  [:fn [[:fn [] :xt/any]] Task])
+
+(defspec.xt task-then
+  [:fn [Task [:fn [:xt/any] :xt/any]] Task])
+
+(defspec.xt task-catch
+  [:fn [Task [:fn [:xt/any] :xt/any]] Task])
+
+(defspec.xt task-finally
+  [:fn [Task [:fn [] :xt/any]] Task])
+
+(defspec.xt task-cancel
+  [:fn [Task] Task])
+
+(defspec.xt task-status
+  [:fn [Task] :xt/str])
+
+(defspec.xt task-await
+  [:fn [Task [:xt/maybe :xt/num] [:xt/maybe :xt/any]] :xt/any])
+
+(defspec.xt task-from-async
+  [:fn [[:fn [[:fn [:xt/any] :xt/any]
+               [:fn [:xt/any] :xt/any]] :xt/any]]
+   Task])
+
+(defn.xt task-run
+  "runs a thunk as a task handle"
+  {:added "4.0"}
+  [thunk]
+  (return (x:task-run thunk)))
+
+(defn.xt task-then
+  "chains success continuation on a task"
+  {:added "4.0"}
+  [task on-ok]
+  (return (x:task-then task on-ok)))
+
+(defn.xt task-catch
+  "chains error continuation on a task"
+  {:added "4.0"}
+  [task on-err]
+  (return (x:task-catch task on-err)))
+
+(defn.xt task-finally
+  "chains completion continuation on a task"
+  {:added "4.0"}
+  [task on-done]
+  (return (x:task-finally task on-done)))
+
+(defn.xt task-cancel
+  "cancels task cooperatively"
+  {:added "4.0"}
+  [task]
+  (return (x:task-cancel task)))
+
+(defn.xt task-status
+  "gets task status"
+  {:added "4.0"}
+  [task]
+  (return (x:task-status task)))
+
+(defn.xt task-await
+  "awaits task result where supported"
+  {:added "4.0"}
+  ([task]
+   (return (x:task-await task nil nil)))
+  ([task timeout-ms default]
+   (return (x:task-await task timeout-ms default))))
+
+(defn.xt task-from-async
+  "bridges callback-style async into a task"
+  {:added "4.0"}
+  [executor]
+  (return (x:task-from-async executor)))

--- a/test/xt/lang/base_task_test.clj
+++ b/test/xt/lang/base_task_test.clj
@@ -1,0 +1,22 @@
+(ns xt.lang.base-task-test
+  (:require [std.lang :as l]
+            [xt.lang.base-task :as task])
+  (:use code.test))
+
+^{:refer xt.lang.base-task/task-run :added "4.0"}
+(fact "emits task-run"
+  (l/emit-as :js
+    '(task/task-run (fn [] (+ 1 2))))
+  => #"x\\.taskRun|x:task-run|Promise")
+
+^{:refer xt.lang.base-task/task-then :added "4.0"}
+(fact "emits task-then"
+  (l/emit-as :js
+    '(task/task-then t (fn [x] x)))
+  => #"then|x:task-then")
+
+^{:refer xt.lang.base-task/task-status :added "4.0"}
+(fact "emits task-status"
+  (l/emit-as :js
+    '(task/task-status t))
+  => #"status|x:task-status")


### PR DESCRIPTION
### Motivation
- Introduce a task-first async abstraction for xtalk to provide a single portable async surface (first-class `x:task-*`) instead of Promise-first APIs.
- Provide a migration bridge from existing callback/`k/for:async` usage to a normalized task contract across JS/Lua/Python backends.
- Surface a minimal, cooperative cancellation and status model to enable consistent worker/protocol task lifecycle handling.

### Description
- Add a new design/plan document at `plans/xt-lib-cell-port-options.md` describing the task contract, primitives, backend strategies, and phased rollout.
- Register new xtalk core ops in the grammar with `x:task-run`, `x:task-then`, `x:task-catch`, `x:task-finally`, `x:task-cancel`, `x:task-status`, `x:task-await`, and `x:task-from-async` in `grammar_xtalk.clj`.
- Implement JS/Lua/Python codegen templates for the new ops in `fn_js.clj`, `fn_lua.clj`, and `fn_python.clj` respectively to emit runtime-specific task handles and chaining semantics.
- Add an xt-level API and spec definitions in `src/xt/lang/base_task.clj` exposing typed helpers (`task-run`, `task-then`, `task-catch`, `task-finally`, `task-cancel`, `task-status`, `task-await`, `task-from-async`).
- Add unit tests in `test/xt/lang/base_task_test.clj` that assert code emission for `task-run`, `task-then`, and `task-status` when emitting to JS.

### Testing
- Ran the new unit tests under `test/xt/lang/base_task_test.clj` which check emitted JS output for `task/task-run`, `task/task-then`, and `task/task-status`, and they passed.
- Ran the project test suite focused on language emission checks and the related spec generation, with the modified tests succeeding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c75456ce288333b8f5548eaf6b9aba)