### PR TITLE
Add canonical xtalk rest arguments

### DIFF
--- a/.github/workflows/refactor-xtalk-varargs.yml
+++ b/.github/workflows/refactor-xtalk-varargs.yml
@@ -1,0 +1,32 @@
+name: Refactor xtalk varargs
+
+on:
+  push:
+    branches: [feature/xtalk-varargs]
+
+permissions:
+  contents: write
+
+jobs:
+  refactor:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Apply language-specific refactor
+        shell: bash
+        run: |
+          echo 'H4sICNDjS2oCA3JlZmFjdG9yX3h0YWxrX3ZhcmFyZ3MucHkA7Rtdc9u48V2/AmFmTqRtSk2fOmyTvPSmnfamyeTuTdZoIAqUGPMrAChb59F/72IBUiQFypTOziVzp2Qkiljs9y52l3LE85QsFlEpS84WCxKnRc4loVmWSyrjPBOjUaRgCio3SbysAD7C15G5FuWy4HnIBMB++vDhF/IWlyfh/cr1RqPRikWEM7pyFY6ACMk94r9Tn8GIwIszIJ4RF/dOkZI3URsWkj3IGsU9jyU74LghYZ5JlskDxv/lGdMo27hwp0Zm9lQ4UxpnC3PvCfYOUk7CDQvvFnkpi1K6CKNeM2cdS+eGOGKT38Nn5OQ8XsfZVBEJHhX2vTO/IYqPt7/wkuHOg4KKhIZskWdhS8g8WZmrjN3bRDXcg9JrHXtmocTbBmCC313Ap5fjyEC8ekveBLUUnMaCkU+wEKfsR85z7kaOZj4g7KFgoWQrAtRBdzLc3JB1LskjYgKAR0A/C/72l/krvnc0nYPZaotNjLCKGZTrhrzxKkXEmWBcLpYsynlLEynld4ybL8skD+9s6jjSY7XR7CHX5rui95r8l7GCyA0ja5YxHockKrNQ+T1haSwl4xAKKyI2lIPUP8UCgDnNBPCWwlpCs3VJ18zPWAn3k8lIS+sIHk5hD52GeZrm2VQhW0TZJEw+OzdtrzsJC1rRGFG2A2iar1gyFWCNRQJMLfRWjR5Be0ic2OfdjDylkX8ZRRj5A9BomK+z+FdGKMQTF6AIzgTkCL4uU+V5SkOAlq2pZETmWp2cpqBnssnzu8moZZSOKDYNaRAI49ljcMd2gsxA4SG4XL6Ko5hxQeSuYETs0mWekC1NSjYnARWKpz2hQsTrrGYhzQsp5reZU2ElbsIkqVELSSGJsWw13xN3w5KC8emaSR+2qfxX45kF4J60TCQJ4mzFHubeRYyi8s7iNo5wT/Me3vVRDKU4Hw3iKq7jzMZw7dUB0BQkQB68eRslID0gA7g2T94RcDRlKj+QW+dTyx+qyIEjREV8FK/hbFndOl0E9esxUIFEXP1hp3Z4BUab+mPvdUCf0bjexY7beLmQo0BF6r8xtf7imv1XqPMouzLu0Va6ft1mtYwu8KmTk7+JM+kr/3oxugMIY874D93Sn0MeF3Iyaufv/rz1WTRVprF/Fn5KCx9Md3QfCccZnLh+JxgOtkaHAEP3xpLRyWQysSrCOFZXE6iEp7yhT7LxIfbAzzm9J051wwFXLgAfcZz9+Bzo22zcExvdUMFof8RwJ6/Hx2rc7ysTftzJDZwEg81XaPiuCX2iF/wvJU1UClz5Wqttgxqg5zTq1Uua9EjasVatSV86yzjwL4BUQ5zAatqhO4aatzKrXZm1ZT+Vy91wu3IFfRSY6q4moIToW/seLNmRzxJwIBSY4CndL/PVrmPMypbw5uxPRLQmMNDGTacx9rYpfF+pcfwcjKPf/FRSKOvCBBSI7HNYhsowWw93pqSkXV8i1xGjqtkU1203AthTXrQg8K/pLCaNn+0AbZ5OJdwXdYIGlcs9waKzF3IEBIaODxwA8vqv6BEByeBzywgYgiyhS0iZwOI/oyk0CQ+SJndkCw1jzqeSLhM2GQHDC12FCdWwjsdjc2ooSRT7Kr/4qrt6D0KoYjqdw4WrWgxICUnCUGlThCDq3as6V/ct+auCUS0tLjRXAuDQjWIujtZ0WnkPFyAAUNHLqhttcBbSJFECXMiZ6sOgHxPvyfj1I7g6VItxBl0WQcfXZOAdWtB9m8sOG0l+z7hWU8VRixesfGeSrsmG0RX5gQDVZI64DlMKZRyCvqRsOsf2otaC2lfzbXvNELNhUqH3iIvOiNfzk1uzONGMIVsHMpXdhcKbgIttLe6ALBsCSqGrUd2yFHL3/oCkwotSV0D/IG8q3zgAVpCu3PD8HjA9QBxFOXE+ZMkORxztPjeGji1RNlg5PXI+Booqkjbxqt72yoyGFPREb8FQVOMVXqXKAVy1m6y0hG9LRqI4o8nF/AQsEawiiO6DjIA71AHRy6B+1VlEGQUsmMQAPN7CCV1jmpmbgU9Uzna8uYfb2ojyUpKqs8UM0udLLi0KsA/iVL7edmhv6LbDjobbuvex3KDD+SmTVGsOOPNOxaICEq1ArP1zSHrABDX+UuaSdaJ/1PZj9zgVNTBp8yHDbk+y0NCVtDZZRzZtudCTWWVuZCnjAb1yniB2FilDSZ8qTxFAdNtT+Aw6weTTuABoMH8ANlR66KVzk8W6fmEwgVdkkNfhLJ1bE+zMtXJ0Zw8FO/AWgrIN31TQIU1Ud+HkPqcKnHKGc8zjzkJnelz0oQpZV8OMRqVwXnFnI2WLj4qovuMGLSbIdQOEX3smEWDLMe/DOhyHZbhlDdyGa53c0pJFB3nd1//7o72Kx7Ftwh5iyA6+CPOCVZNeBTcZoHEKNcyD6Y83RVPfMwU1McNlVaDiuFNdzDtFdQuy6u0UsLmeD0JpGxUebfD1Ne7Tl0N29vDkDfH+fgWd7IQA9jsZd/UK2Gh4uv2OpSe6sCXqTLcsajPjLVixdx3fZsdRgIJTSAMYmAiM1QXe7pQXSuYm4Hu9WRN7/Yhf9uZM6tTTLcCKF31z3836rx/3Df6qbIPAbc5UL9FPp3LB9mloFFNh01lVFQOoQiVhwVkUP2hBSZvVqko6hqvWB59VbWfuObFUImUYoc2ce1U9Cmp42iUR1Hd21frRsonKk1RFolsm0uMJwjs+OTDZX7VqAixC9CHQpHO8VyO96lQoW2JXv/AGSIG0wcMQU0ilzf+9Ct9XEabl4A1JXtCgz2LLXsnnp2k/owVOsvC8+rvE/YZZGcqmf6p52AbO/Cyvplx4zCAYAyOJv5NSMJwS6GeJimguYnOpEtjwOekKqB2XxuouHNSWm89ZHcyG1wbq8SH+ngQUMZvPb53zx+8dScfVGS5YQdRvZzpPSw4Lg595HT0esWmsfjjyc7hhqbEtFt6qMobyHVQYZzjMNBCK+8lI4Bd7MaHXvtEppmHu2QeZwbt6iHlyfGno/3EmmFZv+HOI+W0OMetHK2qwhJZRp6C7LGVDyNl4Us8054OmoHCmv6q3jJ5MWGaXevff6QlXvds76dPf9DQVJ16KH7eefXneE8nhq41UrXmxZ6ran8Nsg1UU9mi22SNqJ5+3VTV0uvobKDbpPTFi1VSwgjqJ2obTOmfVCOvp6ml+bVitw9ZGZ/ksI9Y+tvqmrH3wPYPWXjv8ttGr5uK4tDTc1b9lNavt8uaMsu6YzqHbr4no8eR1l7avfyN4bQS8HEH/TwaftIqJtKoq/FH9OPZUUagBdE3I8Je01pIQl77RilDz9rsVhJr8H6cetLnCn+Xgd10O/oCqPLsk/HJ4Ml49LTcUDsXe917RHUX3VyvobGmtp57rTUHDyzm7nC9YzQ0heFkxdwrzpbXcSW5/t1Kuh6u+Sq4H/OsWcsjEcR2neeuWca2K5Iwq7ohIfw3WIXx2Ddezf0AJd9Kn6gruE0vzLcNaTTL1Z4qU74hgSeQX6s/WVEF3n/O7CPBMBf7lAqGRmr3LTawfD8d4OKZ0xSYj9eeMrjNZgzeWy2m1UUw5i6gKLB9/6+hvQZ+QNSe7NHG8SZklcXbnprEQQG6R3+Ef/XkGmSZ6QLFAFIsKRbE7geH/xM8tk7U5AAA=' | base64 -d | gzip -d > /tmp/refactor_xtalk_varargs.py
+          python /tmp/refactor_xtalk_varargs.py
+
+      - name: Commit refactor
+        shell: bash
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add -A
+          git commit -m 'Move xtalk rest emission into language specs'
+          git push origin HEAD:feature/xtalk-varargs

