### PR TITLE
Fix auth profile example with local-min playground UI

### DIFF
--- a/src-lang/xt/db/node/example_auth_profile.clj
+++ b/src-lang/xt/db/node/example_auth_profile.clj
@@ -3,12 +3,14 @@
 
 (l/script :xtalk
   {:require [[xt.lang.spec-base :as xt]
-             [xt.lang.spec-promise :as promise]
-             [xt.lang.common-data :as xtd]
-             [xt.substrate :as substrate]
-             [xt.substrate.page-core :as page-core]
-             [xt.db.system.impl-supabase-session :as session]
-             [xt.db.node.client-supabase :as supabase]]})
+              [xt.lang.spec-promise :as promise]
+              [xt.lang.common-data :as xtd]
+              [xt.substrate :as substrate]
+              [xt.substrate.page-core :as page-core]
+              [xt.db.system.main :as db-main]
+              [xt.db.system.impl-supabase-session :as session]
+              [xt.db.node.kernel-supabase :as kernel-supabase]
+              [xt.db.node.client-supabase :as supabase]]})
 
 (def.xt DEFAULT_SPACE_ID "example/auth")
 
@@ -49,6 +51,18 @@
    {"handler" (fn [ctx]
                 (var #{node} ctx)
                 (return (supabase/user-get node service-id {})))
+    "defaults" {"args" []}
+    "options" {}}))
+
+(defn.xt sign-up-model
+  "creates a model for password sign-up"
+  {:added "4.1"}
+  [service-id]
+  (return
+   {"handler" (fn [ctx credentials]
+                (var #{node} ctx)
+                (:= credentials (-/first-arg ctx credentials "credentials"))
+                (return (supabase/sign-up node service-id credentials {})))
     "defaults" {"args" []}
     "options" {}}))
 
@@ -100,7 +114,10 @@
                                             {"data" profile-data}
                                             {"token" (xt/x:get-key curr-session "access_token")}))))
                      (promise/x:promise-then
-                      (fn [updated-user]
+                      (fn [updated]
+                        (var updated-user
+                             (or (xt/x:get-key updated "user")
+                                 updated))
                         (var impl (substrate/get-service node service-id))
                         (var curr-session (session/get-session impl))
                         (when curr-session
@@ -113,13 +130,14 @@
     "options" {}}))
 
 (defn.xt auth-profile-models
-  "returns login/logout/profile page models backed by Supabase auth"
+  "returns sign-up/login/logout/profile page models backed by Supabase auth"
   {:added "4.1"}
   [service-id]
   (:= service-id (or service-id -/DEFAULT_SERVICE_ID))
   (return
    {"session"        (-/session-model service-id)
     "profile"        (-/profile-model service-id)
+    "sign-up"        (-/sign-up-model service-id)
     "login"          (-/login-model service-id)
     "logout"         (-/logout-model service-id)
     "change-profile" (-/change-profile-model service-id)}))
@@ -140,4 +158,16 @@
   (return {"status" "attached"
            "space" space-id
            "group" group-id
-           "models" ["session" "profile" "login" "logout" "change-profile"]}))
+           "models" ["session" "profile" "sign-up" "login" "logout" "change-profile"]}))
+
+(defn.xt create-auth-profile-node
+  "creates a substrate node with a Supabase service, handlers and auth/profile models"
+  {:added "4.1"}
+  [client-defaults service-id page-args]
+  (:= service-id (or service-id -/DEFAULT_SERVICE_ID))
+  (var node (substrate/node-create {}))
+  (var impl (db-main/create-impl "supabase" client-defaults nil nil))
+  (substrate/set-service node service-id impl)
+  (kernel-supabase/init-handlers node)
+  (-/attach-auth-profile-models node service-id page-args)
+  (return node))

