### PR TITLE
Add walkthrough docs for concurrent, JVM, and integration libraries

### DIFF
--- a/config/publish/std.edn
+++ b/config/publish/std.edn
@@ -1,167 +1,71 @@
-{:theme    "foundation"
- :output   "public/std"
- :pages    {index
-            {:base  "home.html"
-             :input "src-doc/documentation/std/std_index.clj"
-             :title "std"
-             :subtitle "standard libraries for foundation"}
+{:theme "foundation"
+ :output "public/std"
+ :pages
+ {index {:base "home.html" :input "src-doc/documentation/std/std_index.clj" :title "std" :subtitle "standard libraries for foundation"}
 
-            std-concurrent
-            {:input "src-doc/documentation/std/std_concurrent.clj"
-             :title "std.concurrent"
-             :subtitle "concurrency primitives"}
+  std-concurrent {:input "src-doc/documentation/std/std_concurrent.clj" :title "std.concurrent" :subtitle "concurrency primitives"}
+  std-concurrent-atom {:input "src-doc/documentation/std/std_concurrent_atom.clj" :title "std.concurrent.atom" :subtitle "batched atom queues"}
+  std-concurrent-bus {:input "src-doc/documentation/std/std_concurrent_bus.clj" :title "std.concurrent.bus" :subtitle "thread message bus"}
+  std-concurrent-executor {:input "src-doc/documentation/std/std_concurrent_executor.clj" :title "std.concurrent.executor" :subtitle "executors and scheduling"}
+  std-concurrent-pool {:input "src-doc/documentation/std/std_concurrent_pool.clj" :title "std.concurrent.pool" :subtitle "reusable resource pools"}
+  std-concurrent-print {:input "src-doc/documentation/std/std_concurrent_print.clj" :title "std.concurrent.print" :subtitle "serialized concurrent output"}
+  std-concurrent-queue {:input "src-doc/documentation/std/std_concurrent_queue.clj" :title "std.concurrent.queue" :subtitle "blocking queues and deques"}
+  std-concurrent-relay {:input "src-doc/documentation/std/std_concurrent_relay.clj" :title "std.concurrent.relay" :subtitle "interactive streams"}
+  std-concurrent-request {:input "src-doc/documentation/std/std_concurrent_request.clj" :title "std.concurrent.request" :subtitle "request orchestration"}
+  std-concurrent-request-apply {:input "src-doc/documentation/std/std_concurrent_request_apply.clj" :title "std.concurrent.request-apply" :subtitle "request applicatives"}
+  std-concurrent-request-command {:input "src-doc/documentation/std/std_concurrent_request_command.clj" :title "std.concurrent.request-command" :subtitle "request command templates"}
+  std-concurrent-thread {:input "src-doc/documentation/std/std_concurrent_thread.clj" :title "std.concurrent.thread" :subtitle "thread utilities"}
 
-            std-dispatch
-            {:input "src-doc/documentation/std/std_dispatch.clj"
-             :title "std.dispatch"
-             :subtitle "dispatch boards, hubs, and queues"}
+  std-dispatch {:input "src-doc/documentation/std/std_dispatch.clj" :title "std.dispatch" :subtitle "dispatch boards, hubs, and queues"}
+  std-fs {:input "src-doc/documentation/std/std_fs.clj" :title "std.fs" :subtitle "filesystem paths and operations"}
+  std-scheduler {:input "src-doc/documentation/std/std_scheduler.clj" :title "std.scheduler" :subtitle "scheduled task runners"}
+  std-string {:input "src-doc/documentation/std/std_string.clj" :title "std.string" :subtitle "string utilities"}
+  std-task {:input "src-doc/documentation/std/std_task.clj" :title "std.task" :subtitle "task execution"}
+  std-time {:input "src-doc/documentation/std/std_time.clj" :title "std.time" :subtitle "time utilities"}
+  std-timeseries {:input "src-doc/documentation/std/std_timeseries.clj" :title "std.timeseries" :subtitle "time-series journals"}
+  std-block {:input "src-doc/documentation/std/std_block.clj" :title "std.block" :subtitle "code representation"}
 
-            std-fs
-            {:input "src-doc/documentation/std/std_fs.clj"
-             :title "std.fs"
-             :subtitle "filesystem paths and operations"}
+  jvm-artifact {:input "src-doc/documentation/std/jvm_artifact.clj" :title "jvm.artifact" :subtitle "artifact coordinates and paths"}
+  jvm-classloader {:input "src-doc/documentation/std/jvm_classloader.clj" :title "jvm.classloader" :subtitle "classpath and classloaders"}
+  jvm-deps {:input "src-doc/documentation/std/jvm_deps.clj" :title "jvm.deps" :subtitle "JVM dependency resolution"}
+  jvm-monitor {:input "src-doc/documentation/std/jvm_monitor.clj" :title "jvm.monitor" :subtitle "JVM metrics"}
+  jvm-namespace {:input "src-doc/documentation/std/jvm_namespace.clj" :title "jvm.namespace" :subtitle "namespace management"}
+  jvm-protocol {:input "src-doc/documentation/std/jvm_protocol.clj" :title "jvm.protocol" :subtitle "JVM extension protocols"}
+  jvm-reflect {:input "src-doc/documentation/std/jvm_reflect.clj" :title "jvm.reflect" :subtitle "Java reflection"}
+  jvm-require {:input "src-doc/documentation/std/jvm_require.clj" :title "jvm.require" :subtitle "dependency-aware requiring"}
+  jvm-tool {:input "src-doc/documentation/std/jvm_tool.clj" :title "jvm.tool" :subtitle "REPL development tools"}
 
-            std-scheduler
-            {:input "src-doc/documentation/std/std_scheduler.clj"
-             :title "std.scheduler"
-             :subtitle "scheduled task runners"}
+  lib-aether {:input "src-doc/documentation/std/lib_aether.clj" :title "lib.aether" :subtitle "Maven repository integration"}
+  lib-docker {:input "src-doc/documentation/std/lib_docker.clj" :title "lib.docker" :subtitle "container lifecycle helpers"}
+  lib-jdbc {:input "src-doc/documentation/std/lib_jdbc.clj" :title "lib.jdbc" :subtitle "JDBC database access"}
+  lib-lucene {:input "src-doc/documentation/std/lib_lucene.clj" :title "lib.lucene" :subtitle "Lucene search engines"}
+  lib-minio {:input "src-doc/documentation/std/lib_minio.clj" :title "lib.minio" :subtitle "local MinIO environments"}
+  lib-openpgp {:input "src-doc/documentation/std/lib_openpgp.clj" :title "lib.openpgp" :subtitle "OpenPGP operations"}
+  lib-oshi {:input "src-doc/documentation/std/lib_oshi.clj" :title "lib.oshi" :subtitle "system information"}
+  lib-postgres {:input "src-doc/documentation/std/lib_postgres.clj" :title "lib.postgres" :subtitle "PostgreSQL lifecycle"}
+  lib-rabbitmq {:input "src-doc/documentation/std/lib_rabbitmq.clj" :title "lib.rabbitmq" :subtitle "RabbitMQ management"}
+  lib-redis {:input "src-doc/documentation/std/lib_redis.clj" :title "lib.redis" :subtitle "Redis client lifecycle"}
 
-            std-string
-            {:input "src-doc/documentation/std/std_string.clj"
-             :title "std.string"
-             :subtitle "string utilities"}
-
-            std-task
-            {:input "src-doc/documentation/std/std_task.clj"
-             :title "std.task"
-             :subtitle "task execution"}
-
-            std-time
-            {:input "src-doc/documentation/std/std_time.clj"
-             :title "std.time"
-             :subtitle "time utilities"}
-
-            std-timeseries
-            {:input "src-doc/documentation/std/std_timeseries.clj"
-             :title "std.timeseries"
-             :subtitle "time-series journals"}
-
-            std-block
-            {:input "src-doc/documentation/std/std_block.clj"
-             :title "std.block"
-             :subtitle "code representation"}
-
-            std-lib-apply
-            {:input "src-doc/documentation/std/std_lib_apply.clj"
-             :title "std.lib.apply"
-             :subtitle "applicative invocation"}
-
-            std-lib-atom
-            {:input "src-doc/documentation/std/std_lib_atom.clj"
-             :title "std.lib.atom"
-             :subtitle "enhanced atom operations"}
-
-            std-lib-bin
-            {:input "src-doc/documentation/std/std_lib_bin.clj"
-             :title "std.lib.bin"
-             :subtitle "binary data utilities"}
-
-            std-lib-class
-            {:input "src-doc/documentation/std/std_lib_class.clj"
-             :title "std.lib.class"
-             :subtitle "class and reflection helpers"}
-
-            std-lib-collection
-            {:input "src-doc/documentation/std/std_lib_collection.clj"
-             :title "std.lib.collection"
-             :subtitle "collection utilities"}
-
-            std-lib-component
-            {:input "src-doc/documentation/std/std_lib_component.clj"
-             :title "std.lib.component"
-             :subtitle "component lifecycle utilities"}
-
-            std-lib-encode
-            {:input "src-doc/documentation/std/std_lib_encode.clj"
-             :title "std.lib.encode"
-             :subtitle "encoding utilities"}
-
-            std-lib-enum
-            {:input "src-doc/documentation/std/std_lib_enum.clj"
-             :title "std.lib.enum"
-             :subtitle "enum utilities"}
-
-            std-lib-env
-            {:input "src-doc/documentation/std/std_lib_env.clj"
-             :title "std.lib.env"
-             :subtitle "environment and system utilities"}
-
-            std-lib-foundation
-            {:input "src-doc/documentation/std/std_lib_foundation.clj"
-             :title "std.lib.foundation"
-             :subtitle "basic functionality for foundation"}
-
-            std-lib-future
-            {:input "src-doc/documentation/std/std_lib_future.clj"
-             :title "std.lib.future"
-             :subtitle "future and async helpers"}
-
-            std-lib-io
-            {:input "src-doc/documentation/std/std_lib_io.clj"
-             :title "std.lib.io"
-             :subtitle "I/O utilities"}
-
-            std-lib-network
-            {:input "src-doc/documentation/std/std_lib_network.clj"
-             :title "std.lib.network"
-             :subtitle "network utilities"}
-
-            std-lib-resource
-            {:input "src-doc/documentation/std/std_lib_resource.clj"
-             :title "std.lib.resource"
-             :subtitle "resource loading utilities"}
-
-            std-lib-schema
-            {:input "src-doc/documentation/std/std_lib_schema.clj"
-             :title "std.lib.schema"
-             :subtitle "schema utilities"}
-
-            std-lib-security
-            {:input "src-doc/documentation/std/std_lib_security.clj"
-             :title "std.lib.security"
-             :subtitle "security utilities"}
-
-            std-lib-sort
-            {:input "src-doc/documentation/std/std_lib_sort.clj"
-             :title "std.lib.sort"
-             :subtitle "sorting utilities"}
-
-            std-lib-stream
-            {:input "src-doc/documentation/std/std_lib_stream.clj"
-             :title "std.lib.stream"
-             :subtitle "streams and transducers"}
-
-            std-lib-system
-            {:input "src-doc/documentation/std/std_lib_system.clj"
-             :title "std.lib.system"
-             :subtitle "system composition utilities"}
-
-            std-lib-time
-            {:input "src-doc/documentation/std/std_lib_time.clj"
-             :title "std.lib.time"
-             :subtitle "time utilities"}
-
-            std-lib-transform
-            {:input "src-doc/documentation/std/std_lib_transform.clj"
-             :title "std.lib.transform"
-             :subtitle "data transform utilities"}
-
-            std-lib-walk
-            {:input "src-doc/documentation/std/std_lib_walk.clj"
-             :title "std.lib.walk"
-             :subtitle "walk and traversal utilities"}
-
-            std-lib-zip
-            {:input "src-doc/documentation/std/std_lib_zip.clj"
-             :title "std.lib.zip"
-             :subtitle "zipper utilities"}}}
+  std-lib-apply {:input "src-doc/documentation/std/std_lib_apply.clj" :title "std.lib.apply" :subtitle "applicative invocation"}
+  std-lib-atom {:input "src-doc/documentation/std/std_lib_atom.clj" :title "std.lib.atom" :subtitle "enhanced atom operations"}
+  std-lib-bin {:input "src-doc/documentation/std/std_lib_bin.clj" :title "std.lib.bin" :subtitle "binary data utilities"}
+  std-lib-class {:input "src-doc/documentation/std/std_lib_class.clj" :title "std.lib.class" :subtitle "class and reflection helpers"}
+  std-lib-collection {:input "src-doc/documentation/std/std_lib_collection.clj" :title "std.lib.collection" :subtitle "collection utilities"}
+  std-lib-component {:input "src-doc/documentation/std/std_lib_component.clj" :title "std.lib.component" :subtitle "component lifecycle utilities"}
+  std-lib-encode {:input "src-doc/documentation/std/std_lib_encode.clj" :title "std.lib.encode" :subtitle "encoding utilities"}
+  std-lib-enum {:input "src-doc/documentation/std/std_lib_enum.clj" :title "std.lib.enum" :subtitle "enum utilities"}
+  std-lib-env {:input "src-doc/documentation/std/std_lib_env.clj" :title "std.lib.env" :subtitle "environment and system utilities"}
+  std-lib-foundation {:input "src-doc/documentation/std/std_lib_foundation.clj" :title "std.lib.foundation" :subtitle "basic functionality for foundation"}
+  std-lib-future {:input "src-doc/documentation/std/std_lib_future.clj" :title "std.lib.future" :subtitle "future and async helpers"}
+  std-lib-io {:input "src-doc/documentation/std/std_lib_io.clj" :title "std.lib.io" :subtitle "I/O utilities"}
+  std-lib-network {:input "src-doc/documentation/std/std_lib_network.clj" :title "std.lib.network" :subtitle "network utilities"}
+  std-lib-resource {:input "src-doc/documentation/std/std_lib_resource.clj" :title "std.lib.resource" :subtitle "resource loading utilities"}
+  std-lib-schema {:input "src-doc/documentation/std/std_lib_schema.clj" :title "std.lib.schema" :subtitle "schema utilities"}
+  std-lib-security {:input "src-doc/documentation/std/std_lib_security.clj" :title "std.lib.security" :subtitle "security utilities"}
+  std-lib-sort {:input "src-doc/documentation/std/std_lib_sort.clj" :title "std.lib.sort" :subtitle "sorting utilities"}
+  std-lib-stream {:input "src-doc/documentation/std/std_lib_stream.clj" :title "std.lib.stream" :subtitle "streams and transducers"}
+  std-lib-system {:input "src-doc/documentation/std/std_lib_system.clj" :title "std.lib.system" :subtitle "system composition utilities"}
+  std-lib-time {:input "src-doc/documentation/std/std_lib_time.clj" :title "std.lib.time" :subtitle "time utilities"}
+  std-lib-transform {:input "src-doc/documentation/std/std_lib_transform.clj" :title "std.lib.transform" :subtitle "data transform utilities"}
+  std-lib-walk {:input "src-doc/documentation/std/std_lib_walk.clj" :title "std.lib.walk" :subtitle "walk and traversal utilities"}
+  std-lib-zip {:input "src-doc/documentation/std/std_lib_zip.clj" :title "std.lib.zip" :subtitle "zipper utilities"}}}