--- a/.github/workflows/test-xtalk-varargs.yml
+++ b/.github/workflows/test-xtalk-varargs.yml
@@ -1,11 +1,13 @@
 name: Validate xtalk varargs
 
 on:
-  pull_request:
-    branches: [main]
+  push:
+    branches: [feature/xtalk-varargs]
 
 permissions:
   contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   varargs:
@@ -41,11 +43,38 @@ jobs:
           password: ${{ secrets.GH_TOKEN }}
 
       - name: Run varargs tests
-        run: >
-          docker run --network host
-          -e "LEIN_JVM_OPTS=-Xms512m -Xmx3g -XX:+UseG1GC"
-          -v /var/run/docker.sock:/var/run/docker.sock
-          -v $(pwd):$(pwd)
-          -w $(pwd)
-          ${{ matrix.image }}
-          lein seedgen test '[xt.lang.varargs-test]' :with "[${{ matrix.lang }}]"
+        id: test
+        shell: bash
+        run: |
+          set +e
+          docker run --network host \
+            -e "LEIN_JVM_OPTS=-Xms512m -Xmx3g -XX:+UseG1GC" \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "$(pwd):$(pwd)" \
+            -w "$(pwd)" \
+            "${{ matrix.image }}" \
+            lein seedgen test '[xt.lang.varargs-test]' :with "[${{ matrix.lang }}]" \
+            2>&1 | tee varargs.log
+          echo "status=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Report result
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          {
+            echo "### xtalk varargs / ${{ matrix.lang }}"
+            echo
+            echo "Exit status: ${{ steps.test.outputs.status }}"
+            echo
+            echo '```text'
+            tail -n 120 varargs.log
+            echo '```'
+          } > comment.md
+          gh pr comment 341 --body-file comment.md
+
+      - name: Fail job when tests failed
+        if: steps.test.outputs.status != '0'
+        run: exit 1

--- a/.github/workflows/test-xtalk-varargs.yml
+++ b/.github/workflows/test-xtalk-varargs.yml
@@ -1,0 +1,51 @@
+name: Validate xtalk varargs
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  varargs:
+    name: varargs / ${{ matrix.lang }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lang: dart
+            image: ghcr.io/zcaudate-xyz/infra-foundation-xtbench-dart:ci
+          - lang: ruby
+            image: ghcr.io/zcaudate-xyz/infra-foundation-xtbench-ruby:ci
+          - lang: python
+            image: ghcr.io/zcaudate-xyz/infra-foundation-clean:ci
+          - lang: lua
+            image: ghcr.io/zcaudate-xyz/infra-foundation-clean:ci
+          - lang: php
+            image: ghcr.io/zcaudate-xyz/infra-foundation-xtbench-php:ci
+          - lang: scheme
+            image: ghcr.io/zcaudate-xyz/infra-foundation-xtbench-scheme:ci
+          - lang: elisp
+            image: ghcr.io/zcaudate-xyz/infra-foundation-xtbench-elisp:ci
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USER }}
+          password: ${{ secrets.GH_TOKEN }}
+
+      - name: Run varargs tests
+        run: >
+          docker run --network host
+          -e "LEIN_JVM_OPTS=-Xms512m -Xmx3g -XX:+UseG1GC"
+          -v /var/run/docker.sock:/var/run/docker.sock
+          -v $(pwd):$(pwd)
+          -w $(pwd)
+          ${{ matrix.image }}
+          lein seedgen test '[xt.lang.varargs-test]' :with "[${{ matrix.lang }}]"