--- a/src-lang/xt/db/node/example_auth_profile_ui.clj
+++ b/src-lang/xt/db/node/example_auth_profile_ui.clj
@@ -1,0 +1,357 @@
+(ns xt.db.node.example-auth-profile-ui
+  (:require [hara.lang :as l]))
+
+(l/script :js
+  {:require [[xt.lang.spec-base :as xt]
+             [xt.lang.common-data :as xtd]
+             [xt.lang.spec-promise :as promise]
+             [xt.substrate.page-core :as page-core]
+             [xt.db.node.example-auth-profile :as example]
+             [js.react :as r]]})
+
+(defn.js error-message
+  "returns a readable message for an async auth failure"
+  {:added "4.1"}
+  [err]
+  (return (or (xt/x:ex-message err)
+              (xt/x:to-string err))))
+
+(defn.js refresh-auth-state
+  "refreshes the session/profile models and updates the supplied React setters"
+  {:added "4.1"}
+  [node space-id group-id setSession setProfile]
+  (return
+   (-> (page-core/model-refresh node space-id group-id "session" {} nil)
+       (promise/x:promise-then
+        (fn [_]
+          (var curr-session
+               (page-core/model-get-output node space-id group-id "session"))
+          (setSession curr-session)
+          (if (xt/x:not-nil? curr-session)
+            (return
+             (-> (page-core/model-refresh node space-id group-id "profile" {} nil)
+                 (promise/x:promise-then
+                  (fn [_]
+                    (var profile-output
+                         (page-core/model-get-output node space-id group-id "profile"))
+                    (setProfile (xtd/get-in profile-output ["user"]))
+                    (return profile-output)))))
+            (do (setProfile nil)
+                (return nil))))))))
+
+(defn.js run-action
+  "runs a page-model action and refreshes the visible auth state"
+  {:added "4.1"}
+  [node space-id group-id model-id event
+   setBusy setError setSession setProfile]
+  (setBusy model-id)
+  (setError nil)
+  (return
+   (-> (page-core/model-refresh node
+                                space-id
+                                group-id
+                                model-id
+                                (or event {})
+                                nil)
+       (promise/x:promise-then
+        (fn [_]
+          (return
+           (-/refresh-auth-state node
+                                 space-id
+                                 group-id
+                                 setSession
+                                 setProfile))))
+       (promise/x:promise-then
+        (fn [out]
+          (setBusy nil)
+          (return out)))
+       (promise/x:promise-catch
+        (fn [err]
+          (setBusy nil)
+          (setError (-/error-message err))
+          (return nil))))))
+
+(defn.js field-style
+  []
+  (return {:display "flex"
+           :flexDirection "column"
+           :gap "6px"
+           :fontSize "13px"
+           :fontWeight 600
+           :color "#374151"}))
+
+(defn.js input-style
+  []
+  (return {:border "1px solid #d1d5db"
+           :borderRadius "8px"
+           :padding "10px 12px"
+           :fontSize "14px"
+           :fontWeight 400
+           :outline "none"}))
+
+(defn.js button-style
+  [primary]
+  (return {:border "1px solid"
+           :borderColor (:? primary "#111827" "#d1d5db")
+           :background (:? primary "#111827" "#ffffff")
+           :color (:? primary "#ffffff" "#111827")
+           :borderRadius "8px"
+           :padding "9px 13px"
+           :fontSize "13px"
+           :fontWeight 600
+           :cursor "pointer"}))
+
+(defn.js AuthProfileApp
+  "interactive auth/profile example backed by the attached page models"
+  {:added "4.1"}
+  [#{node space-id group-id initial-email}]
+  (:= space-id (or space-id example/DEFAULT_SPACE_ID))
+  (:= group-id (or group-id example/DEFAULT_GROUP_ID))
+  (var [email setEmail]
+       (r/local
+        (or initial-email
+            (xt/x:cat "auth-profile-"
+                      (xt/x:to-string (xt/x:now-ms))
+                      "@example.com"))))
+  (var [password setPassword] (r/local "secret123"))
+  (var [displayName setDisplayName] (r/local "Playground User"))
+  (var [session setSession] (r/local nil))
+  (var [profile setProfile] (r/local nil))
+  (var [busy setBusy] (r/local nil))
+  (var [error setError] (r/local nil))
+  (var credentials {"email" email
+                    "password" password})
+  (var current-user (or profile
+                        (xt/x:get-key session "user")))
+  (var current-email (xt/x:get-key current-user "email"))
+  (var current-name (xtd/get-in current-user
+                                ["user_metadata" "display_name"]))
+  (var signed-in (xt/x:not-nil? session))
+  (r/init []
+    (-/refresh-auth-state node
+                          space-id
+                          group-id
+                          setSession
+                          setProfile)
+    (return nil))
+  (return
+   [:main
+    {:style {:minHeight "100%"
+             :boxSizing "border-box"
+             :padding "32px"
+             :background "#f3f4f6"
+             :fontFamily "system-ui, sans-serif"
+             :color "#111827"}}
+    [:div
+     {:style {:maxWidth "720px"
+              :margin "0 auto"
+              :display "flex"
+              :flexDirection "column"
+              :gap "18px"}}
+     [:header
+      [:div
+       {:style {:fontSize "12px"
+                :fontWeight 700
+                :letterSpacing "0.08em"
+                :textTransform "uppercase"
+                :color "#6b7280"}}
+       "foundation-base / local-min"]
+      [:h1
+       {:style {:margin "6px 0 4px"
+                :fontSize "30px"}}
+       "Supabase auth profile"]
+      [:p
+       {:style {:margin 0
+                :color "#4b5563"
+                :lineHeight 1.5}}
+       "Create or sign in to a local account, then update the user's auth metadata through substrate page models."]]
+     [:section
+      {:style {:background "#ffffff"
+               :border "1px solid #e5e7eb"
+               :borderRadius "12px"
+               :padding "20px"
+               :display "flex"
+               :flexDirection "column"
+               :gap "14px"
+               :boxShadow "0 8px 24px rgba(17,24,39,0.05)"}}
+      [:label
+       {:style (-/field-style)}
+       "Email"
+       [:input
+        {:style (-/input-style)
+         :value email
+         :disabled signed-in
+         :onChange (fn [event]
+                     (setEmail (. event target value)))}]]
+      [:label
+       {:style (-/field-style)}
+       "Password"
+       [:input
+        {:style (-/input-style)
+         :type "password"
+         :value password
+         :disabled signed-in
+         :onChange (fn [event]
+                     (setPassword (. event target value)))}]]
+      [:div
+       {:style {:display "flex"
+                :gap "10px"
+                :flexWrap "wrap"}}
+       [:button
+        {:style (-/button-style true)
+         :disabled (xt/x:not-nil? busy)
+         :onClick (fn []
+                    (-/run-action node
+                                  space-id
+                                  group-id
+                                  "sign-up"
+                                  {"credentials" credentials}
+                                  setBusy
+                                  setError
+                                  setSession
+                                  setProfile))}
+        (:? (== busy "sign-up")
+            "Creating..."
+            "Create account")]
+       [:button
+        {:style (-/button-style false)
+         :disabled (xt/x:not-nil? busy)
+         :onClick (fn []
+                    (-/run-action node
+                                  space-id
+                                  group-id
+                                  "login"
+                                  {"credentials" credentials}
+                                  setBusy
+                                  setError
+                                  setSession
+                                  setProfile))}
+        (:? (== busy "login")
+            "Signing in..."
+            "Sign in")]
+       [:button
+        {:style (-/button-style false)
+         :disabled (or (xt/x:not-nil? busy)
+                       (not signed-in))
+         :onClick (fn []
+                    (-/run-action node
+                                  space-id
+                                  group-id
+                                  "logout"
+                                  {}
+                                  setBusy
+                                  setError
+                                  setSession
+                                  setProfile))}
+        (:? (== busy "logout")
+            "Signing out..."
+            "Sign out")]]
+      (:? error
+          [:div
+           {:style {:padding "10px 12px"
+                    :borderRadius "8px"
+                    :background "#fef2f2"
+                    :color "#b91c1c"
+                    :fontSize "13px"}}
+           error]
+          nil)]
+     [:section
+      {:style {:background "#ffffff"
+               :border "1px solid #e5e7eb"
+               :borderRadius "12px"
+               :padding "20px"
+               :display "flex"
+               :flexDirection "column"
+               :gap "14px"}}
+      [:div
+       {:style {:display "flex"
+                :justifyContent "space-between"
+                :gap "16px"
+                :alignItems "flex-start"}}
+       [:div
+        [:h2
+         {:style {:margin "0 0 4px"
+                  :fontSize "18px"}}
+         "Current session"]
+        [:div
+         {:style {:color "#6b7280"
+                  :fontSize "13px"}}
+         (:? signed-in
+             (or current-email "Authenticated user")
+             "Not signed in")]]
+       [:span
+        {:style {:padding "5px 9px"
+                 :borderRadius "999px"
+                 :fontSize "12px"
+                 :fontWeight 700
+                 :background (:? signed-in "#dcfce7" "#f3f4f6")
+                 :color (:? signed-in "#166534" "#6b7280")}}
+        (:? signed-in "signed in" "signed out")]]
+      [:label
+       {:style (-/field-style)}
+       "Display name"
+       [:input
+        {:style (-/input-style)
+         :value displayName
+         :disabled (not signed-in)
+         :onChange (fn [event]
+                     (setDisplayName (. event target value)))}]]
+      [:button
+       {:style (-/button-style true)
+        :disabled (or (xt/x:not-nil? busy)
+                      (not signed-in))
+        :onClick (fn []
+                   (-/run-action node
+                                 space-id
+                                 group-id
+                                 "change-profile"
+                                 {"profile" {"display_name" displayName}}
+                                 setBusy
+                                 setError
+                                 setSession
+                                 setProfile))}
+       (:? (== busy "change-profile")
+           "Saving..."
+           "Save profile")]
+      (:? current-name
+          [:div
+           {:style {:fontSize "13px"
+                    :color "#374151"}}
+           "Stored display name: "
+           [:strong current-name]]
+          nil)]]]))
+
+(defn.js render-playground
+  "renders the auth/profile UI into the active playground stage"
+  {:added "4.1"}
+  [node opts]
+  (:= opts (or opts {}))
+  (var space-id (or (xt/x:get-key opts "space_id")
+                    example/DEFAULT_SPACE_ID))
+  (var group-id (or (xt/x:get-key opts "group_id")
+                    example/DEFAULT_GROUP_ID))
+  (window.PLAYGROUND.setTitle "Supabase auth profile")
+  (window.PLAYGROUND.setStage
+   [:% -/AuthProfileApp
+    {:node node
+     :space-id space-id
+     :group-id group-id
+     :initial-email (xt/x:get-key opts "email")}])
+  (return node))
+
+(defn.js mount-playground
+  "creates the example node and mounts its UI in a :runtime :playground page"
+  {:added "4.1"}
+  [client-defaults opts]
+  (:= opts (or opts {}))
+  (var service-id (or (xt/x:get-key opts "service_id")
+                      example/DEFAULT_SERVICE_ID))
+  (var page-args {"space_id" (or (xt/x:get-key opts "space_id")
+                                  example/DEFAULT_SPACE_ID)
+                  "group_id" (or (xt/x:get-key opts "group_id")
+                                  example/DEFAULT_GROUP_ID)})
+  (var node (example/create-auth-profile-node client-defaults
+                                               service-id
+                                               page-args))
+  (-/render-playground node opts)
+  (return node))

--- a/src-lang/xt/db/node/example_auth_profile_ui.clj
+++ b/src-lang/xt/db/node/example_auth_profile_ui.clj
@@ -199,7 +199,8 @@
                 :flexWrap "wrap"}}
        [:button
         {:style (-/button-style true)
-         :disabled (xt/x:not-nil? busy)
+         :disabled (or (xt/x:not-nil? busy)
+                       signed-in)
          :onClick (fn []
                     (-/run-action node
                                   space-id
@@ -215,7 +216,8 @@
             "Create account")]
        [:button
         {:style (-/button-style false)
-         :disabled (xt/x:not-nil? busy)
+         :disabled (or (xt/x:not-nil? busy)
+                       signed-in)
          :onClick (fn []
                     (-/run-action node
                                   space-id

--- a/test-lang/xt/db/node/example_auth_profile_test.clj
+++ b/test-lang/xt/db/node/example_auth_profile_test.clj
@@ -234,9 +234,16 @@
 
 (comment
 
-  ;; With the namespace loaded, open +url+ in a browser and evaluate:
+  (local-min/start-supabase)
+  (l/rt:restart :js)
+  (l/rt:scaffold-imports :js)
+  (def +url+ (js-playground/play-url (l/rt :js)))
+
+  ;; Open +url+ in a browser, then evaluate:
   (!.js
    (ui/mount-playground
     (-/local-client-defaults)
     {"space_id" "room/playground"
-     "group_id" "auth"})))
+     "group_id" "auth"}))
+
+  (l/rt:stop))

--- a/test-lang/xt/db/node/example_auth_profile_test.clj
+++ b/test-lang/xt/db/node/example_auth_profile_test.clj
@@ -1,79 +1,70 @@
 (ns xt.db.node.example-auth-profile-test
   (:use code.test)
   (:require [hara.lang :as l]
+            [scaffold.supabase.local-min :as local-min]
+            [std.lib.component :as component]
             [xt.lang.common-notify :as notify]))
 
+(require '[hara.runtime.js-playground :as js-playground]
+         '[hara.runtime.chromedriver :as chromedriver])
+
 (l/script- :js
-  {:runtime :basic
+  {:runtime :playground
+   :config {:port 0}
+   :test-mode true
    :require [[xt.lang.common-repl :as repl]
              [xt.lang.common-data :as xtd]
              [xt.lang.spec-base :as xt]
              [xt.lang.spec-promise :as promise]
              [xt.db.node.example-auth-profile :as example]
+             [xt.db.node.example-auth-profile-ui :as ui]
              [xt.db.system.impl-supabase-session :as session]
              [xt.substrate :as substrate]
-             [xt.substrate.page-core :as page-core]]})
+             [xt.substrate.page-core :as page-core]
+             [hara.runtime.js-playground.client :as client]]
+   :emit {:lang/jsx false}})
+
+(defn.js local-client-defaults
+  "returns browser client defaults for scaffold/supabase local-min"
+  {:added "4.1"}
+  []
+  (return
+   {:host (@! (-> local-min/+config+ :api :hostname))
+    :port (@! (-> local-min/+config+ :api :port))
+    :secured false
+    :apikey (@! (-> local-min/+config+ :api :anon-key))}))
+
+(defn.js create-local-node
+  "creates the example node connected to scaffold/supabase local-min"
+  {:added "4.1"}
+  []
+  (return
+   (example/create-auth-profile-node
+    (-/local-client-defaults)
+    example/DEFAULT_SERVICE_ID
+    {"space_id" "room/a"
+     "group_id" "auth"})))
+
+(defn- wait-for-channel
+  "waits up to 5s for the playground websocket channel to be connected"
+  [rt]
+  (let [channel (:channel rt)]
+    (loop [i 0]
+      (when (and (< i 50) (not @channel))
+        (Thread/sleep 100)
+        (recur (inc i))))))
 
 (fact:global
- {:setup [(l/rt:restart)]
-  :teardown [(l/rt:stop)]})
-
-(defn.js install-fake-supabase-handlers
-  "installs in-memory Supabase auth handlers for the example models"
-  {:added "4.1"}
-  [node]
-  (substrate/set-service node "auth/supabase" {"state" {"session" nil}})
-  (substrate/register-handler
-   node
-   "@xt.supabase/sign-in"
-   (fn [space args request node]
-     (var service-id (xt/x:first args))
-     (var credentials (xt/x:second args))
-     (var impl (substrate/get-service node service-id))
-     (var user {"email" (xt/x:get-key credentials "email")
-                "user_metadata" {}})
-     (var next-session {"access_token" "token-1"
-                        "refresh_token" "refresh-1"
-                        "user" user})
-     (session/set-session impl next-session)
-     (return next-session))
-   nil)
-  (substrate/register-handler
-   node
-   "@xt.supabase/sign-out"
-   (fn [space args request node]
-     (var service-id (xt/x:first args))
-     (session/set-session (substrate/get-service node service-id) nil)
-     (return {"status" "ok"}))
-   nil)
-  (substrate/register-handler
-   node
-   "@xt.supabase/current-session"
-   (fn [space args request node]
-     (var service-id (xt/x:first args))
-     (return (session/get-session (substrate/get-service node service-id))))
-   nil)
-  (substrate/register-handler
-   node
-   "@xt.supabase/user-get"
-   (fn [space args request node]
-     (var service-id (xt/x:first args))
-     (return {"user" (xtd/get-in (substrate/get-service node service-id)
-                                  ["state" "session" "user"])}))
-   nil)
-  (substrate/register-handler
-   node
-   "@xt.supabase/user-put"
-   (fn [space args request node]
-     (var service-id (xt/x:first args))
-     (var data (xt/x:second args))
-     (var impl (substrate/get-service node service-id))
-     (var curr-user (xtd/get-in impl ["state" "session" "user"]))
-     (var updated-user (xt/x:obj-assign (xt/x:obj-clone curr-user)
-                                        {"user_metadata" (xt/x:get-key data "data")}))
-     (return updated-user))
-   nil)
-  (return node))
+ {:setup [(local-min/start-supabase)
+          (l/rt:restart :js)
+          (l/rt:scaffold-imports :js)
+          (def +url+ (js-playground/play-url (l/rt :js)))
+          (def +browser+ (chromedriver/browser {}))
+          (chromedriver/goto +url+ 5000 +browser+)
+          (wait-for-channel (l/rt :js))]
+  :teardown [(component/stop +browser+)
+             (l/rt:stop)
+             (local-min/stop-supabase nil)]})
 
 ^{:refer xt.db.node.example-auth-profile/auth-profile-models :added "4.1"}
 (fact "returns the auth/profile example model specs"
@@ -82,86 +73,170 @@
    (var models (example/auth-profile-models "auth/supabase"))
    [(xt/x:is-function? (xtd/get-in models ["session" "handler"]))
     (xt/x:is-function? (xtd/get-in models ["profile" "handler"]))
+    (xt/x:is-function? (xtd/get-in models ["sign-up" "handler"]))
     (xt/x:is-function? (xtd/get-in models ["login" "handler"]))
     (xt/x:is-function? (xtd/get-in models ["logout" "handler"]))
     (xt/x:is-function? (xtd/get-in models ["change-profile" "handler"]))])
