### PR TITLE
Revert affected Python files to b930cba

### DIFF
--- a/src/hara/model/spec_python.clj
+++ b/src/hara/model/spec_python.clj
@@ -34,14 +34,6 @@
   [v]
   (if v "True" "False"))
 
-(defn python-tf-inif
-  "Python's `cond and then or else` ternary fails when `then` is falsy.
-   Wrap the branches in single-element lists so the truthiness test only
-   sees the list, then extract the chosen value with `[0]."
-  {:added "4.1"}
-  [[_ check then else]]
-  (list '. (list 'or (list 'and check [then]) [else]) [0]))
-
 (defn- python-qualified-symbol
   [sym]
   (let [{:keys [module]} (preprocess/macro-opts)
@@ -200,119 +192,17 @@
   (str "nonlocal "
        (string/join ", " (map #(common/*emit-fn* % grammar mopts) syms))))
 
-(defn- python-vargs-param?
-  "checks if an args vector uses the variadic `...` marker"
-  {:added "4.1"}
-  [args]
-  (and (vector? args)
-       (some #(= '... %) args)))
-
-(defn- python-vargs-collector-param?
-  "checks if an args vector uses the `[args]` variadic-collector convention"
-  {:added "4.1"}
-  [args]
-  (and (vector? args)
-       (= 1 (count args))
-       (symbol? (first args))
-       (= 'args (first args))))
-
-(declare python-replace-vargs-body)
-
-(defn- python-replace-vargs-body
-  "replaces `...` with vargs-sym in body forms and converts `[...]` to
-   (list vargs-sym)"
-  {:added "4.1"}
-  [form vargs-sym]
-  (cond (seq? form)
-        (with-meta
-          (apply list (map #(python-replace-vargs-body % vargs-sym) form))
-          (meta form))
-
-        (vector? form)
-        (let [items (vec (map #(python-replace-vargs-body % vargs-sym) form))]
-          (if (and (= 1 (count items))
-                   (= vargs-sym (first items)))
-            (list 'list vargs-sym)
-            (with-meta items (meta form))))
-
-        (= '... form)
-        vargs-sym
-
-        :else form))
-
-(defn- python-replace-vargs
-  "replaces `...` with vargs-sym in the args vector and body"
-  {:added "4.1"}
-  [form vargs-sym]
-  (let [[tag name args & more] form]
-    (apply list tag name
-           (vec (map #(if (= '... %) vargs-sym %) args))
-           (map #(python-replace-vargs-body % vargs-sym) more))))
-
-(defn- python-add-vargs-star
-  "post-processes a Python function header so the vargs parameter emits as *vargs"
-  {:added "4.1"}
-  [source vargs-sym]
-  (let [vargs-name (name vargs-sym)
-        pattern (re-pattern (str vargs-name "\\s*=\\s*None\\):"))]
-    (clojure.string/replace source pattern (str "*" vargs-name "):"))))
-
-(defn- python-default-nil
-  "gives every plain parameter a default of nil so that Python matches JS/Lua
-   semantics for omitted trailing arguments. Only applies when every parameter
-   is a simple symbol (or the variadic `...` marker) to avoid Python's
-   'parameter without a default follows parameter with a default' error."
-  {:added "4.1"}
-  [args]
-  (if-not (and (vector? args)
-               (every? symbol? args)
-               (not (some #(#{:= '&} %) args)))
-    args
-    (vec (mapcat (fn [i]
-                   (let [a (nth args i)
-                         n (nth args (inc i) nil)]
-                     (if (and (symbol? a)
-                              (not= '... a)
-                              (not= '& a)
-                              (not= := n))
-                       [a := nil]
-                       [a])))
-                 (range (count args))))))
-
 (defn python-defn-
   "hidden function without decorators"
   {:added "4.0"}
   [form grammar mopts]
   (let [[tag name args & more] form
-        more (python-prepend-nonlocals name args more)
-        collector? (python-vargs-collector-param? args)
-        args (-> (python-apply-optional-defaults name args)
-                 (python-default-nil))]
-    (if (or (python-vargs-param? args)
-            collector?)
-      (let [vargs-sym (if collector?
-                        'args
-                        (gensym "vargs__"))
-            form* (python-replace-vargs
-                   (list* tag name args more)
-                   vargs-sym)
-            form* (if collector?
-                    (let [[tag name args & body] form*]
-                      (apply list tag name args
-                             (cons (list 'var 'args (list 'list 'args))
-                                   body)))
-                    form*)
-            output (top/emit-top-level
-                    :defn
-                    form*
-                    grammar
-                    mopts)]
-        (python-add-vargs-star output vargs-sym))
-      (top/emit-top-level
-       :defn
-       (list* tag name args more)
-       grammar
-       mopts))))
+        more (python-prepend-nonlocals name args more)]
+    (top/emit-top-level
+     :defn
+      (list* tag name (python-apply-optional-defaults name args) more)
+     grammar
+     mopts)))
 
 (defn python-defn
   "creates a defn function for python"
@@ -503,7 +393,6 @@
          :for-array   {:macro #'tf-for-array  :emit :macro}
          :for-iter    {:macro #'tf-for-iter   :emit :macro}
          :for-index   {:macro #'tf-for-index  :emit :macro}
-         :inif        {:macro #'python-tf-inif :emit :macro}
          :prototype-get       {:macro #'python-tf-prototype-get     :emit :macro}
          :prototype-set       {:macro #'python-tf-prototype-set     :emit :macro}
          :prototype-create    {:macro #'python-tf-prototype-create  :emit :macro
@@ -519,7 +408,6 @@
         :del       {:op :del     :symbol #{'del}  :raw "del"  :emit :prefix}
         :pass      {:op :pass    :symbol #{'pass} :raw "pass" :emit :return :type :special}
         :nan       {:op :nan     :symbol #{'NaN}  :raw "NaN"  :value true :emit :throw}
-         :vargs     {:op :vargs   :symbol '#{...} :raw "args" :value true :emit :throw}
          :nonlocal  {:op :nonlocal :symbol #{'nonlocal} :emit #'python-emit-nonlocal}
          :with      {:op :with    :symbol #{'with} :type :block
                      :block  {:main #{:parameter :body}}}})))
@@ -537,7 +425,7 @@
                   :function  {:raw "lambda"
                               :args      {:start " " :end ":" :space ""}
                               :body      {:start "" :end "" :append true}}
-                  :infix     {:if  {:check " if " :then " else "}}
+                  :infix     {:if  {:check "and" :then "or"}}
                   :global    {:reference '(globals)}}
         :token   {:nil       {:as "None"}
                   :boolean   {:as #'python-token-boolean}
@@ -548,7 +436,6 @@
                                                  :args {:start "" :end ":" :space ""}}}}
                    :branch   {:control {:elseif {:raw "elif"}}}}
         :data     {:map-entry {:key-fn data/default-map-key}
-                   :map       {:start "__XtObject({" :end "})" :space ""}
                    :set       {:start "{" :end "}" :space ""}
                    :vector    {:start "[" :end "]" :space ""}
                    :tuple     {:start "(" :end ")" :space ""}

--- a/src/hara/model/spec_python/rewrite.clj
+++ b/src/hara/model/spec_python/rewrite.clj
@@ -208,12 +208,6 @@
              (concat (map python-normalize-form body)
                      (map python-rewrite-handler handlers))))))
 
-(defn- python-spread-form?
-  [form]
-  (and (collection/form? form)
-       (= :.. (first form))
-       (= 2 (count form))))
-
 (defn- python-rewrite-list
   [form]
   (cond
@@ -228,10 +222,6 @@
 
     (= 'try (first form))
     (python-rewrite-try form)
-
-    (python-spread-form? form)
-    (with-form-meta form
-      (list :* (python-normalize-form (second form))))
 
     :else
     (with-form-meta form

--- a/src/hara/model/spec_xtalk/fn_python.clj
+++ b/src/hara/model/spec_xtalk/fn_python.clj
@@ -215,10 +215,7 @@
 
 (defn python-tf-x-to-number
   [[_ e]]
-  (list ':?
-        (list '. e '(isdigit))
-        (list 'int e)
-        (list 'float e)))
+  (list 'float e))
 
 (defn python-tf-x-is-string?
   [[_ e]]

--- a/src/hara/runtime/basic/impl/process_python.clj
+++ b/src/hara/runtime/basic/impl/process_python.clj
@@ -14,15 +14,6 @@
             [std.lib.os :as os]
             [xt.lang.common-lib :as lib]))
 
-(def ^{:added "4.1"
-       :doc "Base dict subclass that lets emitted xtalk objects use attribute-style\n   access for keys (e.g. obj._size) while still behaving as dicts."}
-  +python-obj-helper+
-  (str "class __XtObject(dict):\n"
-       "    def __getattr__(self, key):\n"
-       "        return self.get(key)\n"
-       "    def __setattr__(self, key, value):\n"
-       "        self[key] = value\n"))
-
 (def +python-init+
   (common/put-program-options
    :python  {:default  {:oneshot     :cpython
@@ -108,9 +99,7 @@
                    {:lang :python
                     :layout :flat})]
     (fn [body]
-      (str +python-obj-helper+
-           "\n\n"
-           bootstrap
+      (str bootstrap
            "\n\n"
            (impl/emit-as
             :python [(list 'print (list 'return-eval body))])))))
@@ -181,9 +170,7 @@
                          :python +client-basic+)]
                        (clojure.string/join "\n\n"))]
     (fn [port & [{:keys [host]}]]
-      (str +python-obj-helper+
-           "\n\n"
-           bootstrap
+      (str bootstrap
            "\n\n"
            (impl/emit-as
             :python [(list 'client-basic
@@ -244,9 +231,7 @@
                          :python +client-ws+)]
                        (clojure.string/join "\n\n"))]
     (fn [port & [{:keys [host]}]]
-      (str +python-obj-helper+
-           "\n\n"
-           bootstrap
+      (str bootstrap
            "\n\n"
            (impl/emit-as
             :python [(list 'client-ws


### PR DESCRIPTION
## Summary

Restore the affected Python emitter and runtime files to their state at `b930cba06541b2fbf003a38f5c2724bc4d3c7f6a`.

## Files restored

- `src/hara/model/spec_python.clj`
- `src/hara/model/spec_python/rewrite.clj`
- `src/hara/model/spec_xtalk/fn_python.clj`
- `src/hara/runtime/basic/impl/process_python.clj`

All other changes currently on `main`, including documentation and changes for other target languages, are preserved.

## Reason

Recent Python emitter/runtime changes are associated with failures in the Python xtbench jobs, including generated callback arity and runtime compatibility errors.

## Verification

The branch diff against `main` contains exactly the four Python files listed above. CI should confirm whether restoring these files resolves the affected Python jobs.