### PR TITLE
Restrict GitHub Actions to main

### DIFF
--- a/.github/workflows/build-js.yml
+++ b/.github/workflows/build-js.yml
@@ -1,6 +1,10 @@
 name: Build JS
 
-on: [push, repository_dispatch, workflow_dispatch]
+on:
+  push:
+    branches: [main]
+  repository_dispatch:
+  workflow_dispatch:
 
 env:
   LEIN_JVM_OPTS: -Xms512m -Xmx3g -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp
@@ -8,9 +12,10 @@ env:
 
 jobs:
   build-js-web:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    
+
     steps:
       - name: Write SSH keys
         shell: bash
@@ -18,14 +23,14 @@ jobs:
           install -m 600 -D /dev/null ~/.ssh/id_rsa
           echo "${{ secrets.GH_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
           ssh-keyscan -H github.com > ~/.ssh/known_hosts
-          
+
       - name: Checkout base repository
         uses: actions/checkout@v4
         with:
           repository: zcaudate/foundation-base
           path: foundation-base
           token: ${{ secrets.GH_TOKEN }}
-          
+
       - name: Deploying native-code
         run: >
           docker run --network host
@@ -33,7 +38,7 @@ jobs:
           -v /var/run/docker.sock:/var/run/docker.sock
           -v $HOME/.ssh:/root/.ssh
           -v $(pwd):$(pwd) -w $(pwd)
-          -e "GITHUB_TOKEN=${{ secrets.GH_TOKEN }}"  
+          -e "GITHUB_TOKEN=${{ secrets.GH_TOKEN }}"
           -e "GITHUB_USER=${{ secrets.GH_USER }}"
-          ghcr.io/zcaudate-xyz/infra-foundation-clean:ci 
+          ghcr.io/zcaudate-xyz/infra-foundation-clean:ci
           bash -c "cd foundation-base && git config --global --add safe.directory '*' && git config --global user.name 'github-actions' && git config --global user.email 'github-actions@github.com' && lein push-native-code"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -8,6 +8,7 @@ env:
 
 jobs:
   copilot-setup-steps:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -2,7 +2,7 @@ name: Publish Documentation
 
 on:
   push:
-    branches: [main, master]
+    branches: [main]
     paths:
       - 'src-doc/**'
       - 'src/**'
@@ -26,9 +26,10 @@ concurrency:
 
 jobs:
   build:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -39,21 +40,21 @@ jobs:
           registry: ghcr.io
           username: ${{ secrets.GH_USER }}
           password: ${{ secrets.GH_TOKEN }}
-        
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
         with:
           enablement: true
-        
+
       - name: Generate Documentation
         run: >
-          docker run --network host 
+          docker run --network host
           -e "LEIN_JVM_OPTS=${LEIN_JVM_OPTS}"
-          -v /var/run/docker.sock:/var/run/docker.sock 
+          -v /var/run/docker.sock:/var/run/docker.sock
           -v /home/runner/.docker/config.json:/root/.docker/config.json:ro