-  => [true true true true true])
+  => [true true true true true true])
 
-^{:refer xt.db.node.example-auth-profile-test/install-fake-supabase-handlers :added "4.1"}
-(fact "fake handlers support the Supabase client API"
+^{:refer xt.db.node.example-auth-profile/create-auth-profile-node :added "4.1"}
+(fact "creates a local-min node with the Supabase service and handlers"
 
-  (notify/wait-on [:js 10000]
-    (var node (substrate/node-create {}))
-    (-/install-fake-supabase-handlers node)
-    (-> (substrate/request node
-                           nil
-                           "@xt.supabase/sign-in"
-                           ["auth/supabase" {"email" "person@example.com"} {}]
-                           {})
-        (promise/x:promise-then
-         (fn [_]
-           (return (substrate/request node
-                                      nil
-                                      "@xt.supabase/current-session"
-                                      ["auth/supabase"]
-                                      {}))))
-        (promise/x:promise-then
-         (fn [out]
-           (repl/notify (xtd/get-in out ["user" "email"]))))))
-  => "person@example.com")
+  (!.js
+   (var node (-/create-local-node))
+   (var [_group profile-model]
+        (page-core/model-ensure node "room/a" "auth" "profile"))
+   [(xt/x:not-nil? (substrate/get-service node "auth/supabase"))
+    (xt/x:not-nil? (xt/x:get-key
+                    (xt/x:get-key node "handlers")
+                    "@xt.supabase/sign-up"))
+    (xt/x:not-nil? profile-model)])
+  => [true true true])
 
 ^{:refer xt.db.node.example-auth-profile/attach-auth-profile-models :added "4.1"}