--- a/config/publish/std.edn
+++ b/config/publish/std.edn
@@ -25,6 +25,7 @@
   std-timeseries {:input "src-doc/documentation/std/std_timeseries.clj" :title "std.timeseries" :subtitle "time-series journals"}
   std-block {:input "src-doc/documentation/std/std_block.clj" :title "std.block" :subtitle "code representation"}
 
+  jvm-index {:input "src-doc/documentation/std/jvm_index.clj" :title "jvm.*" :subtitle "JVM libraries"}
   jvm-artifact {:input "src-doc/documentation/std/jvm_artifact.clj" :title "jvm.artifact" :subtitle "artifact coordinates and paths"}
   jvm-classloader {:input "src-doc/documentation/std/jvm_classloader.clj" :title "jvm.classloader" :subtitle "classpath and classloaders"}
   jvm-deps {:input "src-doc/documentation/std/jvm_deps.clj" :title "jvm.deps" :subtitle "JVM dependency resolution"}
@@ -35,6 +36,7 @@
   jvm-require {:input "src-doc/documentation/std/jvm_require.clj" :title "jvm.require" :subtitle "dependency-aware requiring"}
   jvm-tool {:input "src-doc/documentation/std/jvm_tool.clj" :title "jvm.tool" :subtitle "REPL development tools"}
 
+  lib-index {:input "src-doc/documentation/std/lib_index.clj" :title "lib.*" :subtitle "integration libraries"}
   lib-aether {:input "src-doc/documentation/std/lib_aether.clj" :title "lib.aether" :subtitle "Maven repository integration"}
   lib-docker {:input "src-doc/documentation/std/lib_docker.clj" :title "lib.docker" :subtitle "container lifecycle helpers"}
   lib-jdbc {:input "src-doc/documentation/std/lib_jdbc.clj" :title "lib.jdbc" :subtitle "JDBC database access"}