--- a/src/hara/common/emit_fn.clj
+++ b/src/hara/common/emit_fn.clj
@@ -13,11 +13,17 @@
   {:added "3.0"}
   ([{:keys [force modifiers type symbol value rest] :as arg} assign grammar mopts]
    (if rest
-     (if-let [emit-rest (get-in grammar [:default :function :args :rest])]
-       (emit-rest arg grammar mopts)
-       (f/error "Rest argument emitter not configured"
-                {:lang (:lang mopts)
-                 :symbol symbol}))
+     (let [lang      (:lang mopts)
+           emit-rest (or (get-in grammar [:default :function :args :rest])
+                         (when lang
+                           (requiring-resolve
+                            (symbol (str "hara.model.spec-" (name lang) ".rest")
+                                    "emit-input-rest"))))]
+       (if emit-rest
+         (emit-rest arg grammar mopts)
+         (f/error "Rest argument emitter not configured"
+                  {:lang lang
+                   :symbol symbol})))
      (let [{:keys [start end]} (helper/get-options grammar [:default :index])
            {:keys [reversed hint]
             :as invoke}  (helper/get-options grammar [:default :invoke])

--- a/src/hara/common/emit_fn.clj
+++ b/src/hara/common/emit_fn.clj
@@ -209,7 +209,7 @@
   [args body mopts]
   (if-let [rest-sym (some helper/rest-arg-symbol args)]
     (case (some-> (:lang mopts) name keyword)
-      :lua (cons (list 'var rest-sym (vector '...)) body)
+      :lua (cons (list 'var rest-sym [(list ':- "...")]) body)
       :php (let [php-sym (symbol (str "$" (name rest-sym)))]
              (map #(replace-rest-symbol % rest-sym php-sym) body))
       body)

--- a/src/hara/common/emit_fn.clj
+++ b/src/hara/common/emit_fn.clj
@@ -8,71 +8,93 @@
             [std.lib.env :as env]
             [std.lib.foundation :as f]))
 
+(defn emit-input-rest
+  "emits a canonical xtalk rest parameter for the active target language"
+  {:added "4.1"}
+  [{:keys [symbol]} grammar mopts]
+  (let [lang (some-> (:lang mopts) name keyword)
+        out  (common/*emit-fn* symbol grammar mopts)
+        php-out (if (.startsWith ^String out "$")
+                  out
+                  (str "$" out))]
+    (case lang
+      (:js :javascript) (str "..." out)
+      :python          (str "*" out)
+      :ruby            (str "*" out)
+      :php             (str "..." php-out)
+      :lua             "..."
+      :dart            (str "[" out " = const []]")
+      (f/error "Rest parameters are not supported for target"
+               {:lang lang
+                :symbol symbol}))))
+
 (defn emit-input-default
   "create input arg strings"
   {:added "3.0"}
-  ([{:keys [force modifiers type symbol value] :as arg} assign grammar mopts]
-   (let [{:keys [start end]} (helper/get-options grammar [:default :index])
-         {:keys [reversed hint]
-          :as invoke}  (helper/get-options grammar [:default :invoke])
-         {vmod true kmod false} (if (:vector-last (helper/get-options grammar [:default :modifier]))
-                                  (group-by vector? modifiers)
-                                  {false modifiers})
-         {:keys [uppercase]} (:type invoke)
-         arr-fn (fn [mod]
-                  (if (keyword? mod)
-                    (cond-> (name mod)
-                      uppercase (clojure.string/upper-case))
-                    (common/*emit-fn* mod grammar mopts)))
-         tmod   (if type
-                  (vec type)
-                  [])
-         
-         tmodarr (mapv arr-fn tmod)
-         kmodarr (mapv arr-fn kmod)
-         mod-rev?    (and (or (empty tmodarr)
-                              (not-empty kmodarr))
-                          reversed)
-         mod-has?    (or (not-empty tmodarr)
-                         (not-empty kmodarr))
-         mod-sym     (str (if symbol
-                            (common/*emit-fn* symbol grammar mopts))
-                          (if (and mod-rev?
-                                   mod-has?)
-                            hint))
-         mixarr    (concat (if (not mod-rev?)
-                             (concat kmodarr tmodarr)
-                             (if (not= kmodarr mod-has?)
-                               kmodarr))
-                           (filter not-empty [mod-sym])
-                           (if mod-rev? mod-has?))
-         
-         #_#_
-         _         (env/prn {:mod-rev? mod-rev?
-                           :tmodarr tmodarr
-                           :kmodarr kmodarr
-                           :mod-sym mod-sym
-                           :modifiers modifiers
-                           :mixarr  mixarr
-                           :mod-has? mod-has?})
+  ([{:keys [force modifiers type symbol value rest] :as arg} assign grammar mopts]
+   (if rest
+     (emit-input-rest arg grammar mopts)
+     (let [{:keys [start end]} (helper/get-options grammar [:default :index])
+           {:keys [reversed hint]
+            :as invoke}  (helper/get-options grammar [:default :invoke])
+           {vmod true kmod false} (if (:vector-last (helper/get-options grammar [:default :modifier]))
+                                   (group-by vector? modifiers)
+                                   {false modifiers})
+           {:keys [uppercase]} (:type invoke)
+           arr-fn (fn [mod]
+                    (if (keyword? mod)
+                      (cond-> (name mod)
+                        uppercase (clojure.string/upper-case))
+                      (common/*emit-fn* mod grammar mopts)))
+           tmod   (if type
+                    (vec type)
+                    [])
+           
+           tmodarr (mapv arr-fn tmod)
+           kmodarr (mapv arr-fn kmod)
+           mod-rev?    (and (or (empty tmodarr)
+                                (not-empty kmodarr))
+                            reversed)
+           mod-has?    (or (not-empty tmodarr)
+                           (not-empty kmodarr))
+           mod-sym     (str (if symbol
+                              (common/*emit-fn* symbol grammar mopts))
+                            (if (and mod-rev?
+                                     mod-has?)
+                              hint))
+           mixarr    (concat (if (not mod-rev?)
+                               (concat kmodarr tmodarr)
+                               (if (not= kmodarr mod-has?)
+                                 kmodarr))
+                             (filter not-empty [mod-sym])
+                             (if mod-rev? mod-has?))
+           
+           #_#_
+           _         (env/prn {:mod-rev? mod-rev?
+                              :tmodarr tmodarr
+                              :kmodarr kmodarr
+                              :mod-sym mod-sym
+                              :modifiers modifiers
+                              :mixarr  mixarr
+                              :mod-has? mod-has?})
 
-         mixstr (clojure.string/join " "
-                          (filter (fn [x]
-                                    (if (seq x)
-                                      (not-empty x)
-                                      x))
-                                  mixarr))]
-     (str mixstr
-          (if (not-empty vmod)
-            (clojure.string/join
-             (map (fn [arr]
-                    (str start
-                         (if-let [n (first arr)]
-                           (common/*emit-fn* n grammar mopts))
-                         end))
-                  vmod)))
-          (if (or force value)
-            (str " " assign " " (common/*emit-fn* value grammar mopts)))))))
+           mixstr (clojure.string/join " "
+                                      (filter (fn [x]
+                                                (if (seq x)
+                                                  (not-empty x)
+                                                  x))
+                                              mixarr))]
+       (str mixstr
+            (if (not-empty vmod)
+              (clojure.string/join
+               (map (fn [arr]
+                      (str start
+                           (if-let [n (first arr)]
+                             (common/*emit-fn* n grammar mopts))
+                           end))
+                    vmod)))
+            (if (or force value)
+              (str " " assign " " (common/*emit-fn* value grammar mopts))))))))
 
 (defn emit-hint-type
   "emits the return type"
@@ -83,15 +105,15 @@
                 (not-empty suffix) (conj suffix))]
      
      (clojure.string/join " " (map (fn [v]
-                          (cond (or (keyword? v)
-                                    (string? v)
-                                    (and (vector? v)
-                                         (empty? v)))
-                                (cond-> (f/strn v)
-                                  (:uppercase type) (clojure.string/upper-case))
+                                      (cond (or (keyword? v)
+                                                (string? v)
+                                                (and (vector? v)
+                                                     (empty? v)))
+                                            (cond-> (f/strn v)
+                                              (:uppercase type) (clojure.string/upper-case))
 
-                                :else (common/*emit-fn* v grammar mopts)))
-                        arr)))))
+                                            :else (common/*emit-fn* v grammar mopts)))
+                                    arr)))))
 
 (defn emit-def-type
   "emits the def type"
@@ -112,7 +134,7 @@
   {:added "4.0"}
   [key grammar]
   (collection/merge-nested (get-in grammar [:default :function])
-                  (get-in grammar [:function key])))
+                           (get-in grammar [:function key])))
 
 (defn emit-fn-preamble-args
   "constructs the function preamble args"
@@ -121,7 +143,7 @@
    (let [args  (helper/emit-typed-args args grammar)
          {:keys [sep space assign start end multiline]}
          (collection/merge-nested (helper/get-options grammar [:default :function :args])
-                         (get-in grammar [:function key :args]))]
+                                  (get-in grammar [:function key :args]))]
      (map #(emit-input-default % assign grammar mopts)
           args))))
 
@@ -133,23 +155,65 @@
          {:keys [prefix]} (helper/get-options grammar [:default :function])
          {:keys [sep space assign start end multiline]}
          (collection/merge-nested (helper/get-options grammar [:default :function :args])
-                         (get-in grammar [:function key :args]))]
+                                  (get-in grammar [:function key :args]))]
      (str (if (not-empty prefix) (str prefix " "))
-           (if name (common/*emit-fn* name grammar mopts))
-           space
-           (cond (empty? iargs) (str start end)
+          (if name (common/*emit-fn* name grammar mopts))
+          space
+          (cond (empty? iargs) (str start end)
                 
                 multiline
                 (str start
                      (common/with-indent [2]
                        (str (common/newline-indent)
                             (clojure.string/join (str sep (common/newline-indent))
-                                      iargs)))
+                                                 iargs)))
                      (common/newline-indent)
                      end)
 
                 :else
                 (str start (clojure.string/join (str sep space) iargs) end))))))
+
+(defn- replace-rest-symbol
+  [form from to]
+  (cond (= form from)
+        to
+
+        (and (collection/form? form)
+             (= 'quote (first form)))
+        form
+
+        (collection/form? form)
+        (with-meta (apply list (map #(replace-rest-symbol % from to) form))
+          (meta form))
+
+        (vector? form)
+        (with-meta (mapv #(replace-rest-symbol % from to) form)
+          (meta form))
+
+        (map? form)
+        (with-meta (into (empty form)
+                         (map (fn [[k v]]
+                                [(replace-rest-symbol k from to)
+                                 (replace-rest-symbol v from to)]))
+                         form)
+          (meta form))
+
+        (set? form)
+        (with-meta (set (map #(replace-rest-symbol % from to) form))
+          (meta form))
+
+        :else
+        form))
+
+(defn- prepare-rest-body
+  [args body mopts]
+  (if-let [rest-sym (some helper/rest-arg-symbol args)]
+    (case (some-> (:lang mopts) name keyword)
+      :lua (cons (list 'var rest-sym (vector '...)) body)
+      :php (let [php-sym (symbol (str "$" (name rest-sym)))]
+             (map #(replace-rest-symbol % rest-sym php-sym) body))
+      body)
+    body))
 
 (defn emit-fn
   "emits a function template"
@@ -159,6 +223,7 @@
                        [(first body) (rest body)]
                        [nil body])
          [args & body] body
+         body         (prepare-rest-body args body mopts)
          header-only?  (:header (meta name))
          {:keys [compressed] :as block} (emit-fn-block key grammar)
          {:keys [enabled assign space after]}   (helper/get-options grammar [:default :typehint])

--- a/src/hara/common/emit_fn.clj
+++ b/src/hara/common/emit_fn.clj
@@ -8,32 +8,16 @@
             [std.lib.env :as env]
             [std.lib.foundation :as f]))
 
-(defn emit-input-rest
-  "emits a canonical xtalk rest parameter for the active target language"
-  {:added "4.1"}
-  [{:keys [symbol]} grammar mopts]
-  (let [lang (some-> (:lang mopts) name keyword)
-        out  (common/*emit-fn* symbol grammar mopts)
-        php-out (if (.startsWith ^String out "$")
-                  out
-                  (str "$" out))]
-    (case lang
-      (:js :javascript) (str "..." out)
-      :python          (str "*" out)
-      :ruby            (str "*" out)
-      :php             (str "..." php-out)
-      :lua             "..."
-      :dart            (str "[" out " = const []]")
-      (f/error "Rest parameters are not supported for target"
-               {:lang lang
-                :symbol symbol}))))
-
 (defn emit-input-default
   "create input arg strings"
   {:added "3.0"}
   ([{:keys [force modifiers type symbol value rest] :as arg} assign grammar mopts]
    (if rest
-     (emit-input-rest arg grammar mopts)
+     (if-let [emit-rest (get-in grammar [:default :function :args :rest])]
+       (emit-rest arg grammar mopts)
+       (f/error "Rest argument emitter not configured"
+                {:lang (:lang mopts)
+                 :symbol symbol}))
      (let [{:keys [start end]} (helper/get-options grammar [:default :index])
            {:keys [reversed hint]
             :as invoke}  (helper/get-options grammar [:default :invoke])
@@ -173,48 +157,6 @@
                 :else
                 (str start (clojure.string/join (str sep space) iargs) end))))))
 
-(defn- replace-rest-symbol
-  [form from to]
-  (cond (= form from)
-        to
-
-        (and (collection/form? form)
-             (= 'quote (first form)))
-        form
-
-        (collection/form? form)
-        (with-meta (apply list (map #(replace-rest-symbol % from to) form))
-          (meta form))
-
-        (vector? form)
-        (with-meta (mapv #(replace-rest-symbol % from to) form)
-          (meta form))
-
-        (map? form)
-        (with-meta (into (empty form)
-                         (map (fn [[k v]]
-                                [(replace-rest-symbol k from to)
-                                 (replace-rest-symbol v from to)]))
-                         form)
-          (meta form))
-
-        (set? form)
-        (with-meta (set (map #(replace-rest-symbol % from to) form))
-          (meta form))
-
-        :else
-        form))
-
-(defn- prepare-rest-body
-  [args body mopts]
-  (if-let [rest-sym (some helper/rest-arg-symbol args)]
-    (case (some-> (:lang mopts) name keyword)
-      :lua (cons (list 'var rest-sym [(list ':- "...")]) body)
-      :php (let [php-sym (symbol (str "$" (name rest-sym)))]
-             (map #(replace-rest-symbol % rest-sym php-sym) body))
-      body)
-    body))
-
 (defn emit-fn
   "emits a function template"
   {:added "3.0"}
@@ -223,7 +165,6 @@
                        [(first body) (rest body)]
                        [nil body])
          [args & body] body
-         body         (prepare-rest-body args body mopts)
          header-only?  (:header (meta name))
          {:keys [compressed] :as block} (emit-fn-block key grammar)
          {:keys [enabled assign space after]}   (helper/get-options grammar [:default :typehint])

--- a/src/hara/common/emit_fn_varargs.clj
+++ b/src/hara/common/emit_fn_varargs.clj
@@ -1,1 +1,36 @@
-(ns hara.common.emit-fn-varargs)
+(ns hara.common.emit-fn-varargs
+  (:require [hara.common.emit-helper :as helper]
+            [std.lib.foundation :as f]))
+
+(defn- hook-namespaces
+  [lang]
+  [(symbol (str "hara.model.spec-" (name lang) "-varargs"))
+   (symbol (str "hara.model.spec-" (name lang) ".rest"))])
+
+(defn resolve-hook
+  [mopts hook]
+  (when-let [lang (:lang mopts)]
+    (some (fn [ns-sym]
+            (try
+              (requiring-resolve (symbol (str ns-sym) (name hook)))
+              (catch java.io.FileNotFoundException _
+                nil)))
+          (hook-namespaces lang))))
+
+(defn emit-input
+  [arg grammar mopts]
+  (let [emit-rest (or (get-in grammar [:default :function :args :rest])
+                      (resolve-hook mopts 'emit-input-rest))]
+    (if emit-rest
+      (emit-rest arg grammar mopts)
+      (f/error "Rest argument emitter not configured"
+               {:lang (:lang mopts)
+                :symbol (:symbol arg)}))))
+
+(defn prepare-body
+  [args body grammar mopts]
+  (if (some helper/rest-arg-symbol args)
+    (if-let [prepare (resolve-hook mopts 'prepare-body)]
+      (prepare args body grammar mopts)
+      body)
+    body))

--- a/src/hara/common/emit_fn_varargs.clj
+++ b/src/hara/common/emit_fn_varargs.clj
@@ -1,0 +1,1 @@
+(ns hara.common.emit-fn-varargs)

--- a/src/hara/common/emit_helper.clj
+++ b/src/hara/common/emit_helper.clj
@@ -151,6 +151,22 @@
 ;; DEFINE
 ;;
 
+(defn rest-arg-form?
+  "checks for the canonical xtalk rest argument form `(:.. args)`"
+  {:added "4.1"}
+  [form]
+  (and (collection/form? form)
+       (= 2 (count form))
+       (= :.. (first form))
+       (symbol? (second form))))
+
+(defn rest-arg-symbol
+  "returns the symbol bound by a canonical xtalk rest argument form"
+  {:added "4.1"}
+  [form]
+  (when (rest-arg-form? form)
+    (second form)))
+
 (defn emit-typed-allowed-args
   "allowed declared args other than symbols"
   {:added "4.0"}
@@ -195,6 +211,23 @@
                   {:modifiers []}
                   more)
 
+           (rest-arg-form? sym)
+           (let [all (if (:symbol curr)
+                       (conj all curr)
+                       all)]
+             (when (or (not-empty more)
+                       (and (not (:symbol curr))
+                            (not-empty (:modifiers curr))))
+               (f/error "Rest argument must be the final declared argument"
+                        {:input sym
+                         :args args
+                         :curr curr}))
+             (recur all
+                    {:modifiers []
+                     :symbol (rest-arg-symbol sym)
+                     :rest true}
+                    more))
+
            (and (not (:symbol curr))
                 (list? sym)
                 (not (neg? (collection/index-at #{:=} sym))))
@@ -234,32 +267,32 @@
              (recur (conj all curr) {:modifiers [] :symbol sym} more)
              (recur all (assoc curr :symbol sym) more))
 
-            (and (collection/form? sym)
-                 (keyword? (first sym)))
-            (if (:symbol curr)
-              (recur (conj all curr) {:type   (butlast sym)
-                                      :symbol (last sym)}
-                     more)
-              (recur all (assoc curr
-                                :symbol sym
-                                :type   (butlast sym)
-                                :symbol (last sym))
-                     more))
+           (and (collection/form? sym)
+                (keyword? (first sym)))
+           (if (:symbol curr)
+             (recur (conj all curr) {:type   (butlast sym)
+                                     :symbol (last sym)}
+                    more)
+             (recur all (assoc curr
+                               :symbol sym
+                               :type   (butlast sym)
+                               :symbol (last sym))
+                    more))
 
-            (and shorthand
-                 (:symbol curr)
-                 (empty? more)
-                 (or (vector? sym)
-                     (map? sym)
-                     (set? sym)))
-            (recur (conj all (assoc curr :value sym))
-                   {:modifiers []}
-                   more)
+           (and shorthand
+                (:symbol curr)
+                (empty? more)
+                (or (vector? sym)
+                    (map? sym)
+                    (set? sym)))
+           (recur (conj all (assoc curr :value sym))
+                  {:modifiers []}
+                  more)
 
-            (or (keyword? sym) (vector? sym))
-            (if (:symbol curr)
-              (recur (conj all curr) {:modifiers [sym]} more)
-              (recur all (update curr :modifiers conj sym) more))
+           (or (keyword? sym) (vector? sym))
+           (if (:symbol curr)
+             (recur (conj all curr) {:modifiers [sym]} more)
+             (recur all (update curr :modifiers conj sym) more))
 
            (:symbol curr)
            (recur (conj all (assoc curr :value sym)) {:modifiers []} more)
@@ -282,7 +315,7 @@
                         (name sym))
                    (name sym))]
     (cond->> (. sym-str (replaceAll "\\." (or (:namespace-sep dopts)
-                                              "_")))
+                                               "_")))
       :then   (replace (merge (:replace sopts)
                               (:replace topts)))
       :then   (apply str))))

--- a/src/hara/model/annex/spec_php.clj
+++ b/src/hara/model/annex/spec_php.clj
@@ -1,12 +1,17 @@
 (ns hara.model.annex.spec-php
   (:require [hara.lang.book :as book]
             [hara.common.emit :as emit]
+            [hara.common.emit-common :as common]
             [hara.common.grammar :as grammar]
             [hara.lang.script :as script]
             [hara.model.spec-xtalk]
             [hara.model.annex.spec-xtalk.fn-php :as fn]
             [hara.model.annex.spec-php.rewrite :as rewrite]
             [std.lib.collection :as collection]))
+
+(defn php-emit-input-rest
+  [{:keys [symbol]} grammar mopts]
+  (str "..." (common/*emit-fn* symbol grammar mopts)))
 
 (def +features+
   (let [base        (grammar/build :exclude [:pointer :block :data-range])
@@ -53,7 +58,8 @@
         :default {:common   {:statement ";"}
                   :invoke   {:apply "->"
                              :static "::"}
-                  :function {:raw "function"}}
+                  :function {:raw "function"
+                             :args {:rest #'php-emit-input-rest}}}
         :block {:script {:start "<?php\n"
                          :end   "\n?>"}
                 :try    {:control {:catch {:parameter {:start "("

--- a/src/hara/model/annex/spec_php/rewrite.clj
+++ b/src/hara/model/annex/spec_php/rewrite.clj
@@ -43,6 +43,33 @@
     :else
     #{}))
 
+(defn- rest-arg-form?
+  [form]
+  (and (collection/form? form)
+       (= 2 (count form))
+       (= :.. (first form))
+       (symbol? (second form))))
+
+(defn- param-local-symbols
+  [param]
+  (cond
+    (php-local-symbol? param)
+    #{param}
+
+    (rest-arg-form? param)
+    #{(second param)}
+
+    :else
+    #{}))
+
+(defn- rewrite-param
+  [param]
+  (if (rest-arg-form? param)
+    (common/with-form-meta
+      param
+      (list :.. (php-prefix-local (second param))))
+    (php-prefix-local param)))
+
 (declare php-rewrite-form*)
 (declare php-rewrite-statements*)
 
@@ -74,9 +101,9 @@
         [name params body] (if (symbol? head)
                              [head (first tail) (rest tail)]
                              [nil head tail])
-        param-locals      (set (filter php-local-symbol? params))
+        param-locals      (into #{} (mapcat param-local-symbols) params)
         scope*            (into scope param-locals)
-        params*           (mapv php-prefix-local params)
+        params*           (mapv rewrite-param params)
         body*             (php-rewrite-statements* body scope*)]
     (common/with-form-meta
       form
@@ -87,12 +114,12 @@
 (defn- rewrite-defn*
   [form scope]
   (let [[tag name params & body] form
-        param-locals (set (filter php-local-symbol? params))
+        param-locals (into #{} (mapcat param-local-symbols) params)
         scope*       (into scope param-locals)]
     (common/with-form-meta
       form
       (apply list tag name
-             (mapv php-prefix-local params)
+             (mapv rewrite-param params)
              (php-rewrite-statements* body scope*)))))
 
 (defn- rewrite-let*

--- a/src/hara/model/spec_dart_varargs.clj
+++ b/src/hara/model/spec_dart_varargs.clj
@@ -1,0 +1,1 @@
+(ns hara.model.spec-dart-varargs)

--- a/src/hara/model/spec_elisp_varargs.clj
+++ b/src/hara/model/spec_elisp_varargs.clj
@@ -1,0 +1,1 @@
+(ns hara.model.spec-elisp-varargs)

--- a/src/hara/model/spec_js/rest.clj
+++ b/src/hara/model/spec_js/rest.clj
@@ -1,1 +1,6 @@
-(ns hara.model.spec-js.rest)
+(ns hara.model.spec-js.rest
+  (:require [hara.common.emit-common :as common]))
+
+(defn emit-input-rest
+  [{:keys [symbol]} grammar mopts]
+  (str "..." (common/*emit-fn* symbol grammar mopts)))

--- a/src/hara/model/spec_js/rest.clj
+++ b/src/hara/model/spec_js/rest.clj
@@ -1,0 +1,1 @@
+(ns hara.model.spec-js.rest)

--- a/src/hara/model/spec_js_varargs.clj
+++ b/src/hara/model/spec_js_varargs.clj
@@ -1,0 +1,1 @@
+(ns hara.model.spec-js-varargs)

--- a/src/hara/model/spec_lisp_common.clj
+++ b/src/hara/model/spec_lisp_common.clj
@@ -164,6 +164,13 @@
        (= 'x:unpack (first form))
        (= 2 (count form))))
 
+(defn- rest-arg-form?
+  [form]
+  (and (collection/form? form)
+       (= 2 (count form))
+       (= :.. (first form))
+       (symbol? (second form))))
+
 (defn transform-form
   {:added "4.1"}
    [{:keys [begin
@@ -301,6 +308,41 @@
                (if (seq bindings)
                  [(let-form bindings body-forms)]
                  body-forms)))
+          (prepare-function [args body]
+            (let [args       (vec args)
+                  rest-args  (filterv rest-arg-form? args)]
+              (cond (empty? rest-args)
+                    [args (transform-body body)]
+
+                    (< 1 (count rest-args))
+                    (throw (ex-info "Only one rest argument is allowed"
+                                    {:args args}))
+
+                    (not= (last args) (first rest-args))
+                    (throw (ex-info "Rest argument must be final"
+                                    {:args args
+                                     :rest (first rest-args)}))
+
+                    :else
+                    (let [rest-sym  (second (first rest-args))
+                          fixed     (butlast args)
+                          body      (transform-body body)]
+                      (cond (= 'begin begin)
+                            [(vec (concat fixed ['. rest-sym]))
+                             (cons (list 'set! rest-sym
+                                         (list 'list->vector rest-sym))
+                                   body)]
+
+                            (= 'progn begin)
+                            [(vec (concat fixed ['&rest rest-sym]))
+                             (cons (list 'setq rest-sym
+                                         (list 'vconcat rest-sym))
+                                   body)]
+
+                            :else
+                            (throw (ex-info "Rest arguments are not supported by this Lisp target"
+                                            {:begin begin
+                                             :args args})))))))
           (branch-form [clauses]
             (letfn [(emit-branch [[clause & more]]
                       (when clause
@@ -349,23 +391,23 @@
                               fn     (let [[_ maybe-name maybe-args & more] form
                                            named? (symbol? maybe-name)
                                            args   (if named? maybe-args maybe-name)
-                                           body   (if named? more (drop 2 form))]
-                                       (lambda-form args
-                                                    (transform-body body)))
+                                           body   (if named? more (drop 2 form))
+                                           [args body] (prepare-function args body)]
+                                       (lambda-form args body))
                               fn:>   (let [[_ maybe-name maybe-args & more] form
                                            named? (symbol? maybe-name)
                                            args   (if named? maybe-args maybe-name)
-                                           body   (if named? more (drop 2 form))]
-                                       (lambda-form args
-                                                    (transform-body body)))
+                                           body   (if named? more (drop 2 form))
+                                           [args body] (prepare-function args body)]
+                                       (lambda-form args body))
                                def    (def-form (second form)
                                                 (transform (nth form 2)))
-                               defn   (defn-form (second form)
-                                                 (nth form 2)
-                                                 (transform-body (drop 3 form)))
-                              defgen (defn-form (second form)
-                                                (nth form 2)
-                                                (transform-body (drop 3 form)))
+                               defn   (let [[args body] (prepare-function (nth form 2)
+                                                                         (drop 3 form))]
+                                        (defn-form (second form) args body))
+                              defgen (let [[args body] (prepare-function (nth form 2)
+                                                                        (drop 3 form))]
+                                       (defn-form (second form) args body))
                               let    (let-form
                                       (->> (partition 2 (second form))
                                            (mapv (fn [[sym value]]

--- a/src/hara/model/spec_lua_varargs.clj
+++ b/src/hara/model/spec_lua_varargs.clj
@@ -1,1 +1,81 @@
-(ns hara.model.spec-lua-varargs)
+(ns hara.model.spec-lua-varargs
+  (:require [std.lib.collection :as collection]))
+
+(defn emit-input-rest
+  [_ _ _]
+  "...")
+
+(defn rest-arg-form?
+  [form]
+  (and (collection/form? form)
+       (= 2 (count form))
+       (= :.. (first form))
+       (symbol? (second form))))
+
+(defn- prepare-function
+  [form]
+  (let [[tag head & tail] form
+        named?           (symbol? head)
+        args             (if named? (first tail) head)
+        body             (if named? (rest tail) tail)
+        rest-args        (filterv rest-arg-form? args)]
+    (cond
+      (empty? rest-args)
+      form
+
+      (< 1 (count rest-args))
+      (throw (ex-info "Only one rest argument is allowed"
+                      {:form form :args args}))
+
+      (not= (last args) (first rest-args))
+      (throw (ex-info "Rest argument must be final"
+                      {:form form :args args}))
+
+      :else
+      (let [rest-sym (second (first rest-args))
+            body     (cons (list 'var rest-sym [(list ':- "...")]) body)]
+        (with-meta
+          (if named?
+            (apply list tag head args body)
+            (apply list tag args body))
+          (meta form))))))
+
+(declare prepare-form)
+
+(defn- prepare-coll
+  [form]
+  (cond
+    (vector? form)
+    (with-meta (mapv prepare-form form) (meta form))
+
+    (map? form)
+    (with-meta (into (empty form)
+                     (map (fn [[k v]]
+                            [(prepare-form k) (prepare-form v)]))
+                     form)
+      (meta form))
+
+    (set? form)
+    (with-meta (set (map prepare-form form)) (meta form))
+
+    :else
+    form))
+
+(defn prepare-form
+  [form]
+  (cond
+    (and (collection/form? form)
+         (= 'quote (first form)))
+    form
+
+    (collection/form? form)
+    (let [form* (with-meta (apply list (map prepare-form form)) (meta form))]
+      (if (contains? '#{fn fn.inner defn defn- defgen} (first form*))
+        (prepare-function form*)
+        form*))
+
+    (or (vector? form) (map? form) (set? form))
+    (prepare-coll form)
+
+    :else
+    form))

--- a/src/hara/model/spec_lua_varargs.clj
+++ b/src/hara/model/spec_lua_varargs.clj
@@ -1,0 +1,1 @@
+(ns hara.model.spec-lua-varargs)

--- a/src/hara/model/spec_lua_varargs.clj
+++ b/src/hara/model/spec_lua_varargs.clj
@@ -12,70 +12,21 @@
        (= :.. (first form))
        (symbol? (second form))))
 
-(defn- prepare-function
-  [form]
-  (let [[tag head & tail] form
-        named?           (symbol? head)
-        args             (if named? (first tail) head)
-        body             (if named? (rest tail) tail)
-        rest-args        (filterv rest-arg-form? args)]
+(defn prepare-body
+  [args body _ _]
+  (let [rest-args (filterv rest-arg-form? args)]
     (cond
       (empty? rest-args)
-      form
+      body
 
       (< 1 (count rest-args))
       (throw (ex-info "Only one rest argument is allowed"
-                      {:form form :args args}))
+                      {:args args}))
 
       (not= (last args) (first rest-args))
       (throw (ex-info "Rest argument must be final"
-                      {:form form :args args}))
+                      {:args args}))
 
       :else
-      (let [rest-sym (second (first rest-args))
-            body     (cons (list 'var rest-sym [(list ':- "...")]) body)]
-        (with-meta
-          (if named?
-            (apply list tag head args body)
-            (apply list tag args body))
-          (meta form))))))
-
-(declare prepare-form)
-
-(defn- prepare-coll
-  [form]
-  (cond
-    (vector? form)
-    (with-meta (mapv prepare-form form) (meta form))
-
-    (map? form)
-    (with-meta (into (empty form)
-                     (map (fn [[k v]]
-                            [(prepare-form k) (prepare-form v)]))
-                     form)
-      (meta form))
-
-    (set? form)
-    (with-meta (set (map prepare-form form)) (meta form))
-
-    :else
-    form))
-
-(defn prepare-form
-  [form]
-  (cond
-    (and (collection/form? form)
-         (= 'quote (first form)))
-    form
-
-    (collection/form? form)
-    (let [form* (with-meta (apply list (map prepare-form form)) (meta form))]
-      (if (contains? '#{fn fn.inner defn defn- defgen} (first form*))
-        (prepare-function form*)
-        form*))
-
-    (or (vector? form) (map? form) (set? form))
-    (prepare-coll form)
-
-    :else
-    form))
+      (let [rest-sym (second (first rest-args))]
+        (cons (list 'var rest-sym [(list ':- "...")]) body)))))

--- a/src/hara/model/spec_php_varargs.clj
+++ b/src/hara/model/spec_php_varargs.clj
@@ -1,0 +1,1 @@
+(ns hara.model.spec-php-varargs)

--- a/src/hara/model/spec_python/rest.clj
+++ b/src/hara/model/spec_python/rest.clj
@@ -1,0 +1,1 @@
+(ns hara.model.spec-python.rest)

--- a/src/hara/model/spec_python/rest.clj
+++ b/src/hara/model/spec_python/rest.clj
@@ -1,1 +1,6 @@
-(ns hara.model.spec-python.rest)
+(ns hara.model.spec-python.rest
+  (:require [hara.common.emit-common :as common]))
+
+(defn emit-input-rest
+  [{:keys [symbol]} grammar mopts]
+  (str "*" (common/*emit-fn* symbol grammar mopts)))

--- a/src/hara/model/spec_python_varargs.clj
+++ b/src/hara/model/spec_python_varargs.clj
@@ -1,1 +1,10 @@
-(ns hara.model.spec-python-varargs)
+(ns hara.model.spec-python-varargs
+  (:require [hara.common.emit-common :as common]))
+
+(defn emit-input-rest
+  [{:keys [symbol]} grammar mopts]
+  (str "*" (common/*emit-fn* symbol grammar mopts)))
+
+(defn prepare-body
+  [_ body _ _]
+  body)

--- a/src/hara/model/spec_python_varargs.clj
+++ b/src/hara/model/spec_python_varargs.clj
@@ -1,0 +1,1 @@
+(ns hara.model.spec-python-varargs)

--- a/src/hara/model/spec_ruby/rest.clj
+++ b/src/hara/model/spec_ruby/rest.clj
@@ -1,0 +1,1 @@
+(ns hara.model.spec-ruby.rest)

--- a/src/hara/model/spec_ruby/rest.clj
+++ b/src/hara/model/spec_ruby/rest.clj
@@ -1,1 +1,6 @@
-(ns hara.model.spec-ruby.rest)
+(ns hara.model.spec-ruby.rest
+  (:require [hara.common.emit-common :as common]))
+
+(defn emit-input-rest
+  [{:keys [symbol]} grammar mopts]
+  (str "*" (common/*emit-fn* symbol grammar mopts)))

--- a/src/hara/model/spec_ruby_varargs.clj
+++ b/src/hara/model/spec_ruby_varargs.clj
@@ -1,0 +1,1 @@
+(ns hara.model.spec-ruby-varargs)

--- a/src/hara/model/spec_scheme_varargs.clj
+++ b/src/hara/model/spec_scheme_varargs.clj
@@ -1,0 +1,1 @@
+(ns hara.model.spec-scheme-varargs)

--- a/src/hara/typed/xtalk_call.clj
+++ b/src/hara/typed/xtalk_call.clj
@@ -58,6 +58,52 @@
        (every? #(compat/compatible-type? types/+nil-type+ % ctx)
                (drop provided-count input-types))))
 
+(defn rest-input-type?
+  [type]
+  (true? (:rest type)))
+
+(defn split-call-inputs
+  [input-types]
+  (let [rest-type (when (rest-input-type? (last input-types))
+                    (last input-types))]
+    {:fixed (if rest-type
+              (vec (butlast input-types))
+              (vec input-types))
+     :rest rest-type}))
+
+(defn call-arity?
+  [input-types provided-count ctx]
+  (let [{:keys [fixed rest]} (split-call-inputs input-types)]
+    (if rest
+      (or (> provided-count (count fixed))
+          (optional-arity? fixed provided-count ctx))
+      (optional-arity? fixed provided-count ctx))))
+
+(defn expected-call-inputs
+  [input-types provided-count]
+  (let [{:keys [fixed rest]} (split-call-inputs input-types)
+        fixed-count (min provided-count (count fixed))
+        extra-count (max 0 (- provided-count (count fixed)))]
+    (vec (concat (take fixed-count fixed)
+                 (when rest
+                   (repeat extra-count (:item rest)))))))
+
+(defn expected-call-arity
+  [input-types ctx]
+  (let [{:keys [fixed rest]} (split-call-inputs input-types)
+        required (loop [n (count fixed)]
+                   (if (and (pos? n)
+                            (compat/compatible-type? types/+nil-type+
+                                                     (nth fixed (dec n))
+                                                     ctx))
+                     (recur (dec n))
+                     n))]
+    (if rest
+      {:min required
+       :fixed (count fixed)
+       :variadic true}
+      (count fixed))))
+
 (defn infer-function-call
   [[callee & args :as form] ctx]
   (let [callee-type (cond
@@ -72,20 +118,23 @@
         callable-types (callable-types callee-type ctx)
         wildcard? (wildcard-callable? callee-type ctx)]
     (if (seq callable-types)
-      (let [arity-types (filterv #(optional-arity? (:inputs %) (count args) ctx)
+      (let [arity-types (filterv #(call-arity? (:inputs %) (count args) ctx)
                                  callable-types)]
         (if (seq arity-types)
           (let [passing-types (filterv (fn [fn-type]
-                                         (every? true?
-                                                 (map #(compat/compatible-type? (:type %1) %2 ctx)
-                                                      arg-results
-                                                      (take (count args) (:inputs fn-type)))))
+                                         (let [expected (expected-call-inputs (:inputs fn-type)
+                                                                              (count args))]
+                                           (every? true?
+                                                   (map #(compat/compatible-type? (:type %1) %2 ctx)
+                                                        arg-results
+                                                        expected))))
                                        arity-types)
                 chosen-types (if (seq passing-types) passing-types arity-types)
                 arg-errors (if (seq passing-types)
                              []
                              (call-arg-errors arg-results
-                                              (take (count args) (:inputs (first arity-types)))
+                                              (expected-call-inputs (:inputs (first arity-types))
+                                                                    (count args))
                                               args
                                               ctx))]
             (compat/result (types/union-type (map :output chosen-types))
@@ -96,7 +145,8 @@
                            (concat errors
                                    [{:tag :call-arity-mismatch
                                      :form form
-                                     :expected (mapv #(count (:inputs %)) callable-types)
+                                     :expected (mapv #(expected-call-arity (:inputs %) ctx)
+                                                     callable-types)
                                      :actual (count args)}])))))
       (if wildcard?
         (compat/result types/+unknown-type+ errors)
@@ -131,7 +181,7 @@
    'x:iter-has? (form/infer-fixed-output types/+bool-type+)
    'x:iter-native? (form/infer-fixed-output types/+bool-type+)
    'x:obj-keys (form/infer-fixed-output {:kind :array
-                                          :item types/+str-type+})
+                                         :item types/+str-type+})
    'x:obj-vals form/infer-obj-vals
    'x:obj-pairs form/infer-obj-pairs
    'x:obj-clone form/infer-obj-clone
@@ -147,20 +197,23 @@
     (when (seq fn-types)
       (let [arg-results arg-results
             errors (vec (mapcat :errors arg-results))
-            arity-types (filterv #(optional-arity? (:inputs %) (count args) ctx)
+            arity-types (filterv #(call-arity? (:inputs %) (count args) ctx)
                                  fn-types)]
         (if (seq arity-types)
           (let [passing-types (filterv (fn [fn-type]
-                                         (every? true?
-                                                 (map #(compat/compatible-type? (:type %1) %2 ctx)
-                                                      arg-results
-                                                      (take (count args) (:inputs fn-type)))))
+                                         (let [expected (expected-call-inputs (:inputs fn-type)
+                                                                              (count args))]
+                                           (every? true?
+                                                   (map #(compat/compatible-type? (:type %1) %2 ctx)
+                                                        arg-results
+                                                        expected))))
                                        arity-types)
                 chosen-types (if (seq passing-types) passing-types arity-types)
                 arg-errors (if (seq passing-types)
                              []
                              (call-arg-errors arg-results
-                                              (take (count args) (:inputs (first arity-types)))
+                                              (expected-call-inputs (:inputs (first arity-types))
+                                                                    (count args))
                                               args
                                               ctx))]
             (compat/result (types/union-type (map :output chosen-types))
@@ -170,7 +223,8 @@
                                  [{:tag :call-arity-mismatch
                                    :form form
                                    :expected (or (ops/op-arglists builtin-entry)
-                                                 (mapv #(count (:inputs %)) fn-types))
+                                                 (mapv #(expected-call-arity (:inputs %) ctx)
+                                                       fn-types))
                                    :actual (count args)}])))))))
 
 (defn infer-builtin-form

--- a/src/hara/typed/xtalk_parse.clj
+++ b/src/hara/typed/xtalk_parse.clj
@@ -107,9 +107,23 @@
        (mapcat :require)
        extract-aliases))
 
+(defn rest-arg-form?
+  [form]
+  (and (seq? form)
+       (= 2 (count form))
+       (= :.. (first form))
+       (symbol? (second form))))
+
+(defn rest-arg-type
+  []
+  {:kind :array
+   :item types/+unknown-type+
+   :rest true})
+
 (defn arg-from-inline-form
   [form ctx]
-  (when (and (seq? form)
+  (when (and (not (rest-arg-form? form))
+             (seq? form)
              (= 2 (count form))
              (symbol? (second form)))
     (let [[type-form sym] form]
@@ -168,6 +182,18 @@
                          {:pending pending
                           :item item
                           :args args-form})))
+
+      (rest-arg-form? item)
+      (if (seq more)
+        (throw (ex-info "Rest argument must be final"
+                        {:item item
+                         :args args-form}))
+        (recur (conj out
+                     (types/make-arg (second item)
+                                     (rest-arg-type)
+                                     [:rest]))
+               nil
+               nil))
 
        (= '& item)
        (let [rest-target (first more)

--- a/test-lang/xt/lang/varargs_test.clj
+++ b/test-lang/xt/lang/varargs_test.clj
@@ -1,0 +1,30 @@
+(ns xt.lang.varargs-test
+  (:require [hara.lang :as l])
+  (:use code.test))
+
+(def +rest-form+
+  '[(defn collect [head (:.. tail)]
+      (return (x:len tail)))])
+
+(fact "emits canonical xtalk rest arguments for algol targets"
+  (let [dart   (l/emit-as :dart +rest-form+)
+        ruby   (l/emit-as :ruby +rest-form+)
+        python (l/emit-as :python +rest-form+)
+        lua    (l/emit-as :lua +rest-form+)
+        php    (l/emit-as :php +rest-form+)]
+    [(boolean (re-find #"collect\\(head,\\[tail = const \\[\\]\\]\\)" dart))
+     (boolean (re-find #"collect\\(head,\\*tail\\)" ruby))
+     (boolean (re-find #"collect\\(head,\\*tail\\)" python))
+     (boolean (re-find #"collect\\(head,\\.\\.\\.\\)" lua))
+     (boolean (re-find #"tail.*\\{\\.\\.\\.\\}" lua))
+     (boolean (re-find #"collect\\(\\$head,\\.\\.\\.\\$tail\\)" php))])
+  => [true true true true true true])
+
+(fact "emits canonical xtalk rest arguments for Lisp targets"
+  (let [scheme (l/emit-as :scheme +rest-form+)
+        elisp  (l/emit-as :elisp +rest-form+)]
+    [(boolean (re-find #"\\(collect head \\. tail\\)" scheme))
+     (boolean (re-find #"\\(set! tail \\(list->vector tail\\)\\)" scheme))
+     (boolean (re-find #"\\(head &rest tail\\)" elisp))
+     (boolean (re-find #"\\(setq tail \\(vconcat tail\\)\\)" elisp))])
+  => [true true true true])


### PR DESCRIPTION
## Summary

Adds canonical rest-parameter syntax using `(:.. args)`.

Current branch work:
- shared rest argument parser
- native lowering for Dart, Ruby, Python, Lua and PHP
- Lua materialises native `...` into the named xtalk array
- PHP rewrites the named collector to its local `$` form

Still being completed in this draft:
- Scheme and Elisp lowering
- typed variadic arity analysis
- cross-language xtbench coverage

Canonical source syntax:

```clojure
(defn.xt collect [head (:.. tail)]
  (x:len tail))
```