-(fact "logs in, updates auth profile metadata and logs out through page models"
+(fact "signs up, signs back in, updates auth metadata and logs out through local-min"
 
-  (notify/wait-on [:js 10000]
-    (var credentials {"email" "person@example.com" "password" "secret123"})
-    (var node (substrate/node-create {}))
-    (-/install-fake-supabase-handlers node)
-    (example/attach-auth-profile-models node
-                                        "auth/supabase"
-                                        {"space_id" "room/a"
-                                         "group_id" "auth"})
+  (notify/wait-on [:js 15000]
+    (var email (xt/x:cat "auth-profile-"
+                         (xt/x:to-string (xt/x:now-ms))
+                         "@example.com"))
+    (var credentials {"email" email
+                      "password" "secret123"})
+    (var node (-/create-local-node))
     (-> (page-core/model-refresh node
-                                    "room/a"
-                                    "auth"
-                                    "login"
-                                    {"credentials" credentials}
-                                    nil)
+                                 "room/a"
+                                 "auth"
+                                 "sign-up"
+                                 {"credentials" credentials}
+                                 nil)
         (promise/x:promise-then
          (fn [_]
-           (return (page-core/model-refresh node "room/a" "auth" "session" {} nil))))
-        (promise/x:promise-then
-         (fn [_]
-           (return (page-core/model-refresh node "room/a" "auth" "profile" {} nil))))
-        (promise/x:promise-then
-         (fn [_]
-           (return (page-core/model-refresh node
-                                              "room/a"
-                                              "auth"
-                                              "change-profile"
-                                              {"profile" {"display_name" "Test User"}}
-                                              nil))))
-        (promise/x:promise-then
-         (fn [_]
-           (return (page-core/model-refresh node "room/a" "auth" "profile" {} nil))))
-        (promise/x:promise-then
-         (fn [_]
-           (var profile-output (page-core/model-get-output node "room/a" "auth" "profile"))
            (return
-            (-> (page-core/model-refresh node "room/a" "auth" "logout" {} nil)
+            (page-core/model-refresh node
+                                     "room/a"
+                                     "auth"
+                                     "logout"
+                                     {}
+                                     nil))))
+        (promise/x:promise-then
+         (fn [_]
+           (return
+            (page-core/model-refresh node
+                                     "room/a"
+                                     "auth"
+                                     "login"
+                                     {"credentials" credentials}
+                                     nil))))
+        (promise/x:promise-then
+         (fn [_]
+           (return
+            (page-core/model-refresh node
+                                     "room/a"
+                                     "auth"
+                                     "session"
+                                     {}
+                                     nil))))
+        (promise/x:promise-then
+         (fn [_]
+           (return
+            (page-core/model-refresh node
+                                     "room/a"
+                                     "auth"
+                                     "profile"
+                                     {}
+                                     nil))))
+        (promise/x:promise-then
+         (fn [_]
+           (return
+            (page-core/model-refresh
+             node
+             "room/a"
+             "auth"
+             "change-profile"
+             {"profile" {"display_name" "Test User"}}
+             nil))))
+        (promise/x:promise-then
+         (fn [_]
+           (return
+            (page-core/model-refresh node
+                                     "room/a"
+                                     "auth"
+                                     "profile"
+                                     {}
+                                     nil))))
+        (promise/x:promise-then
+         (fn [_]
+           (var profile-output
+                (page-core/model-get-output node
+                                            "room/a"
+                                            "auth"
+                                            "profile"))
+           (return
+            (-> (page-core/model-refresh node
+                                         "room/a"
+                                         "auth"
+                                         "logout"
+                                         {}
+                                         nil)
                 (promise/x:promise-then
                  (fn [_]
-                   (return (page-core/model-refresh node "room/a" "auth" "session" {} nil))))
+                   (return
+                    (page-core/model-refresh node
+                                             "room/a"
+                                             "auth"
+                                             "session"
+                                             {}
+                                             nil))))
                 (promise/x:promise-then
                  (fn [_]
-                   (var session-output (page-core/model-get-output node "room/a" "auth" "session"))
-                   (repl/notify {"email" (xtd/get-in profile-output ["user" "email"])
-                                 "display_name" (xtd/get-in profile-output ["user" "user_metadata" "display_name"])
-                                 "session" session-output})))))))
+                   (var session-output
+                        (page-core/model-get-output node
+                                                    "room/a"
+                                                    "auth"
+                                                    "session"))
+                   (var impl
+                        (substrate/get-service node "auth/supabase"))
+                   (session/auto-refresh-stop impl)
+                   (repl/notify
+                    {"email" (xtd/get-in profile-output
+                                         ["user" "email"])
+                     "display_name" (xtd/get-in profile-output
+                                                ["user"
+                                                 "user_metadata"
+                                                 "display_name"])
+                     "session" session-output})))))))
         (promise/x:promise-catch
          (fn [err]
            (repl/notify {"error" (xt/x:ex-message err)
                          "value" (xt/x:to-string err)})))))
