### PR TITLE
Fix optional typing for x:str-substring

### DIFF
--- a/src/std/lang/base/grammar_xtalk.clj
+++ b/src/std/lang/base/grammar_xtalk.clj
@@ -643,7 +643,7 @@
     :op-spec    {:type [:fn [:xt/str :xt/str :xt/num] :xt/str]
                  :arglists '([value pattern] [value pattern from])}}
    {:op :x-str-substring   :symbol #{'x:str-substring}   :emit :abstract
-    :op-spec    {:type [:fn [:xt/str :xt/num :xt/num] :xt/str]
+    :op-spec    {:type [:fn [:xt/str :xt/num [:xt/maybe :xt/num]] :xt/str]
                  :arglists '([value start] [value start len])}}
    {:op :x-str-to-upper    :symbol #{'x:str-to-upper}    :emit :abstract
     :op-spec     {:arglists '([value])

--- a/src/xt/lang/spec_base.clj
+++ b/src/xt/lang/spec_base.clj
@@ -886,7 +886,7 @@
   ([value pattern] (list (quote x:str-index-of) value pattern)) 
   ([value pattern from] (list (quote x:str-index-of) value pattern from)))
 
-(defspec.xt x:str-substring [:fn [:xt/str :xt/num :xt/num] :xt/str])
+(defspec.xt x:str-substring [:fn [:xt/str :xt/num [:xt/maybe :xt/num]] :xt/str])
 
 (defmacro.xt ^{:standalone true :is-template false} 
   x:str-substring

--- a/test/std/lang/model/spec_xtalk_optional_test.clj
+++ b/test/std/lang/model/spec_xtalk_optional_test.clj
@@ -1,0 +1,13 @@
+(ns std.lang.model.spec-xtalk-optional-test
+  (:require [std.lang :as l]
+            [std.lang.model.spec-xtalk.fn-js :refer [js-tf-x-str-substring]]
+            [std.lang.model.spec-xtalk.fn-python :refer [python-tf-x-str-substring]])
+  (:use code.test))
+
+(fact "js substring emits open-ended ranges"
+  (l/emit-as :js [(js-tf-x-str-substring '[_ s 0])])
+  => "s.substring(0)")
+
+(fact "python substring emits open-ended slices"
+  (l/emit-as :python [(python-tf-x-str-substring '[_ s 0])])
+  => "s[(0 - 0):]")

--- a/test/std/lang/typed/xtalk_infer_test.clj
+++ b/test/std/lang/typed/xtalk_infer_test.clj
@@ -446,6 +446,19 @@
                                                      :ns 'sample.route :aliases {}})))
   => '{:kind :primitive :name :xt/str})
 
+^{:refer std.lang.typed.xtalk-infer/infer-type :added "4.1"}
+(fact "infers builtin substring with optional finish"
+  [(types/type->data (:type (infer-type '(x:str-substring value 3)
+                                        {:env '{value {:kind :primitive :name :xt/str}}
+                                         :ns 'sample.route
+                                         :aliases {}})))
+   (:errors (infer-type '(x:str-substring value 3)
+                        {:env '{value {:kind :primitive :name :xt/str}}
+                         :ns 'sample.route
+                         :aliases {}}))]
+  => '[{:kind :primitive :name :xt/str}
+        []])
+
 ^{:refer std.lang.typed.xtalk-infer/infer-get-path :added "4.1"}
 (fact "infers path access through nested records"
   (types/type->data (:type (infer-get-path '(x:get-path route ["user" "id"] nil)


### PR DESCRIPTION
Summary
- align x:str-substring's builtin type with its existing two-arity surface by making the finish argument optional
- update xtalk grammar metadata so typed inference and emitter checks accept the open-ended substring form
- add focused regressions for builtin inference plus JS/Python emission of the 2-arg substring form

Validation
- ./lein run -m code.test :only std.lang.typed.xtalk-infer-test
- ./lein run -m code.test :only std.lang.model.spec-xtalk-optional-test
- ./lein run -m code.test :only xt.lang.common-string-test