--- a/src-doc/documentation/std/jvm_artifact.clj
+++ b/src-doc/documentation/std/jvm_artifact.clj
@@ -1,0 +1,45 @@
+(ns documentation.jvm-artifact
+  (:use code.test))
+
+[[:hero {:title "jvm.artifact"
+         :subtitle "Maven coordinates, repository paths, and artifact representations"
+         :lead "Normalize dependency coordinates and convert them between records, vectors, strings, paths, files, and repository metadata."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"`jvm.artifact` centers on the `Rep` record. A representation stores group, artifact, extension, classifier, version, scope, exclusions, properties, and file information in one value."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Normalize coordinates"}]]
+
+(comment
+  (require '[jvm.artifact :as artifact])
+
+  (def clojure-rep
+    (artifact/rep '[org.clojure/clojure "1.11.1"]))
+
+  (artifact/rep? clojure-rep)
+  (artifact/rep->coord clojure-rep)
+  (artifact/rep->string clojure-rep)
+  (artifact/rep->path clojure-rep))
+
+[[:section {:title "Convert output formats"}]]
+
+"Use `artifact` when the caller chooses an output tag dynamically. Direct conversion functions are clearer when the format is fixed."
+
+(comment
+  (artifact/artifact :string '[org.clojure/clojure "1.11.1"])
+  (artifact/artifact :path "org.clojure:clojure:1.11.1")
+  (artifact/artifact :default '[org.clojure/clojure "1.11.1"]))
+
+[[:chapter {:title "Supporting namespaces" :link "supporting"}]]
+
+"`jvm.artifact.common` contains repository path and resource-entry helpers. `jvm.artifact.search` searches artifact contents and class entries."
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "jvm.artifact"}]]
+[[:api {:namespace "jvm.artifact.common"}]]
+[[:api {:namespace "jvm.artifact.search"}]]

--- a/src-doc/documentation/std/jvm_classloader.clj
+++ b/src-doc/documentation/std/jvm_classloader.clj
@@ -1,0 +1,51 @@
+(ns documentation.jvm-classloader
+  (:use code.test))
+
+[[:hero {:title "jvm.classloader"
+         :subtitle "classpath inspection and dynamic class support"
+         :lead "Inspect classloader delegation, manage classpath URLs, construct loaders, and read classes from supported sources."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"The public namespace adapts system, URL, dynamic, and base classloaders to a shared protocol."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Inspect the current classpath"}]]
+
+(comment
+  (require '[jvm.classloader :as classloader])
+
+  (classloader/classpath)
+  (classloader/all-jars)
+  (classloader/all-paths)
+  (classloader/delegation classloader/+base+))
+
+[[:section {:title "Create a loader"}]]
+
+(comment
+  (def loader
+    (classloader/dynamic-classloader
+     ["target/classes"]
+     classloader/+base+))
+
+  (classloader/add-url loader "target/generated")
+  (classloader/has-url? loader "target/generated")
+  (classloader/remove-url loader "target/generated"))
+
+[[:section {:title "Read a class source"}]]
+
+(comment
+  (classloader/load-class
+   "target/classes/example/Generated.class"
+   {:name "example.Generated"}
+   loader))
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "jvm.classloader"}]]
+[[:api {:namespace "jvm.classloader.common"}]]
+[[:api {:namespace "jvm.classloader.base-classloader"}]]
+[[:api {:namespace "jvm.classloader.url-classloader"}]]
+[[:api {:namespace "jvm.classloader.system-classloader"}]]

--- a/src-doc/documentation/std/jvm_deps.clj
+++ b/src-doc/documentation/std/jvm_deps.clj
@@ -1,0 +1,40 @@
+(ns documentation.jvm-deps
+  (:use code.test))
+
+[[:hero {:title "jvm.deps"
+         :subtitle "JVM artifact resolution and classpath dependency inspection"
+         :lead "Connect artifact coordinates to classpath locations and inspect which dependency versions are available to a loader."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"`jvm.deps` resolves classes and namespaces to classpath locations, maps dependency coordinates to local archive paths, and reports artifacts visible through a classloader."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Resolve code locations"}]]
+
+(comment
+  (require '[jvm.deps :as deps])
+
+  (deps/resolve-classloader String)
+  (deps/resolve-classloader 'clojure.core)
+  (deps/resolve 'clojure.core
+                '[org.clojure/clojure "1.11.1"]))
+
+[[:section {:title "Inspect dependencies"}]]
+
+(comment
+  (deps/all-loaded-artifacts)
+  (deps/version-map)
+  (deps/current-version 'org.clojure/clojure)
+  (deps/loaded-artifact?
+   '[org.clojure/clojure "1.11.1"]))
+
+[[:section {:title "Classpath operations"}]]
+
+"Collection operations are available for adding known local coordinates to a mutable loader and removing them again. The single-coordinate functions are useful when callers need precise control over reporting and error handling."
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "jvm.deps"}]]

--- a/src-doc/documentation/std/jvm_index.clj
+++ b/src-doc/documentation/std/jvm_index.clj
@@ -1,0 +1,19 @@
+(ns documentation.jvm-index)
+
+[[:hero {:title "jvm.*"
+         :subtitle "JVM artifacts, classloaders, namespaces, reflection, monitoring, and development tools"
+         :lead "Choose a focused JVM page for a walkthrough and complete API reference."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:card-grid
+  {:title "JVM libraries"
+   :items
+   [{:meta "Artifacts" :title "jvm.artifact" :text "Coordinates, paths, and artifact representations." :href "jvm-artifact.html"}
+    {:meta "Classpath" :title "jvm.classloader" :text "Classloader inspection and class support." :href "jvm-classloader.html"}
+    {:meta "Dependencies" :title "jvm.deps" :text "Resolve and inspect JVM dependencies." :href "jvm-deps.html"}
+    {:meta "Monitoring" :title "jvm.monitor" :text "JVM metrics through management beans." :href "jvm-monitor.html"}
+    {:meta "Namespaces" :title "jvm.namespace" :text "Inspect, evaluate, clear, and reload namespaces." :href "jvm-namespace.html"}
+    {:meta "Protocols" :title "jvm.protocol" :text "Loader and artifact extension points." :href "jvm-protocol.html"}
+    {:meta "Reflection" :title "jvm.reflect" :text "Interactive class and member queries." :href "jvm-reflect.html"}
+    {:meta "Require" :title "jvm.require" :text "Dependency-aware development requiring." :href "jvm-require.html"}
+    {:meta "REPL" :title "jvm.tool" :text "Hotkeys and linked development tools." :href "jvm-tool.html"}]}]]

--- a/src-doc/documentation/std/jvm_monitor.clj
+++ b/src-doc/documentation/std/jvm_monitor.clj
@@ -1,0 +1,45 @@
+(ns documentation.jvm-monitor
+  (:use code.test))
+
+[[:hero {:title "jvm.monitor"
+         :subtitle "JVM management beans exposed as Clojure data"
+         :lead "Read class loading, compilation, garbage collection, memory, operating-system, runtime, and thread metrics through one API."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"The namespace wraps `ManagementFactory` MXBeans and registers map-like conversions so callers can work with ordinary Clojure maps rather than Java bean accessors."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Discover metric groups"}]]
+
+(comment
+  (require '[jvm.monitor :as monitor])
+
+  (monitor/jvm))
+
+[[:section {:title "Read one group"}]]
+
+(comment
+  (monitor/jvm :memory)
+  (monitor/jvm :gc)
+  (monitor/jvm :thread)
+  (monitor/jvm :os))
+
+[[:section {:title "Capture a complete snapshot"}]]
+
+"Use `:all` for diagnostics, support bundles, or periodic telemetry. For high-frequency monitoring, request only the groups required by the caller."
+
+(comment
+  (def snapshot (monitor/jvm :all))
+  (keys snapshot)
+  (get-in snapshot [:memory :heap-memory-usage :used]))
+
+[[:chapter {:title "Direct bean access" :link "beans"}]]
+
+"The individual `*-bean` functions return the underlying MXBean values when Java interop or another object conversion is required."
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "jvm.monitor"}]]

--- a/src-doc/documentation/std/jvm_namespace.clj
+++ b/src-doc/documentation/std/jvm_namespace.clj
@@ -1,0 +1,54 @@
+(ns documentation.jvm-namespace
+  (:use code.test))
+
+[[:hero {:title "jvm.namespace"
+         :subtitle "namespace inspection, evaluation, cleanup, and reload workflows"
+         :lead "Inspect namespace mappings and memory, evaluate forms in controlled namespaces, and reload dependency-ordered namespace sets."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"The namespace combines direct evaluation helpers with `std.pipe` tasks for listing, clearing, resetting, and reloading namespaces. Most task functions accept one namespace, a collection, or the default current namespace."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Inspect a namespace"}]]
+
+(comment
+  (require '[jvm.namespace :as namespace])
+
+  (namespace/list-publics 'jvm.namespace)
+  (namespace/list-interns 'jvm.namespace)
+  (namespace/list-imports 'jvm.namespace)
+  (namespace/list-aliases 'jvm.namespace))
+
+[[:section {:title "Evaluate in context"}]]
+
+(comment
+  (namespace/eval-ns 'example.scratch
+    '(def answer 42))
+
+  (namespace/with-ns 'example.scratch
+    answer)
+
+  (namespace/eval-temp-ns
+    '(+ 1 2 3)))
+
+[[:section {:title "Reload a dependency set"}]]
+
+"`reload` sorts the supplied namespaces topologically before running the reload task. Use the clear functions narrowly; `reset` removes namespaces under a root and is intended for controlled development workflows."
+
+(comment
+  (namespace/reload
+   '[example.core example.api])
+
+  (namespace/loaded? 'example.core)
+  (namespace/list-in-memory 'example.core))
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "jvm.namespace"}]]
+[[:api {:namespace "jvm.namespace.common"}]]
+[[:api {:namespace "jvm.namespace.context"}]]
+[[:api {:namespace "jvm.namespace.dependent"}]]
+[[:api {:namespace "jvm.namespace.eval"}]]

--- a/src-doc/documentation/std/jvm_protocol.clj
+++ b/src-doc/documentation/std/jvm_protocol.clj
@@ -1,0 +1,54 @@
+(ns documentation.jvm-protocol
+  (:use code.test))
+
+[[:hero {:title "jvm.protocol"
+         :subtitle "extension points for loaders, artifacts, and class sources"
+         :lead "Implement the small protocols and multimethods used by `jvm.classloader` and `jvm.artifact` to support new loader or source types."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"`ILoader` defines URL inspection and mutation. The `-load-class`, `-rep`, and `-artifact` multimethods provide open dispatch for class sources and artifact representations."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Adapt a loader"}]]
+
+(comment
+  (require '[jvm.protocol :as protocol])
+
+  (extend-type ExampleLoader
+    protocol/ILoader
+    (-has-url? [loader path]
+      (contains? (:paths loader) path))
+    (-get-url [loader path]
+      (get (:urls loader) path))
+    (-all-urls [loader]
+      (vals (:urls loader)))
+    (-add-url [loader path]
+      (add-path loader path))
+    (-remove-url [loader path]
+      (remove-path loader path))))
+
+[[:section {:title "Support another artifact input"}]]
+
+(comment
+  (defmethod protocol/-rep ExampleCoordinate
+    [coordinate]
+    (example-coordinate->rep coordinate))
+
+  (defmethod protocol/-artifact :example
+    [_ value]
+    (rep->example value)))
+
+[[:section {:title "Support another class source"}]]
+
+(comment
+  (defmethod protocol/-load-class
+    [ExampleSource clojure.lang.DynamicClassLoader]
+    [source loader opts]
+    (define-example-class source loader opts)))
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "jvm.protocol"}]]

--- a/src-doc/documentation/std/jvm_reflect.clj
+++ b/src-doc/documentation/std/jvm_reflect.clj
@@ -1,0 +1,44 @@
+(ns documentation.jvm-reflect
+  (:use code.test))
+
+[[:hero {:title "jvm.reflect"
+         :subtitle "interactive Java reflection and member queries"
+         :lead "Inspect class metadata and hierarchies, query methods and fields, and pretty-print object views."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"The namespace exposes compact REPL-oriented macros over `std.object`. Selectors can filter members by name, type, modifiers, or regular expression, and output is formatted for interactive exploration."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Inspect a class"}]]
+
+(comment
+  (require '[jvm.reflect :as reflect])
+
+  (reflect/.% String)
+  (reflect/.%> String)
+  (reflect/.? String #"^char" :name))
+
+[[:section {:title "Inspect an instance"}]]
+
+(comment
+  (reflect/.* "hello" #"^to" :name)
+  (reflect/.& (StringBuilder. "hello")))
+
+[[:section {:title "Thread member access"}]]
+
+"`.>` behaves like `->` while resolving keyword or dot-prefixed member names through the object query system."
+
+(comment
+  (reflect/.> "hello" :value String.))
+
+[[:chapter {:title "Supporting output" :link "supporting"}]]
+
+"`jvm.reflect.print` contains the tabular and class-name formatting used by the query macros."
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "jvm.reflect"}]]
+[[:api {:namespace "jvm.reflect.print"}]]

--- a/src-doc/documentation/std/jvm_require.clj
+++ b/src-doc/documentation/std/jvm_require.clj
@@ -1,0 +1,36 @@
+(ns documentation.jvm-require
+  (:use code.test))
+
+[[:hero {:title "jvm.require"
+         :subtitle "dependency-aware namespace requiring for development"
+         :lead "Retry a namespace require after discovering and loading a missing namespace dependency from the compiler error chain."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"`force-require` is a development helper for namespaces that fail to reload because a referenced namespace has not yet been loaded. It follows missing-namespace errors, requires the dependency, and then returns through the original stack."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Require a namespace"}]]
+
+(comment
+  (require '[jvm.require :as jvm-require])
+
+  (jvm-require/force-require
+   'example.application))
+
+[[:section {:title "Use in a reload workflow"}]]
+
+"Call this helper when generating or rearranging namespaces during development. Normal application startup should generally continue to use ordinary `require` declarations so dependency problems remain explicit."
+
+(comment
+  (doseq [namespace
+          '[example.model
+            example.service
+            example.application]]
+    (jvm-require/force-require namespace)))
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "jvm.require"}]]

--- a/src-doc/documentation/std/jvm_tool.clj
+++ b/src-doc/documentation/std/jvm_tool.clj
@@ -1,0 +1,42 @@
+(ns documentation.jvm-tool
+  (:use code.test))
+
+[[:hero {:title "jvm.tool"
+         :subtitle "REPL hotkeys and development-tool injection"
+         :lead "Configure numbered hotkey functions and expose commonly used reflection, build, test, documentation, and namespace tools in the short `s` namespace."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"Loading `jvm.tool` prepares an interactive development environment. It links reflection macros into `clojure.core`, creates the `s` helper namespace, and resolves linked tool vars after their defining namespaces become available."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Configure a hotkey"}]]
+
+(comment
+  (require '[jvm.tool :as tool])
+
+  (tool/hotkey-set
+   1
+   (fn []
+     (println "refreshing")))
+
+  (tool/hotkey-1))
+
+[[:section {:title "Use the helper namespace"}]]
+
+"The injected `s` namespace provides short references to frequently used project, test, build, documentation, logging, and namespace-management functions. Treat it as a REPL convenience rather than an application dependency."
+
+(comment
+  (s/force-require 'example.application)
+  (s/run :all)
+  (s/publish '[std]))
+
+[[:chapter {:title "Initialization behavior" :link "initialization"}]]
+
+"Because this namespace intentionally modifies linked vars and print preferences, require it from a user or development profile rather than production library code."
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "jvm.tool"}]]

--- a/src-doc/documentation/std/lib_aether.clj
+++ b/src-doc/documentation/std/lib_aether.clj
@@ -1,0 +1,64 @@
+(ns documentation.lib-aether
+  (:use code.test))
+
+[[:hero {:title "lib.aether"
+         :subtitle "Maven dependency resolution, installation, and repository operations"
+         :lead "Resolve dependency graphs with Eclipse Aether, prepare artifact requests, and connect resolved coordinates to JVM classloaders."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"`lib.aether` builds repository-system requests from `jvm.artifact` coordinates. It can collect dependency graphs, resolve files and versions, install local artifacts, and prepare repository operations."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Resolve dependencies"}]]
+
+(comment
+  (require '[lib.aether :as aether])
+
+  (aether/collect-dependencies
+   '[org.clojure/data.json "2.5.0"]
+   {:type :coord})
+
+  (aether/resolve-dependencies
+   '[[org.clojure/data.json "2.5.0"]]
+   {:type :coord}))
+
+[[:section {:title "Attach a dependency to a loader"}]]
+
+"`pull` resolves coordinates and adds their local files to a loader. Options control dependency traversal, replacement of another loaded version, and whether loaded entries are retained."
+
+(comment
+  (aether/pull
+   '[[org.clojure/data.json "2.5.0"]]
+   {:keep true})
+
+  (aether/resolve-versions
+   '[[org.clojure/data.json "LATEST"]]))
+
+[[:section {:title "Install project artifacts"}]]
+
+(comment
+  (aether/install-artifact
+   '[example/library "1.0.0"]
+   {:artifacts [{:file "target/library.jar"
+                 :extension "jar"}
+                {:file "target/library.pom"
+                 :extension "pom"}]}))
+
+[[:chapter {:title "Supporting namespaces" :link "supporting"}]]
+
+"Request, result, repository, session, authentication, listener, wagon, and dependency namespaces expose the lower-level Aether integration used by the public functions."
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "lib.aether"}]]
+[[:api {:namespace "lib.aether.base"}]]
+[[:api {:namespace "lib.aether.artifact"}]]
+[[:api {:namespace "lib.aether.dependency"}]]
+[[:api {:namespace "lib.aether.local-repo"}]]
+[[:api {:namespace "lib.aether.remote-repo"}]]
+[[:api {:namespace "lib.aether.request"}]]
+[[:api {:namespace "lib.aether.result"}]]
+[[:api {:namespace "lib.aether.session"}]]

--- a/src-doc/documentation/std/lib_docker.clj
+++ b/src-doc/documentation/std/lib_docker.clj
@@ -1,0 +1,52 @@
+(ns documentation.lib-docker
+  (:use code.test))
+
+[[:hero {:title "lib.docker"
+         :subtitle "container lifecycle helpers for managed runtimes and tests"
+         :lead "Start, inspect, and stop Docker containers, with optional automatic cleanup for temporary resources."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"The public namespace exposes common container operations and composes them into runtime lifecycle hooks. Temporary containers can be associated with the cleanup service used by development and test workflows."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Inspect containers"}]]
+
+(comment
+  (require '[lib.docker :as docker])
+
+  (docker/list-containers)
+  (docker/has-container? "example-service")
+  (docker/get-ip "example-service"))
+
+[[:section {:title "Start and stop a container"}]]
+
+(comment
+  (def container
+    (docker/start-container
+     {:id "example-service"
+      :image "redis:7"
+      :ports {6379 6379}}))
+
+  (docker/stop-container container))
+
+[[:section {:title "Attach a runtime"}]]
+
+"`start-runtime` adds container identity and networking to a runtime map. `stop-runtime` respects permanent and secondary container options."
+
+(comment
+  (def runtime
+    (docker/start-runtime
+     {:lang :redis :tag :cache}
+     {:image "redis:7" :suffix "dev"}))
+
+  (docker/stop-runtime runtime (:container runtime)))
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "lib.docker"}]]
+[[:api {:namespace "lib.docker.common"}]]
+[[:api {:namespace "lib.docker.compose"}]]
+[[:api {:namespace "lib.docker.ryuk"}]]

--- a/src-doc/documentation/std/lib_index.clj
+++ b/src-doc/documentation/std/lib_index.clj
@@ -1,0 +1,20 @@
+(ns documentation.lib-index)
+
+[[:hero {:title "lib.*"
+         :subtitle "Integration library documentation"
+         :lead "Each page includes a walkthrough and API reference."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:card-grid
+  {:title "Integration libraries"
+   :items
+   [{:title "lib.aether" :href "lib-aether.html"}
+    {:title "lib.docker" :href "lib-docker.html"}
+    {:title "lib.jdbc" :href "lib-jdbc.html"}
+    {:title "lib.lucene" :href "lib-lucene.html"}
+    {:title "lib.minio" :href "lib-minio.html"}
+    {:title "lib.openpgp" :href "lib-openpgp.html"}
+    {:title "lib.oshi" :href "lib-oshi.html"}
+    {:title "lib.postgres" :href "lib-postgres.html"}
+    {:title "lib.rabbitmq" :href "lib-rabbitmq.html"}
+    {:title "lib.redis" :href "lib-redis.html"}]}]]

--- a/src-doc/documentation/std/lib_jdbc.clj
+++ b/src-doc/documentation/std/lib_jdbc.clj
@@ -1,0 +1,58 @@
+(ns documentation.lib-jdbc
+  (:use code.test))
+
+[[:hero {:title "lib.jdbc"
+         :subtitle "JDBC connections, prepared statements, eager queries, and cursors"
+         :lead "Use database specifications, URLs, data sources, or existing connections through one protocol-oriented JDBC API."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"`lib.jdbc` normalizes connection inputs and query forms. Queries may be SQL strings, SQL vectors with parameters, or prepared statements. Results can be fetched eagerly or streamed through an explicit cursor."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Open a connection"}]]
+
+(comment
+  (require '[lib.jdbc :as jdbc])
+
+  (def dbspec
+    {:vendor "postgresql"
+     :host "localhost"
+     :port 5432
+     :name "application"
+     :user "application"})
+
+  (with-open [connection (jdbc/connection dbspec)]
+    (jdbc/fetch-one connection
+                    ["select ? as value" 42])))
+
+[[:section {:title "Execute and fetch"}]]
+
+(comment
+  (with-open [connection (jdbc/connection dbspec)]
+    (jdbc/execute connection
+                  ["insert into events(kind) values (?)" "login"])
+    (jdbc/fetch connection
+                ["select * from events where kind = ?" "login"])))
+
+[[:section {:title "Stream large results"}]]
+
+"`fetch-lazy` returns a cursor. Keep the cursor inside `with-open` so its statement and result set are released even when iteration stops early."
+
+(comment
+  (with-open [connection (jdbc/connection dbspec)
+              cursor (jdbc/fetch-lazy connection
+                                      "select * from events")]
+    (doseq [row (take 100 (jdbc/cursor->lazyseq cursor))]
+      (process-row row))))
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "lib.jdbc"}]]
+[[:api {:namespace "lib.jdbc.constants"}]]
+[[:api {:namespace "lib.jdbc.meta"}]]
+[[:api {:namespace "lib.jdbc.protocol"}]]
+[[:api {:namespace "lib.jdbc.resultset"}]]
+[[:api {:namespace "lib.jdbc.types"}]]

--- a/src-doc/documentation/std/lib_lucene.clj
+++ b/src-doc/documentation/std/lib_lucene.clj
@@ -1,0 +1,48 @@
+(ns documentation.lib-lucene
+  (:use code.test))
+
+[[:hero {:title "lib.lucene"
+         :subtitle "component-managed Lucene indexing and search"
+         :lead "Create memory or disk-backed search engines, define field templates, and query indexed documents through a shared protocol."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"`LuceneSearch` implements the search-engine and component protocols. Configuration selects a store and describes document fields and analyzers."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Create an engine"}]]
+
+(comment
+  (require '[lib.lucene :as lucene])
+
+  (def engine
+    (lucene/lucene
+     {:store :memory
+      :template
+      {:article
+       {:analyzer {:type :standard}
+        :type {:id {:stored true}
+               :title {:stored true}
+               :body {:stored true}}}}})))
+
+[[:section {:title "Use the engine protocol"}]]
+
+"The engine protocol provides document addition, replacement, removal, and search. Stop the component when the engine is no longer required so readers, writers, analyzers, and storage are released."
+
+(comment
+  (require '[lib.lucene.protocol :as search])
+  (require '[std.lib.component :as component])
+
+  (search/index-add engine :article
+                    {:id "1" :title "Foundation"}
+                    {})
+  (search/search engine :article {:title "Foundation"} {})
+  (component/stop engine))
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "lib.lucene"}]]
+[[:api {:namespace "lib.lucene.protocol"}]]
+[[:api {:namespace "lib.lucene.impl"}]]

--- a/src-doc/documentation/std/lib_minio.clj
+++ b/src-doc/documentation/std/lib_minio.clj
@@ -1,0 +1,39 @@
+(ns documentation.lib-minio
+  (:use code.test))
+
+[[:hero {:title "lib.minio"
+         :subtitle "local MinIO arrays for integration and benchmark environments"
+         :lead "Start and stop coordinated MinIO instances and inspect the ports allocated to the running array."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"The namespace exposes the public lifecycle functions from `lib.minio.bench`. It is intended for local integration, distributed-storage experiments, and repeatable benchmark environments rather than as a general object-storage client."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Start an array"}]]
+
+(comment
+  (require '[lib.minio :as minio])
+
+  (def array
+    (minio/start-minio-array
+     {:count 4}))
+
+  (minio/all-minio-ports))
+
+[[:section {:title "Stop the environment"}]]
+
+"Retain the returned array value and stop it during test teardown. Port discovery is useful when constructing clients after the processes have started."
+
+(comment
+  (try
+    (run-storage-tests array)
+    (finally
+      (minio/stop-minio-array array))))
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "lib.minio"}]]
+[[:api {:namespace "lib.minio.bench"}]]

--- a/src-doc/documentation/std/lib_openpgp.clj
+++ b/src-doc/documentation/std/lib_openpgp.clj
@@ -1,0 +1,53 @@
+(ns documentation.lib-openpgp
+  (:use code.test))
+
+[[:hero {:title "lib.openpgp"
+         :subtitle "OpenPGP key parsing, encryption, signatures, and verification"
+         :lead "Work with Bouncy Castle OpenPGP keys and byte-oriented encryption or signature operations through Clojure functions."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"The namespace parses armored public and secret key rings, derives usable key pairs, encrypts and decrypts byte arrays, and reads or writes detached signature files."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Parse keys"}]]
+
+(comment
+  (require '[lib.openpgp :as openpgp])
+
+  (def public-key
+    (openpgp/parse-public-key public-key-text))
+
+  (def secret-key
+    (openpgp/parse-secret-key secret-key-text))
+
+  (def pair (openpgp/key-pair secret-key))
+  (openpgp/fingerprint public-key))
+
+[[:section {:title "Encrypt and decrypt bytes"}]]
+
+(comment
+  (let [[public private] pair
+        encrypted (openpgp/encrypt
+                   (.getBytes "hello")
+                   {:public public})]
+    (String.
+     (openpgp/decrypt encrypted
+                      {:private private}))))
+
+[[:section {:title "Create and verify a detached signature"}]]
+
+(comment
+  (let [[public private] pair]
+    (openpgp/sign "artifact.jar"
+                  "artifact.jar.asc"
+                  {:public public :private private})
+    (openpgp/verify "artifact.jar"
+                    "artifact.jar.asc"
+                    {:public public})))
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "lib.openpgp"}]]

--- a/src-doc/documentation/std/lib_oshi.clj
+++ b/src-doc/documentation/std/lib_oshi.clj
@@ -1,0 +1,48 @@
+(ns documentation.lib-oshi
+  (:use code.test))
+
+[[:hero {:title "lib.oshi"
+         :subtitle "cross-platform hardware, operating-system, and process information"
+         :lead "Read OSHI system information as raw Java objects or converted Clojure data for diagnostics and monitoring."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"The public functions create an OSHI `SystemInfo` value and navigate to hardware or operating-system sections. Bind `*raw*` to control whether values are returned directly or converted through `std.object`."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Read system information"}]]
+
+(comment
+  (require '[lib.oshi :as oshi])
+
+  (binding [oshi/*raw* false]
+    {:computer (oshi/computer-system)
+     :cpu (oshi/cpu)
+     :memory (oshi/memory)
+     :operating-system (oshi/os)}))
+
+[[:section {:title "Inspect devices and interfaces"}]]
+
+(comment
+  (binding [oshi/*raw* false]
+    {:disks (oshi/fs)
+     :network (oshi/network-ifs)
+     :power (oshi/power)
+     :sensors (oshi/sensors)
+     :usb (oshi/usb)}))
+
+[[:section {:title "Inspect processes"}]]
+
+(comment
+  (oshi/process-id)
+  (binding [oshi/*raw* false]
+    (oshi/process (oshi/process-id)))
+  (binding [oshi/*raw* false]
+    (oshi/list-processes 20 :cpu)))
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "lib.oshi"}]]
+[[:api {:namespace "lib.oshi.interop"}]]

--- a/src-doc/documentation/std/lib_postgres.clj
+++ b/src-doc/documentation/std/lib_postgres.clj
@@ -1,0 +1,42 @@
+(ns documentation.lib-postgres
+  (:use code.test))
+
+[[:hero {:title "lib.postgres"
+         :subtitle "PostgreSQL runtime and connection lifecycle"
+         :lead "Coordinate PostgreSQL connection startup, readiness, temporary database setup, and shutdown."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"The runtime functions operate on a map containing connection settings, an instance atom, and notification state. Optional settings add setup and teardown hooks."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Start a runtime"}]]
+
+(comment
+  (require '[lib.postgres :as postgres])
+
+  (def runtime
+    {:host "localhost"
+     :port 5432
+     :dbname "application"
+     :instance (atom nil)
+     :notifications (atom {})})
+
+  (postgres/start-pg runtime))
+
+[[:section {:title "Inspect and close"}]]
+
+(comment
+  @(:instance runtime)
+  (postgres/stop-pg runtime))
+
+[[:section {:title "Lifecycle options"}]]
+
+"Temporary database and external runtime options can be added to the same map. The start function waits for availability before creating the connection instance."
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "lib.postgres"}]]
+[[:api {:namespace "lib.postgres.connection"}]]

--- a/src-doc/documentation/std/lib_rabbitmq.clj
+++ b/src-doc/documentation/std/lib_rabbitmq.clj
@@ -1,0 +1,60 @@
+(ns documentation.lib-rabbitmq
+  (:use code.test))
+
+[[:hero {:title "lib.rabbitmq"
+         :subtitle "RabbitMQ management, routing, publishing, and consumers"
+         :lead "Manage queues, exchanges, bindings, vhosts, network state, publishing, and consumers through a component-friendly client."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"The main client combines connection settings for RabbitMQ and its management API. High-level functions return compact maps for queues, exchanges, bindings, consumers, routing, and network state."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Create a client"}]]
+
+(comment
+  (require '[lib.rabbitmq :as rabbitmq])
+
+  (def mq
+    (rabbitmq/rabbit
+     {:host "localhost"
+      :port 5672
+      :management-port 15672
+      :vhost "/"})))
+
+[[:section {:title "Create routing"}]]
+
+(comment
+  (-> mq
+      (rabbitmq/add-exchange
+       "events"
+       {:type "topic" :durable true})
+      (rabbitmq/add-queue
+       "events.audit"
+       {:durable true})
+      (rabbitmq/bind-queue
+       "events"
+       "events.audit"
+       {:routing-key "audit.*"}))
+
+  (rabbitmq/routing mq))
+
+[[:section {:title "Publish and consume"}]]
+
+(comment
+  (rabbitmq/publish mq
+                    "events"
+                    "created"
+                    {:key "audit.created"})
+
+  (rabbitmq/connect mq)
+  (rabbitmq/consume mq "events.audit" handle-message))
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "lib.rabbitmq"}]]
+[[:api {:namespace "lib.rabbitmq.api"}]]
+[[:api {:namespace "lib.rabbitmq.consumer"}]]
+[[:api {:namespace "lib.rabbitmq.request"}]]

--- a/src-doc/documentation/std/lib_redis.clj
+++ b/src-doc/documentation/std/lib_redis.clj
@@ -1,0 +1,46 @@
+(ns documentation.lib-redis
+  (:use code.test))
+
+[[:hero {:title "lib.redis"
+         :subtitle "pooled Redis clients, scripts, events, and lifecycle integration"
+         :lead "Create RESP connection pools and compose them with optional local services, event listeners, notifications, and script state."
+         :actions [{:label "All libraries" :href "index.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"A Redis client map contains identity, host and port settings, runtime script and listener state, and an active connection pool after startup. Component wrappers coordinate supporting lifecycle steps."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Create and start a client"}]]
+
+(comment
+  (require '[lib.redis :as redis])
+
+  (def client
+    (redis/client-create
+     {:host "localhost"
+      :port 6379
+      :mode :eval}))
+
+  (def started
+    (redis/client:start client)))
+
+[[:section {:title "Inspect and close"}]]
+
+(comment
+  (redis/client-string started)
+  (:pool started)
+  @(:runtime started)
+  (redis/client:stop started))
+
+[[:chapter {:title "Supporting namespaces" :link "supporting"}]]
+
+"`lib.redis.event` manages listeners and notification loops. `lib.redis.script` and `lib.redis.extension` support script registration and command extensions. `lib.redis.bench` integrates local test services."
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "lib.redis"}]]
+[[:api {:namespace "lib.redis.event"}]]
+[[:api {:namespace "lib.redis.script"}]]
+[[:api {:namespace "lib.redis.extension"}]]

--- a/src-doc/documentation/std/std_concurrent.clj
+++ b/src-doc/documentation/std/std_concurrent.clj
@@ -3,34 +3,43 @@
 
 [[:hero {:title "std.concurrent"
          :subtitle "concurrency primitives, queues, executors, requests, relays, and threads"
-         :lead "`std.concurrent` is a higher-level standard library family in foundation-base. This page explains when to use it, how it fits internally, and where to find the API surface."}]]
+         :lead "Start with the facade for common operations, then use the focused pages for lifecycle guidance, walkthroughs, and complete API references."}]]
 
-[[:chapter {:title "Motivation" :link "motivation"}]]
+[[:chapter {:title "Choose a primitive" :link "choose"}]]
 
-"Use this layer when application or tooling code needs the behavior described by the page title without reaching directly into implementation namespaces. The top-level namespace is the starting point; subnamespaces expose more focused building blocks."
+[[:card-grid
+  {:title "Concurrency libraries"
+   :lead "Each focused namespace has its own walkthrough and API page."
+   :items
+   [{:meta "Batching" :title "std.concurrent.atom" :text "Atom-backed batch queues and completion-aware hubs." :href "std-concurrent-atom.html"}
+    {:meta "Messaging" :title "std.concurrent.bus" :text "Addressed request and response loops between registered threads." :href "std-concurrent-bus.html"}
+    {:meta "Execution" :title "std.concurrent.executor" :text "Thread pools, submission, scheduling, metrics, and shutdown." :href "std-concurrent-executor.html"}
+    {:meta "Resources" :title "std.concurrent.pool" :text "Reusable resources with acquisition, release, cleanup, and health." :href "std-concurrent-pool.html"}
+    {:meta "Output" :title "std.concurrent.print" :text "Serialized asynchronous printing from concurrent workers." :href "std-concurrent-print.html"}
+    {:meta "Coordination" :title "std.concurrent.queue" :text "Blocking queues, deques, timeouts, draining, and bulk processing." :href "std-concurrent-queue.html"}
+    {:meta "Streams" :title "std.concurrent.relay" :text "Interactive process and socket streams over a shared bus." :href "std-concurrent-relay.html"}
+    {:meta "Requests" :title "std.concurrent.request" :text "Single, asynchronous, bulk, and transactional request orchestration." :href "std-concurrent-request.html"}
+    {:meta "Applicatives" :title "std.concurrent.request-apply" :text "Invokable request definitions with transforms and execution modes." :href "std-concurrent-request-apply.html"}
+    {:meta "Commands" :title "std.concurrent.request-command" :text "Reusable command templates for request clients." :href "std-concurrent-request-command.html"}
+    {:meta "Threads" :title "std.concurrent.thread" :text "Thread construction, inspection, joining, and coordination." :href "std-concurrent-thread.html"}]}]]
 
-[[:chapter {:title "How to use it" :link "usage"}]]
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
 
-"Require the top-level namespace for common workflows, then move to subnamespaces when you need a lower-level primitive. Existing tests under `test/std/concurrent` and `test/std/concurrent_test.clj` are the best executable examples for edge cases."
+"The layers are designed to compose. A blocking queue provides back-pressure, an executor runs anonymous tasks, a bus owns addressed handler loops, and a pool manages reusable resources. Request and relay abstractions build higher-level workflows on those primitives."
 
 (comment
-  (require '[std.concurrent :as lib]))
+  (require '[std.concurrent :as concurrent])
 
-[[:chapter {:title "Internal usage" :link "internal"}]]
+  (def work (concurrent/queue:fixed 32))
+  (def executor (concurrent/executor:pool 2 4 1000 work))
 
-"This library family is used across source, tests, generated examples, and docs tooling. During detailed documentation passes, collect concrete usage with `code.manage/find-usages` and `code.manage/locate-code`, then keep only high-signal examples in the page narrative."
+  @(concurrent/submit executor
+                      (fn [] {:status :complete}))
 
-[[:chapter {:title "API" :link "api"}]]
+  (concurrent/exec:shutdown executor))
+
+[[:chapter {:title "Facade API" :link "api"}]]
+
+"The facade re-exports the most commonly used thread, queue, executor, pool, bus, request, and relay operations. The focused pages document the full source namespaces."
 
 [[:api {:namespace "std.concurrent"}]]
-[[:api {:namespace "std.concurrent.atom"}]]
-[[:api {:namespace "std.concurrent.bus"}]]
-[[:api {:namespace "std.concurrent.executor"}]]
-[[:api {:namespace "std.concurrent.pool"}]]
-[[:api {:namespace "std.concurrent.print"}]]
-[[:api {:namespace "std.concurrent.queue"}]]
-[[:api {:namespace "std.concurrent.relay"}]]
-[[:api {:namespace "std.concurrent.request"}]]
-[[:api {:namespace "std.concurrent.request-apply"}]]
-[[:api {:namespace "std.concurrent.request-command"}]]
-[[:api {:namespace "std.concurrent.thread"}]]

--- a/src-doc/documentation/std/std_concurrent.clj
+++ b/src-doc/documentation/std/std_concurrent.clj
@@ -22,3 +22,15 @@
 
 [[:chapter {:title "API" :link "api"}]]
 
+[[:api {:namespace "std.concurrent"}]]
+[[:api {:namespace "std.concurrent.atom"}]]
+[[:api {:namespace "std.concurrent.bus"}]]
+[[:api {:namespace "std.concurrent.executor"}]]
+[[:api {:namespace "std.concurrent.pool"}]]
+[[:api {:namespace "std.concurrent.print"}]]
+[[:api {:namespace "std.concurrent.queue"}]]
+[[:api {:namespace "std.concurrent.relay"}]]
+[[:api {:namespace "std.concurrent.request"}]]
+[[:api {:namespace "std.concurrent.request-apply"}]]
+[[:api {:namespace "std.concurrent.request-command"}]]
+[[:api {:namespace "std.concurrent.thread"}]]

--- a/src-doc/documentation/std/std_concurrent_atom.clj
+++ b/src-doc/documentation/std/std_concurrent_atom.clj
@@ -1,0 +1,54 @@
+(ns documentation.std-concurrent-atom
+  (:use code.test))
+
+[[:hero {:title "std.concurrent.atom"
+         :subtitle "batched atom queues and trackable asynchronous hubs"
+         :lead "Use atom-backed queues when producers should submit quickly and a single executor should process entries in controlled batches."
+         :actions [{:label "Concurrency overview" :href "std-concurrent.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"`std.concurrent.atom` provides two related patterns. `aq:*` functions maintain a simple vector-backed queue, while `hub:*` functions attach a future ticket to each batch so callers can observe completion."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Create a batched submitter"}]]
+
+"Create an executor with a target, a bulk handler, a maximum batch size, and a short collection interval. The returned map contains the queue, executor, and submission function."
+
+(comment
+  (require '[std.concurrent.atom :as atom])
+
+  (def worker
+    (atom/aq:executor
+     {:target :events
+      :handler (fn [target entries]
+                 {:target target :entries entries})
+      :max-batch 100
+      :interval 25}))
+
+  ((:submit worker) {:id 1} {:id 2}))
+
+[[:section {:title "Wait for a tracked batch"}]]
+
+"Use a hub executor when the caller needs a future representing the batch result. `hub:wait` blocks only while queued work remains."
+
+(comment
+  (def tracked
+    (atom/hub:executor
+     nil
+     {:handler (fn [_ entries] entries)
+      :max-batch 100
+      :interval 25}))
+
+  (let [[ticket start count submitted?]
+        ((:submit tracked) :a :b :c)]
+    {:result @ticket
+     :range [start count]
+     :submitted? submitted?})
+
+  (atom/hub:wait (:queue tracked)))
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "std.concurrent.atom"}]]

--- a/src-doc/documentation/std/std_concurrent_bus.clj
+++ b/src-doc/documentation/std/std_concurrent_bus.clj
@@ -1,0 +1,48 @@
+(ns documentation.std-concurrent-bus
+  (:use code.test))
+
+[[:hero {:title "std.concurrent.bus"
+         :subtitle "request and response messaging between registered threads"
+         :lead "A bus owns per-thread queues, dispatches messages to handlers, and completes futures when responses return."
+         :actions [{:label "Concurrency overview" :href "std-concurrent.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"A bus combines thread registration, blocking queues, handler loops, and future-backed responses. Use it when work must be addressed to a specific long-running thread rather than submitted to an anonymous executor task."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Open a handler"}]]
+
+"`bus:with-temp` starts a temporary bus and registers the current thread. `bus:open` then starts a named handler loop and returns its registration details."
+
+(comment
+  (require '[std.concurrent.bus :as bus])
+
+  (bus/bus:with-temp message-bus
+    (let [{:keys [id stopped]}
+          @(bus/bus:open message-bus
+                         (fn [{:keys [value]}]
+                           {:value (inc value)}))]
+      {:reply @(bus/bus:send message-bus id {:value 10})
+       :info  (bus/info-bus message-bus)
+       :stop  (bus/bus:close message-bus id)
+       :stopped stopped})))
+
+[[:section {:title "Inspect and control workers"}]]
+
+"Use the registry functions to inspect IDs and queues. Prefer `bus:close` for cooperative shutdown; use `bus:kill` only when a handler thread must be interrupted."
+
+(comment
+  (bus/bus:all-ids message-bus)
+  (bus/bus:get-count message-bus)
+  (bus/bus:send-all message-bus {:op :refresh})
+  (bus/bus:close-all message-bus))
+
+[[:chapter {:title "Lifecycle" :link "lifecycle"}]]
+
+"`bus` creates and starts a component. `bus:create` only constructs it. Component-aware code can use `start-bus`, `stop-bus`, `started?-bus`, and `info-bus` directly."
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "std.concurrent.bus"}]]

--- a/src-doc/documentation/std/std_concurrent_executor.clj
+++ b/src-doc/documentation/std/std_concurrent_executor.clj
@@ -1,0 +1,59 @@
+(ns documentation.std-concurrent-executor
+  (:use code.test))
+
+[[:hero {:title "std.concurrent.executor"
+         :subtitle "thread pools, scheduling, submission, and executor lifecycle"
+         :lead "Construct JVM executors with consistent queue handling, tracking, health information, and component-compatible lifecycle operations."
+         :actions [{:label "Concurrency overview" :href "std-concurrent.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"The namespace wraps `ExecutorService` and `ScheduledThreadPoolExecutor` with constructors for single, pooled, cached, scheduled, and shared executors. Submission functions return foundation futures and support delay, minimum runtime, timeout, and default values."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Submit work to a pool"}]]
+
+(comment
+  (require '[std.concurrent.executor :as executor])
+
+  (def pool
+    (executor/executor
+     {:type :pool
+      :size 2
+      :max 4
+      :keep-alive 1000
+      :queue {:size 32}}))
+
+  @(executor/submit pool
+                    (fn [] {:status :complete})
+                    {:max 5000})
+
+  (executor/executor:info pool)
+  (executor/exec:shutdown pool))
+
+[[:section {:title "Schedule repeated work"}]]
+
+"Create a scheduled executor for delayed or repeated tasks. Fixed-rate scheduling targets a wall-clock cadence, while fixed-delay scheduling waits after each completion."
+
+(comment
+  (def scheduler (executor/executor:scheduled 1))
+
+  (executor/schedule scheduler #(println :once) 250)
+  (executor/schedule:fixed-rate scheduler #(println :tick) 1000)
+  (executor/schedule:fixed-delay scheduler #(println :poll) 1000)
+
+  (executor/exec:shutdown-now scheduler))
+
+[[:section {:title "Share an executor"}]]
+
+"Register a long-lived executor under an application-specific ID and retrieve it through the generic `executor` constructor. Always unshare it before final shutdown."
+
+(comment
+  (executor/executor:share :application/background pool)
+  (executor/executor {:type :shared :id :application/background})
+  (executor/executor:unshare :application/background))
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "std.concurrent.executor"}]]

--- a/src-doc/documentation/std/std_concurrent_pool.clj
+++ b/src-doc/documentation/std/std_concurrent_pool.clj
@@ -1,0 +1,59 @@
+(ns documentation.std-concurrent-pool
+  (:use code.test))
+
+[[:hero {:title "std.concurrent.pool"
+         :subtitle "bounded reusable resource pools with lifecycle and health checks"
+         :lead "Manage expensive reusable objects with acquisition tracking, idle cleanup, disposal, and component lifecycle support."
+         :actions [{:label "Concurrency overview" :href "std-concurrent.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"A pool separates resource construction from resource use. It tracks idle and busy objects, enforces a maximum, records utilization, and can dispose unhealthy or long-idle resources in the background."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Create a pool"}]]
+
+(comment
+  (require '[std.concurrent.pool :as pool])
+
+  (def connections
+    (pool/pool
+     {:size 2
+      :max 8
+      :keep-alive 30000
+      :poll 5000
+      :resource {:create (fn [] {:opened-at (System/currentTimeMillis)})
+                 :start identity
+                 :stop  (fn [_] nil)
+                 :health (fn [_] {:status :ok})
+                 :initial 0.5}})))
+
+[[:section {:title "Acquire and release safely"}]]
+
+"Use `pool:with-resource` for normal work. It releases the object even when the body throws. Lower-level code can call `pool:acquire` and `pool:release` directly."
+
+(comment
+  (pool/pool:with-resource [connection connections]
+    (:opened-at connection))
+
+  (let [[id connection] (pool/pool:acquire connections)]
+    (try
+      connection
+      (finally
+        (pool/pool:release connections id)))))
+
+[[:section {:title "Inspect and dispose"}]]
+
+(comment
+  (pool/pool:info connections)
+  (pool/pool:resources:busy connections)
+  (pool/pool:resources:idle connections)
+  (pool/pool:cleanup connections)
+  (pool/pool:stop connections))
+
+"Call `pool:dispose:mark` inside a pooled operation when the current resource should be discarded rather than returned to idle storage."
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "std.concurrent.pool"}]]

--- a/src-doc/documentation/std/std_concurrent_print.clj
+++ b/src-doc/documentation/std/std_concurrent_print.clj
@@ -1,0 +1,35 @@
+(ns documentation.std-concurrent-print
+  (:use code.test))
+
+[[:hero {:title "std.concurrent.print"
+         :subtitle "serialized asynchronous printing for concurrent code"
+         :lead "Route print operations through a single batched executor so output from concurrent tasks remains ordered and readable."
+         :actions [{:label "Concurrency overview" :href "std-concurrent.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"`std.concurrent.print` provides drop-in `print`, `println`, `prn`, and `pprint` functions. In local execution mode they enqueue output through a shared atom executor; outside that mode they fall back to Clojure's standard printing functions."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Use concurrent printing"}]]
+
+(comment
+  (require '[std.concurrent.print :as concurrent-print])
+
+  (future (concurrent-print/println "worker-a" 1))
+  (future (concurrent-print/println "worker-b" 2))
+  (concurrent-print/pprint {:status :running :workers 2}))
+
+[[:section {:title "Submit raw fragments"}]]
+
+"`submit` accepts one or more fragments and places them directly onto the print queue. `get-executor` returns the shared resource and restarts it if its executor has stopped."
+
+(comment
+  (concurrent-print/submit "progress " 50 "%\n")
+  (keys (concurrent-print/get-executor))
+  (concurrent-print/pprint-str {:a 1 :b 2}))
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "std.concurrent.print"}]]

--- a/src-doc/documentation/std/std_concurrent_queue.clj
+++ b/src-doc/documentation/std/std_concurrent_queue.clj
@@ -1,0 +1,52 @@
+(ns documentation.std-concurrent-queue
+  (:use code.test))
+
+[[:hero {:title "std.concurrent.queue"
+         :subtitle "blocking queues, deques, timeouts, and bulk draining"
+         :lead "Use JVM blocking collections through a small Clojure API with consistent timeout units and queue-processing helpers."
+         :actions [{:label "Concurrency overview" :href "std-concurrent.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"The namespace constructs unbounded, fixed, limited, and double-ended blocking queues. Operations accept keyword time units such as `:ms`, `:s`, and `:m`."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Produce and consume"}]]
+
+(comment
+  (require '[std.concurrent.queue :as queue])
+
+  (def jobs (queue/queue:fixed 10))
+
+  (queue/put jobs {:id 1})
+  (queue/put jobs {:id 2} 100 :ms)
+  (queue/peek jobs)
+  (queue/take jobs 1 :s)
+  (queue/remaining-capacity jobs))
+
+[[:section {:title "Drain work in batches"}]]
+
+(comment
+  (queue/drain (queue/queue 1 2 3 4) 2)
+
+  (queue/process-bulk
+   (fn [batch]
+     (println "processing" batch))
+   (queue/queue 1 2 3 4 5)
+   3))
+
+[[:section {:title "Use both ends"}]]
+
+"A deque supports access through `put-first`, `put-last`, `take-first`, and `take-last`."
+
+(comment
+  (def work (queue/deque :middle))
+  (queue/put-first work :urgent)
+  (queue/put-last work :normal)
+  [(queue/take-first work)
+   (queue/take-last work)])
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "std.concurrent.queue"}]]

--- a/src-doc/documentation/std/std_concurrent_relay.clj
+++ b/src-doc/documentation/std/std_concurrent_relay.clj
@@ -1,0 +1,51 @@
+(ns documentation.std-concurrent-relay
+  (:use code.test))
+
+[[:hero {:title "std.concurrent.relay"
+         :subtitle "interactive process and socket streams over a shared message bus"
+         :lead "Wrap a process or socket as a lifecycle-aware relay with structured read, write, flush, exit, and custom stream operations."
+         :actions [{:label "Concurrency overview" :href "std-concurrent.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"A relay pairs input and output streams with a shared bus. It can attach to a running `Process` or `Socket`, or create one from process and network options. The transport namespace implements the low-level stream commands."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Start a process relay"}]]
+
+(comment
+  (require '[std.concurrent.relay :as relay])
+  (require '[std.lib.component :as component])
+
+  (def shell
+    (relay/relay
+     {:type :process
+      :args ["cat"]
+      :options {:receive {:format identity}
+                :send {:format identity}}}))
+
+  (relay/send shell {:op :partial :line "hello"})
+  (relay/send shell {:op :read-line})
+  (relay/send shell {:op :flush})
+  (component/stop shell))
+
+[[:section {:title "Attach to an existing endpoint"}]]
+
+"Supply `:attached` when another part of the application already owns the `Process` or `Socket`. `relay:create` constructs without starting, while `relay` constructs and starts."
+
+(comment
+  (def attached-relay
+    (relay/relay:create
+     {:type :socket
+      :attached existing-socket
+      :options {}}))
+
+  (component/start attached-relay)
+  (relay/send attached-relay {:op :read-some :length 1024})
+  (component/stop attached-relay))
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "std.concurrent.relay"}]]
+[[:api {:namespace "std.concurrent.relay.transport"}]]

--- a/src-doc/documentation/std/std_concurrent_request.clj
+++ b/src-doc/documentation/std/std_concurrent_request.clj
@@ -1,0 +1,54 @@
+(ns documentation.std-concurrent-request
+  (:use code.test))
+
+[[:hero {:title "std.concurrent.request"
+         :subtitle "single, bulk, asynchronous, and transactional request orchestration"
+         :lead "Define one client request protocol and reuse it across synchronous calls, futures, batching, transformations, and transactions."
+         :actions [{:label "Concurrency overview" :href "std-concurrent.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"Request clients implement `std.protocol.request/IRequest`. The orchestration layer prepares options, invokes single or bulk transport functions, processes outputs, and applies pre, post, chain, timing, and error handlers. Plain functions also implement the request protocol."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Make a single request"}]]
+
+(comment
+  (require '[std.concurrent.request :as request])
+
+  ;; Functions are valid clients; each command is an argument vector.
+  (request/req + [1 2 3])
+
+  (request/req + [1 2 3]
+               {:pre [(fn [args] (conj args 4))]
+                :post [inc]
+                :chain [str]}))
+
+[[:section {:title "Run asynchronously"}]]
+
+"Set `:async` to receive a future. `:measure` can be a callback, atom, or map of start, stop, and timer handlers."
+
+(comment
+  (def pending
+    (request/req + [1 2 3]
+                 {:async true
+                  :measure println}))
+  @pending)
+
+[[:section {:title "Batch and transact"}]]
+
+(comment
+  (request/req:bulk [+ {:async false}]
+    (request/req + [1 2])
+    (request/req + [3 4]))
+
+  (request/req:transact [+ {}]
+    (request/req + [1 2])
+    (request/req + [3 4]))
+
+  (request/bulk:map + request/req-fn [[1 2] [3 4]]))
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "std.concurrent.request"}]]

--- a/src-doc/documentation/std/std_concurrent_request_apply.clj
+++ b/src-doc/documentation/std/std_concurrent_request_apply.clj
@@ -1,0 +1,49 @@
+(ns documentation.std-concurrent-request-apply
+  (:use code.test))
+
+[[:hero {:title "std.concurrent.request-apply"
+         :subtitle "applicative functions backed by request clients"
+         :lead "Package request construction, bulk behavior, retries, transforms, and default clients as invokable applicative values."
+         :actions [{:label "Concurrency overview" :href "std-concurrent.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"`ReqApplicative` bridges `std.lib.apply` and the request orchestration layer. Calling an applicative builds one or more commands, selects single, bulk, transactional, or retry execution, and optionally transforms inputs and outputs."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Construct an applicative"}]]
+
+(comment
+  (require '[std.concurrent.request-apply :as request-apply])
+
+  (def add-request
+    (request-apply/req:applicative
+     {:type :single
+      :client +
+      :function (fn [args _opts] args)
+      :options {}
+      :transform {}}))
+
+  (add-request 1 2 3))
+
+[[:section {:title "Select an execution mode"}]]
+
+"Use `:bulk` or `:transact` when the function returns several applicatives. Use `:retry` with a predicate and retry function to recover from selected failures."
+
+(comment
+  (request-apply/req:applicative
+   {:type :bulk
+    :client client
+    :function build-commands
+    :options {:bulk {:async true}}
+    :transform {:in normalize-input
+                :out normalize-output}}))
+
+[[:chapter {:title "Extension point" :link "extension"}]]
+
+"Add another `req-call` method when an application needs a request execution strategy beyond the built-in single, bulk, transaction, and retry modes."
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "std.concurrent.request-apply"}]]

--- a/src-doc/documentation/std/std_concurrent_request_command.clj
+++ b/src-doc/documentation/std/std_concurrent_request_command.clj
@@ -1,0 +1,51 @@
+(ns documentation.std-concurrent-request-command
+  (:use code.test))
+
+[[:hero {:title "std.concurrent.request-command"
+         :subtitle "declarative command templates for request clients"
+         :lead "Describe command construction, option selection, formatting, processing, and execution mode in a reusable value."
+         :actions [{:label "Concurrency overview" :href "std-concurrent.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"A `Command` separates public arguments from the command sent to a client. Input formatting runs before request execution; output formatting and process chains run afterward."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Define a command"}]]
+
+(comment
+  (require '[std.concurrent.request-command :as command])
+
+  (def sum-command
+    (command/req:command
+     {:type :single
+      :name :sum
+      :arguments [:numbers]
+      :function (fn [args _opts] args)
+      :options {:default {} :select []}
+      :format {}
+      :process {}}))
+
+  (command/req:run sum-command + [1 2 3]))
+
+[[:section {:title "Choose an execution mode"}]]
+
+"Use `:bulk` or `:transact` when the command function returns multiple requests. The `:retry` mode can rebuild and submit a command after a selected failure."
+
+(comment
+  (command/req:command
+   {:type :bulk
+    :function build-commands
+    :options {:bulk {:async true}}
+    :format {:input normalize-input
+             :output normalize-output}
+    :process {:chain [summarize]}}))
+
+[[:chapter {:title "Extension point" :link "extension"}]]
+
+"Implement another `run-request` method to add an application-specific execution mode while retaining the common formatting and processing pipeline."
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "std.concurrent.request-command"}]]

--- a/src-doc/documentation/std/std_concurrent_thread.clj
+++ b/src-doc/documentation/std/std_concurrent_thread.clj
@@ -1,0 +1,48 @@
+(ns documentation.std-concurrent-thread
+  (:use code.test))
+
+[[:hero {:title "std.concurrent.thread"
+         :subtitle "thread construction, inspection, and coordination"
+         :lead "Use a consistent Clojure interface for common `java.lang.Thread` operations and configurable thread creation."
+         :actions [{:label "Concurrency overview" :href "std-concurrent.html"}]}]]
+
+[[:chapter {:title "Overview" :link "overview"}]]
+
+"The namespace wraps current-thread access, IDs, joining, locks, stack traces, daemon state, uncaught handlers, context classloaders, and thread construction."
+
+[[:chapter {:title "Walkthrough" :link "walkthrough"}]]
+
+[[:section {:title "Create and join a thread"}]]
+
+(comment
+  (require '[std.concurrent.thread :as thread])
+
+  (def worker
+    (thread/thread
+     {:name "example-worker"
+      :daemon true
+      :handler (fn [] (println :running))
+      :start true}))
+
+  (thread/thread:join worker 1000)
+  (thread/thread:alive? worker))
+
+[[:section {:title "Inspect runtime threads"}]]
+
+(comment
+  (thread/thread:current)
+  (thread/thread:id)
+  (thread/thread:all-ids)
+  (thread/thread:active-count)
+  (thread/stacktrace worker))
+
+[[:section {:title "Coordinate through a lock"}]]
+
+(comment
+  (def lock (Object.))
+  (future (thread/thread:wait-on lock))
+  (thread/thread:notify-all lock))
+
+[[:chapter {:title "API" :link "api"}]]
+
+[[:api {:namespace "std.concurrent.thread"}]]

--- a/src-doc/documentation/std/std_index.clj
+++ b/src-doc/documentation/std/std_index.clj
@@ -2,138 +2,51 @@
 
 [[:hero {:title "std"
          :subtitle "Standard libraries for the foundation ecosystem."
-         :lead "Core utilities for blocks, collections, atoms, streams, environments, components, schemas, transforms, resources, security, and more."
+         :lead "Core utilities, concurrency, JVM tooling, integrations, and focused API references."
          :badges ["Clojure" "Utilities" "Reference"]
          :actions [{:label "Back to home" :href "../index.html" :variant :primary}
                    {:label "Contribute" :href "../guides/index.html"}]}]]
 
-[[:card-grid {:title "Libraries"
-              :lead "Each card links to a focused reference page."
-              :items [{:meta "Concurrency"
-                       :title "std.concurrent"
-                       :text "Queues, executors, requests, relays, pools, and threads."
-                       :href "std-concurrent.html"}
-                      {:meta "Dispatch"
-                       :title "std.dispatch"
-                       :text "Boards, hubs, queues, debounce, hooks, and dispatch core."
-                       :href "std-dispatch.html"}
-                      {:meta "Filesystem"
-                       :title "std.fs"
-                       :text "Paths, walking, archives, attributes, and watchers."
-                       :href "std-fs.html"}
-                      {:meta "Scheduling"
-                       :title "std.scheduler"
-                       :text "Runners, programs, spawns, and scheduled task lifecycle."
-                       :href "std-scheduler.html"}
-                      {:meta "Text"
-                       :title "std.string"
-                       :text "Case, coercion, paths, pluralization, prose, and wrapping."
-                       :href "std-string.html"}
-                      {:meta "Tasks"
-                       :title "std.task"
-                       :text "Process and bulk task execution."
-                       :href "std-task.html"}
-                      {:meta "Time"
-                       :title "std.time"
-                       :text "Time coercion, durations, zones, formats, and representations."
-                       :href "std-time.html"}
-                      {:meta "Timeseries"
-                       :title "std.timeseries"
-                       :text "Journals, intervals, ranges, computation, and processing."
-                       :href "std-timeseries.html"}
-                      {:meta "Code"
-                       :title "std.block"
-                       :text "Code representation, traversal, and manipulation."
-                       :href "std-block.html"}
-                      {:meta "Invocation"
-                       :title "std.lib.apply"
-                       :text "Applicative invocation and host applicatives."
-                       :href "std-lib-apply.html"}
-                      {:meta "State"
-                       :title "std.lib.atom"
-                       :text "Nested atoms, batch updates, cursors, and derived state."
-                       :href "std-lib-atom.html"}
-                      {:meta "Binary"
-                       :title "std.lib.bin"
-                       :text "Binary data, buffers, and low-level data handling."
-                       :href "std-lib-bin.html"}
-                      {:meta "Classes"
-                       :title "std.lib.class"
-                       :text "Class, type, and reflection helpers."
-                       :href "std-lib-class.html"}
-                      {:meta "Collections"
-                       :title "std.lib.collection"
-                       :text "Extended map, sequence, tree, and diff operations."
-                       :href "std-lib-collection.html"}
-                      {:meta "Lifecycle"
-                       :title "std.lib.component"
-                       :text "Component lifecycle and system composition primitives."
-                       :href "std-lib-component.html"}
-                      {:meta "Encoding"
-                       :title "std.lib.encode"
-                       :text "Encoding and decoding helpers."
-                       :href "std-lib-encode.html"}
-                      {:meta "Enums"
-                       :title "std.lib.enum"
-                       :text "Enum and lookup helpers."
-                       :href "std-lib-enum.html"}
-                      {:meta "Environment"
-                       :title "std.lib.env"
-                       :text "Namespace, resource, pprint, and debug utilities."
-                       :href "std-lib-env.html"}
-                      {:meta "Foundation"
-                       :title "std.lib.foundation"
-                       :text "Basic predicates, constructors, and helpers."
-                       :href "std-lib-foundation.html"}
-                      {:meta "Async"
-                       :title "std.lib.future"
-                       :text "Future and asynchronous coordination helpers."
-                       :href "std-lib-future.html"}
-                      {:meta "I/O"
-                       :title "std.lib.io"
-                       :text "I/O helpers and stream handling."
-                       :href "std-lib-io.html"}
-                      {:meta "Network"
-                       :title "std.lib.network"
-                       :text "Network and port utilities."
-                       :href "std-lib-network.html"}
-                      {:meta "Resources"
-                       :title "std.lib.resource"
-                       :text "Classpath and filesystem resource helpers."
-                       :href "std-lib-resource.html"}
-                      {:meta "Schemas"
-                       :title "std.lib.schema"
-                       :text "Schema definitions, lookups, and validation helpers."
-                       :href "std-lib-schema.html"}
-                      {:meta "Security"
-                       :title "std.lib.security"
-                       :text "Security, keys, providers, ciphers, and verification helpers."
-                       :href "std-lib-security.html"}
-                      {:meta "Sorting"
-                       :title "std.lib.sort"
-                       :text "Sorting, ordering, and topological utilities."
-                       :href "std-lib-sort.html"}
-                      {:meta "Streams"
-                       :title "std.lib.stream"
-                       :text "Producers, collectors, pipelines, and transducers."
-                       :href "std-lib-stream.html"}
-                      {:meta "Systems"
-                       :title "std.lib.system"
-                       :text "System topology, scaffolding, display, and lifecycle utilities."
-                       :href "std-lib-system.html"}
-                      {:meta "Time"
-                       :title "std.lib.time"
-                       :text "Time coercion and temporal helpers."
-                       :href "std-lib-time.html"}
-                      {:meta "Transforms"
-                       :title "std.lib.transform"
-                       :text "Composable data transformation helpers."
-                       :href "std-lib-transform.html"}
-                      {:meta "Traversal"
-                       :title "std.lib.walk"
-                       :text "Walking and traversal helpers."
-                       :href "std-lib-walk.html"}
-                      {:meta "Zippers"
-                       :title "std.lib.zip"
-                       :text "Zipper navigation and editing helpers."
-                       :href "std-lib-zip.html"}]}]]
+[[:card-grid
+  {:title "Library families"
+   :lead "Start with a family overview, then follow its focused pages and walkthroughs."
+   :items
+   [{:meta "Concurrency" :title "std.concurrent" :text "Queues, executors, requests, relays, pools, and threads." :href "std-concurrent.html"}
+    {:meta "JVM" :title "jvm.*" :text "Artifacts, classloaders, namespaces, reflection, monitoring, and tools." :href "jvm-index.html"}
+    {:meta "Integrations" :title "lib.*" :text "Databases, containers, search, messaging, storage, and repositories." :href "lib-index.html"}
+    {:meta "Dispatch" :title "std.dispatch" :text "Boards, hubs, queues, debounce, hooks, and dispatch core." :href "std-dispatch.html"}
+    {:meta "Filesystem" :title "std.fs" :text "Paths, walking, archives, attributes, and watchers." :href "std-fs.html"}
+    {:meta "Scheduling" :title "std.scheduler" :text "Runners, programs, spawns, and scheduled task lifecycle." :href "std-scheduler.html"}
+    {:meta "Text" :title "std.string" :text "Case, coercion, paths, pluralization, prose, and wrapping." :href "std-string.html"}
+    {:meta "Tasks" :title "std.task" :text "Process and bulk task execution." :href "std-task.html"}
+    {:meta "Time" :title "std.time" :text "Time coercion, durations, zones, formats, and representations." :href "std-time.html"}
+    {:meta "Timeseries" :title "std.timeseries" :text "Journals, intervals, ranges, computation, and processing." :href "std-timeseries.html"}
+    {:meta "Code" :title "std.block" :text "Code representation, traversal, and manipulation." :href "std-block.html"}]}]]
+
+[[:card-grid
+  {:title "std.lib"
+   :lead "Focused foundational utilities."
+   :items
+   [{:meta "Invocation" :title "std.lib.apply" :text "Applicative invocation and host applicatives." :href "std-lib-apply.html"}
+    {:meta "State" :title "std.lib.atom" :text "Nested atoms, batch updates, cursors, and derived state." :href "std-lib-atom.html"}
+    {:meta "Binary" :title "std.lib.bin" :text "Binary data, buffers, and low-level data handling." :href "std-lib-bin.html"}
+    {:meta "Classes" :title "std.lib.class" :text "Class, type, and reflection helpers." :href "std-lib-class.html"}
+    {:meta "Collections" :title "std.lib.collection" :text "Extended map, sequence, tree, and diff operations." :href "std-lib-collection.html"}
+    {:meta "Lifecycle" :title "std.lib.component" :text "Component lifecycle and system composition primitives." :href "std-lib-component.html"}
+    {:meta "Encoding" :title "std.lib.encode" :text "Encoding and decoding helpers." :href "std-lib-encode.html"}
+    {:meta "Enums" :title "std.lib.enum" :text "Enum and lookup helpers." :href "std-lib-enum.html"}
+    {:meta "Environment" :title "std.lib.env" :text "Namespace, resource, pprint, and debug utilities." :href "std-lib-env.html"}
+    {:meta "Foundation" :title "std.lib.foundation" :text "Basic predicates, constructors, and helpers." :href "std-lib-foundation.html"}
+    {:meta "Async" :title "std.lib.future" :text "Future and asynchronous coordination helpers." :href "std-lib-future.html"}
+    {:meta "I/O" :title "std.lib.io" :text "I/O helpers and stream handling." :href "std-lib-io.html"}
+    {:meta "Network" :title "std.lib.network" :text "Network and port utilities." :href "std-lib-network.html"}
+    {:meta "Resources" :title "std.lib.resource" :text "Classpath and filesystem resource helpers." :href "std-lib-resource.html"}
+    {:meta "Schemas" :title "std.lib.schema" :text "Schema definitions, lookups, and validation helpers." :href "std-lib-schema.html"}
+    {:meta "Security" :title "std.lib.security" :text "Security, keys, providers, ciphers, and verification helpers." :href "std-lib-security.html"}
+    {:meta "Sorting" :title "std.lib.sort" :text "Sorting, ordering, and topological utilities." :href "std-lib-sort.html"}
+    {:meta "Streams" :title "std.lib.stream" :text "Producers, collectors, pipelines, and transducers." :href "std-lib-stream.html"}
+    {:meta "Systems" :title "std.lib.system" :text "System topology, display, and lifecycle utilities." :href "std-lib-system.html"}
+    {:meta "Time" :title "std.lib.time" :text "Time coercion and temporal helpers." :href "std-lib-time.html"}
+    {:meta "Transforms" :title "std.lib.transform" :text "Composable data transformation helpers." :href "std-lib-transform.html"}
+    {:meta "Traversal" :title "std.lib.walk" :text "Walking and traversal helpers." :href "std-lib-walk.html"}
+    {:meta "Zippers" :title "std.lib.zip" :text "Zipper navigation and editing helpers." :href "std-lib-zip.html"}]}]]


### PR DESCRIPTION
## Summary

- turn `std.concurrent` into a documentation hub with a focused page for each public namespace
- add walkthroughs, examples, lifecycle guidance, and API references for the public `std.concurrent.*`, `jvm.*`, and `lib.*` libraries
- group lower-level implementation namespaces under their public parent page
- add JVM and integration overview pages
- register the new pages in `config/publish/std.edn`
- update the main `std` index with links to the new documentation families

## Coverage

- concurrency: atom, bus, executor, pool, print, queue, relay, request, request applicatives, request commands, and thread utilities
- JVM: artifacts, classloaders, dependencies, monitoring, namespaces, protocols, reflection, requiring, and REPL tools
- integrations: Aether, Docker, JDBC, Lucene, MinIO, OpenPGP, OSHI, PostgreSQL, RabbitMQ, and Redis

## Verification

- all 35 expected changed files are present
- each focused page and both family indexes are registered in the publishing configuration
- the main index links to the concurrent, JVM, and integration hubs
- the pull request is mergeable
- documentation generation has not been executed in this environment