-  => {"email" "person@example.com"
+  => {"email" string?
       "display_name" "Test User"
       "session" nil})
+
+^{:refer xt.db.node.example-auth-profile-ui/mount-playground :added "4.1"}
+(fact "mounts the interactive auth/profile UI in the playground stage"
+
+  (notify/wait-on [:js 5000]
+    (var node
+         (ui/mount-playground
+          (-/local-client-defaults)
+          {"space_id" "room/ui"
+           "group_id" "auth"}))
+    (promise/x:with-delay
+     200
+     (fn []
+       (var heading (. document (querySelector "h1")))
+       (repl/notify
+        [(xt/x:get-key heading "textContent")
+         (xt/x:not-nil?
+          (substrate/get-service node "auth/supabase"))]))))
+  => ["Supabase auth profile" true])
+
+(comment
+
+  ;; With the namespace loaded, open +url+ in a browser and evaluate:
+  (!.js
+   (ui/mount-playground
+    (-/local-client-defaults)
+    {"space_id" "room/playground"
+     "group_id" "auth"})))


### PR DESCRIPTION
## Summary
- replace the fake Supabase handler path in `example_auth_profile_test.clj` with a real `scaffold.supabase.local-min` browser flow
- add a `sign-up` page model and a reusable constructor that installs the Supabase service and kernel handlers
- add an interactive React auth/profile UI that mounts through `window.PLAYGROUND.setStage`
- cover sign-up, logout, login, profile metadata update, final logout, node wiring, and playground rendering

## Playground
Load `xt.db.node.example-auth-profile-test`, open its `+url+`, then evaluate the comment form calling `ui/mount-playground`. The UI can create a local account, sign in, update `user_metadata.display_name`, and sign out.

## Validation
- delimiter/static review completed for all three Clojure/xtalk files
- repository CI is expected to perform the executable runtime validation because the connected environment cannot run the repository's local Supabase/Chrome stack