### PR TITLE
Fix substrate remote request promise settlement

### DIFF
--- a/src-lang/xt/substrate/base_util.clj
+++ b/src-lang/xt/substrate/base_util.clj
@@ -321,39 +321,26 @@
   (if (xt/x:nil? target)
     (return
      (node-request/invoke-handler node request-frame))
-    (try
-      (var pending-state {"status" "pending"
-                          "value" nil
-                          "error" nil})
-      (node-request/add-pending node
-                                request-frame
-                                (fn [value]
-                                  (xt/x:set-key pending-state "status" "resolved")
-                                  (xt/x:set-key pending-state "value" value)
-                                  (return value))
-                                (fn [err]
-                                  (xt/x:set-key pending-state "status" "rejected")
-                                  (xt/x:set-key pending-state "error" err)
-                                  (return err))
-                                {:transport_id target})
-      (return
-       (promise/x:promise-then
-        (promise/x:promise-catch
-         (promise/x:promise-then
-          (-/transport-send node target request-frame)
-          (fn [_]
-            (return nil)))
-         (fn [err]
-           (node-request/remove-pending node
-                                        (xt/x:get-key request-frame "id"))
-           (xt/x:throw err)))
-        (fn [_]
-          (return (-/pending-await pending-state)))))
-      (catch err
-        (return
-         (promise/x:promise
-          (fn []
-            (xt/x:throw err))))))))
+    (return
+     (promise/x:promise-new
+      (fn [resolve reject]
+        (node-request/add-pending node
+                                  request-frame
+                                  resolve
+                                  reject
+                                  {:transport_id target})
+        (try
+          (return
+           (promise/x:promise-catch
+            (-/transport-send node target request-frame)
+            (fn [err]
+              (node-request/remove-pending node
+                                           (xt/x:get-key request-frame "id"))
+              (return (reject err)))))
+          (catch err
+            (node-request/remove-pending node
+                                         (xt/x:get-key request-frame "id"))
+            (return (reject err)))))))))
 
 (defn.xt publish
   "publishes a stream frame through node core and subscribed transports"

--- a/test-lang/xt/substrate/request_promise_test.clj
+++ b/test-lang/xt/substrate/request_promise_test.clj
@@ -1,0 +1,99 @@
+(ns xt.substrate.request-promise-test
+  (:use code.test)
+  (:require [hara.lang :as l]
+            [xt.lang.common-notify :as notify]))
+
+^{:seedgen/root {:all true, :langs [:js :lua :python]}}
+(l/script- :js
+  {:runtime :basic
+   :require [[xt.lang.common-repl :as repl]
+             [xt.lang.spec-promise :as promise]
+             [xt.substrate :as event-node]
+             [xt.substrate.transport-memory :as transport-memory]]})
+
+(l/script- :lua
+  {:runtime :basic
+   :require [[xt.lang.common-repl :as repl]
+             [xt.lang.spec-promise :as promise]
+             [xt.substrate :as event-node]
+             [xt.substrate.transport-memory :as transport-memory]]})
+
+(l/script- :python
+  {:runtime :basic
+   :require [[xt.lang.common-repl :as repl]
+             [xt.lang.spec-promise :as promise]
+             [xt.substrate :as event-node]
+             [xt.substrate.transport-memory :as transport-memory]]})
+
+(fact:global
+ {:setup [(l/rt:restart)]
+  :teardown [(l/rt:stop)]})
+
+^{:refer xt.substrate.base-util/request :added "4.1"}
+(fact "settles linked requests through promise resolver callbacks"
+
+  (notify/wait-on :js
+    (var server
+         (event-node/node-create
+          {"id" "request-server"
+           "handlers"
+           {"demo/echo"
+            {"fn" (fn [space args request server-node]
+                    (return {"echo" args}))
+             "meta" {"kind" "request"}}}}))
+    (var client (event-node/node-create {"id" "request-client"}))
+    (-> (transport-memory/link-pair server client)
+        (promise/x:promise-then
+         (fn [_]
+           (return
+            (event-node/request client
+                                "room/a"
+                                "demo/echo"
+                                ["ping"]
+                                nil))))
+        (repl/notify)))
+  => {"echo" ["ping"]}
+
+  (notify/wait-on :lua
+    (var server
+         (event-node/node-create
+          {"id" "request-server"
+           "handlers"
+           {"demo/echo"
+            {"fn" (fn [space args request server-node]
+                    (return {"echo" args}))
+             "meta" {"kind" "request"}}}}))
+    (var client (event-node/node-create {"id" "request-client"}))
+    (-> (transport-memory/link-pair server client)
+        (promise/x:promise-then
+         (fn [_]
+           (return
+            (event-node/request client
+                                "room/a"
+                                "demo/echo"
+                                ["ping"]
+                                nil))))
+        (repl/notify)))
+  => {"echo" ["ping"]}
+
+  (notify/wait-on :python
+    (var server
+         (event-node/node-create
+          {"id" "request-server"
+           "handlers"
+           {"demo/echo"
+            {"fn" (fn [space args request server-node]
+                    (return {"echo" args}))
+             "meta" {"kind" "request"}}}}))
+    (var client (event-node/node-create {"id" "request-client"}))
+    (-> (transport-memory/link-pair server client)
+        (promise/x:promise-then
+         (fn [_]
+           (return
+            (event-node/request client
+                                "room/a"
+                                "demo/echo"
+                                ["ping"]
+                                nil))))
+        (repl/notify)))
+  => {"echo" ["ping"]})


### PR DESCRIPTION
## Summary

Replace polling-based remote request settlement with `promise/x:promise-new` resolver/rejecter callbacks.

## Problem

`xt.substrate.base-util/request` stored response state in a mutable map and repeatedly called `pending-await`. That polling path depends on `xt/x:async-run`, which behaves differently across runtimes:

- Lua resumes the coroutine immediately, causing recursive spinning.
- Python starts another OS thread for each poll.
- Dart can continuously schedule completed futures and starve other event-loop work.

This caused linked requests to hang or time out even though the threaded expression ending in `repl/notify` was valid.

## Changes

- Register the `promise-new` resolver and rejecter directly in the pending request entry.
- Resolve or reject that promise when `settle-pending` receives the response.
- Remove the pending entry and reject the request when transport sending fails synchronously or asynchronously.
- Add a regression test covering the exact `link-pair -> promise-then -> request -> repl/notify` chain for JavaScript, Lua, and Python.

## Verification

The branch diff contains only:

- `src-lang/xt/substrate/base_util.clj`
- `test-lang/xt/substrate/request_promise_test.clj`

GitHub Actions are currently configured to run only on `main`, so the new branch cannot execute the xtbench matrix before merge. The regression test is included for the next `main` run.