-          -v $(pwd):$(pwd) 
-          -w $(pwd) 
-          ghcr.io/zcaudate-xyz/infra-foundation-clean:ci 
+          -v $(pwd):$(pwd)
+          -w $(pwd)
+          ghcr.io/zcaudate-xyz/infra-foundation-clean:ci
           lein exec -ep "(require '[code.doc :as doc]
                                   '[code.doc.executive :as exec])
                           (let [project (doc/make-project)
@@ -64,19 +65,20 @@ jobs:
                             (doseq [k (sort (filter #(sites (namespace %))
                                                     (keys lookup)))]
                               (exec/render k {:write true} lookup project)))"
-          
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
-          
+
   deploy:
+    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    
+
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,13 +1,16 @@
 name: Notify
 
-on: [push, workflow_dispatch]
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  
   notify:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -15,8 +18,8 @@ jobs:
 #            - 'zcaudate-xyz/foundation-embed'
 #            - 'zcaudate-xyz/foundation-fx'
             - 'zcaudate-xyz/foundation-web'
-    
-    steps:    
+
+    steps:
       - name: Notify Downstream
         uses: peter-evans/repository-dispatch@v3
         with:

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -1,17 +1,21 @@
 name: Run Code
 
-on: [push, repository_dispatch, workflow_dispatch]
+on:
+  push:
+    branches: [main]
+  repository_dispatch:
+  workflow_dispatch:
 
 env:
   LEIN_JVM_OPTS: -Xms512m -Xmx3g -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  
   run-incomplete:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -22,18 +26,19 @@ jobs:
           registry: ghcr.io
           username: ${{ secrets.GH_USER }}
           password: ${{ secrets.GH_TOKEN }}
-        
+
       - name: Run Incomplete
         run: >
-          docker run --network host 
+          docker run --network host
           -e "LEIN_JVM_OPTS=${LEIN_JVM_OPTS}"
-          -v /var/run/docker.sock:/var/run/docker.sock 
+          -v /var/run/docker.sock:/var/run/docker.sock
           -v /home/runner/.docker/config.json:/root/.docker/config.json:ro
-          -v $(pwd):$(pwd) 
-          -w $(pwd) 
+          -v $(pwd):$(pwd)
+          -w $(pwd)
           ghcr.io/zcaudate-xyz/infra-foundation-clean:ci lein incomplete
-          
+
   run-group-tests:
+    if: github.ref == 'refs/heads/main'
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
@@ -66,7 +71,7 @@ jobs:
           - name: postgres
             target: "[postgres]"
             command: lein test :with "[postgres]"
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -100,7 +105,7 @@ jobs:
         if: matrix.install_js_parser == true
         working-directory: scripts/js_parser
         run: npm ci
-        
+
       - name: run
         run: |
           mkdir -p .tmp
@@ -117,7 +122,7 @@ jobs:
             apt-get update &&
             apt-get install -y --no-install-recommends lua5.4 python3 python3-pip redis-server &&
             ${{ matrix.command }}'
-        
+
     services:
       postgres:
         image: ghcr.io/zcaudate-xyz/infra-db:main
@@ -134,6 +139,7 @@ jobs:
           - 6379:6379
 
   run-lang-tests:
+    if: github.ref == 'refs/heads/main'
     name: Run Tests - ${{ matrix.lang }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
@@ -146,7 +152,7 @@ jobs:
           - lang: lua
           - lang: python
           - lang: dart
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -173,7 +179,7 @@ jobs:
         if: matrix.install_js_parser == true
         working-directory: scripts/js_parser
         run: npm ci
-        
+
       - name: Run Tests - ${{ matrix.lang }}
         run: |
           mkdir -p .tmp
@@ -190,7 +196,7 @@ jobs:
               ${{ matrix.lang == 'js' && 'apt-get update && apt-get install -y --no-install-recommends ca-certificates curl gnupg && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && apt-get install -y --no-install-recommends nodejs' || 'true' }} &&
               ${{ matrix.lang == 'python' && 'pip install --no-cache-dir psycopg2-binary redis' || 'true' }} &&
               lein test :with "${{ matrix.lang }}"'
-        
+
     services:
       postgres:
         image: ghcr.io/zcaudate-xyz/infra-db:main
@@ -205,4 +211,3 @@ jobs:
         image: redis:7-alpine
         ports:
           - 6379:6379
-

--- a/.github/workflows/run-xtbench.yml
+++ b/.github/workflows/run-xtbench.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  LEIN_JVM_OPTS: -Xms512m -Xmx3g -XX:+UseG1GC -XX:HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp
+  LEIN_JVM_OPTS: -Xms512m -Xmx3g -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:

--- a/.github/workflows/run-xtbench.yml
+++ b/.github/workflows/run-xtbench.yml
@@ -1,13 +1,18 @@
 name: Run xtbench Tests
 
-on: [push, repository_dispatch, workflow_dispatch]
+on:
+  push:
+    branches: [main]
+  repository_dispatch:
+  workflow_dispatch:
 
 env:
-  LEIN_JVM_OPTS: -Xms512m -Xmx3g -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp
+  LEIN_JVM_OPTS: -Xms512m -Xmx3g -XX:+UseG1GC -XX:HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   run-xtbench-lang-tests:
+    if: github.ref == 'refs/heads/main'
     name: 01 - xt.lang / ${{ matrix.lang }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
@@ -51,9 +56,10 @@ jobs:
           -v $(pwd):$(pwd)
           -w $(pwd)
           ${{ matrix.image }}
-          lein seedgen test '[xt.lang]' :with "[${{ matrix.lang }}]" 
+          lein seedgen test '[xt.lang]' :with "[${{ matrix.lang }}]"
 
   run-xtbench-event-tests:
+    if: github.ref == 'refs/heads/main'
     name: 02 - xt.event / ${{ matrix.lang }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
@@ -91,9 +97,10 @@ jobs:
           -v $(pwd):$(pwd)
           -w $(pwd)
           ${{ matrix.image }}
-          lein seedgen test '[xt.event]' :with "[${{ matrix.lang }}]" 
+          lein seedgen test '[xt.event]' :with "[${{ matrix.lang }}]"
 
   run-xtbench-substrate-tests:
+    if: github.ref == 'refs/heads/main'
     name: 03 - xt.substrate / ${{ matrix.lang }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
@@ -145,6 +152,7 @@ jobs:
           - 5432:5432
 
   run-xtbench-db-tests:
+    if: github.ref == 'refs/heads/main'
     name: 05 - xt.db / ${{ matrix.lang }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
@@ -196,6 +204,7 @@ jobs:
           - 5432:5432
 
   run-xtbench-kmi-tests:
+    if: github.ref == 'refs/heads/main'
     name: 10 - kmi.lang / ${{ matrix.lang }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
@@ -233,5 +242,4 @@ jobs:
           -v $(pwd):$(pwd)
           -w $(pwd)
           ${{ matrix.image }}
-          lein seedgen test '[kmi.lang]' :with "[${{ matrix.lang }}]" 
-                
+          lein seedgen test '[kmi.lang]' :with "[${{ matrix.lang }}]"


### PR DESCRIPTION
## Summary

- restrict every automatic `push` trigger to the `main` branch
- remove the legacy `master` branch from documentation publishing
- retain `repository_dispatch` and `workflow_dispatch` where they already existed
- add `github.ref == 'refs/heads/main'` guards to every job so manually dispatched workflows selected from another branch are skipped

## Workflows

- `notify.yml`
- `make-docs.yml`
- `build-js.yml`
- `copilot-setup-steps.yml`
- `run-xtbench.yml`
- `run-test.yml`

## Verification

- all six workflow files now enforce `main`
- no `pull_request` triggers are present
- `repository_dispatch` continues to execute against the repository default branch
- workflow jobs are guarded against non-main manual dispatches