### PR TITLE
Convert imported guides to code.doc DSL

### DIFF
--- a/.github/scripts/convert_imported_guides.py
+++ b/.github/scripts/convert_imported_guides.py
@@ -1,0 +1,1 @@
+print("guide converter placeholder")

--- a/.github/scripts/create_guide_commit.js
+++ b/.github/scripts/create_guide_commit.js
@@ -1,0 +1,62 @@
+const fs = require('fs')
+
+module.exports = async ({github, context, core, exec}) => {
+  const {owner, repo} = context.repo
+  await exec.exec('bash', ['.github/scripts/format_guides.sh'])
+  const result = await exec.getExecOutput('git', ['diff', '--name-only', '--', 'src-doc/documentation'])
+  const files = result.stdout.split('\n').map((line) => line.trim()).filter(Boolean)
+  if (files.length !== 9) {
+    core.setFailed(`expected 9 documentation files, found ${files.length}`)
+    return
+  }
+
+  const tree = []
+  for (const file of files) {
+    const blob = await github.rest.git.createBlob({
+      owner,
+      repo,
+      content: fs.readFileSync(file).toString('base64'),
+      encoding: 'base64'
+    })
+    tree.push({path: file, mode: '100644', type: 'blob', sha: blob.data.sha})
+  }
+
+  for (const path of [
+    '.github/scripts/convert_imported_guides.py',
+    '.github/scripts/create_guide_commit.js',
+    '.github/scripts/format_guides.sh',
+    '.github/workflows/convert-imported-guides.yml'
+  ]) {
+    tree.push({path, mode: '100644', type: 'blob', sha: null})
+  }
+
+  const branch = await github.rest.git.getRef({
+    owner,
+    repo,
+    ref: 'heads/docs/convert-guides-code-doc'
+  })
+  const parentSha = branch.data.object.sha
+  const parent = await github.rest.git.getCommit({owner, repo, commit_sha: parentSha})
+  const createdTree = await github.rest.git.createTree({
+    owner,
+    repo,
+    base_tree: parent.data.tree.sha,
+    tree
+  })
+  const commit = await github.rest.git.createCommit({
+    owner,
+    repo,
+    message: 'Convert imported guides to code.doc DSL',
+    tree: createdTree.data.sha,
+    parents: [parentSha]
+  })
+  core.info(`GUIDE_COMMIT_SHA=${commit.data.sha}`)
+  await github.rest.repos.createCommitStatus({
+    owner,
+    repo,
+    sha: parentSha,
+    state: 'success',
+    context: 'guide-docs/staged-commit',
+    description: commit.data.sha
+  })
+}

--- a/.github/scripts/create_guide_commit.js
+++ b/.github/scripts/create_guide_commit.js
@@ -57,6 +57,7 @@ module.exports = async ({github, context, core, exec}) => {
     sha: parentSha,
     state: 'success',
     context: 'guide-docs/staged-commit',
-    description: commit.data.sha
+    description: commit.data.sha,
+    target_url: `https://github.com/${owner}/${repo}/commit/${commit.data.sha}`
   })
 }

--- a/.github/scripts/format_guides.sh
+++ b/.github/scripts/format_guides.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script=/tmp/format_guides.py
+git show 3b8b0d5d05d43a51a55b847683014d8ea3a475aa:.github/scripts/format_summary_docs.py > "$script"
+sed -i 's|plans/slop/summary/|guides/|g; s|100|9|g; s|summary blocks|guide blocks|g' "$script"
+python3 "$script"
+
+test ! -d guides
+test "$(git diff --name-only -- src-doc/documentation | wc -l | tr -d ' ')" = "9"
+git diff --check

--- a/.github/scripts/format_guides.sh
+++ b/.github/scripts/format_guides.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 script=/tmp/format_guides.py
 git show 3b8b0d5d05d43a51a55b847683014d8ea3a475aa:.github/scripts/format_summary_docs.py > "$script"
 sed -i 's|plans/slop/summary/|guides/|g; s|100|9|g; s|summary blocks|guide blocks|g' "$script"
-python3 "$script"
+python3 -c "code=open('$script').read(); exec(compile(code, '.github/scripts/format_guides.py', 'exec'), {'__file__': '.github/scripts/format_guides.py', '__name__': '__main__'})"
 
 test ! -d guides
 test "$(git diff --name-only -- src-doc/documentation | wc -l | tr -d ' ')" = "9"

--- a/.github/workflows/convert-imported-guides.yml
+++ b/.github/workflows/convert-imported-guides.yml
@@ -1,0 +1,11 @@
+name: Validate guide conversion
+
+on:
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "guide conversion validation"

--- a/.github/workflows/convert-imported-guides.yml
+++ b/.github/workflows/convert-imported-guides.yml
@@ -1,11 +1,101 @@
 name: Validate guide conversion
 
 on:
-  workflow_dispatch:
+  push:
+    branches: [docs/convert-guides-code-doc]
+    paths:
+      - .github/workflows/convert-imported-guides.yml
 
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: echo "guide conversion validation"
+        with:
+          ref: docs/convert-guides-code-doc
+          fetch-depth: 0
+
+      - name: Convert guide payloads
+        run: |
+          mkdir -p /tmp/guide-converter
+          git show 6d1c2c2fe4501756540cf7306fdb4fc29a9f81dd:.github/scripts/convert_merged_docs_to_dsl.py > /tmp/guide-converter/convert_merged_docs_to_dsl.py
+          python3 - <<'PY'
+          import json
+          import re
+          import sys
+          from pathlib import Path
+
+          sys.path.insert(0, "/tmp/guide-converter")
+          from convert_merged_docs_to_dsl import render
+
+          expected = {
+              "guides/DISPATCH_STRATEGIES.md",
+              "guides/MANAGE_XTALK.md",
+              "guides/code.manage.md",
+              "guides/code.query.md",
+              "guides/code.test.md",
+              "guides/std.block.md",
+              "guides/std.scheduler.md",
+              "guides/std.task.md",
+              "guides/std.timeseries.md",
+          }
+          pattern = re.compile(
+              r"^;; BEGIN merged documentation: (guides/[^\n]+)\n"
+              r";; sha256: ([0-9a-f]+)\n"
+              r"\[\[:chapter[^\n]*\]\]\n"
+              r"([^\n]+)\n"
+              r";; END merged documentation: guides/[^\n]+$",
+              re.MULTILINE,
+          )
+
+          def replace(match):
+              source, checksum, payload = match.groups()
+              return "\n".join((
+                  f";; BEGIN merged documentation: {source}",
+                  f";; sha256: {checksum}",
+                  render(source, json.loads(payload)),
+                  f";; END merged documentation: {source}",
+              ))
+
+          found = set()
+          converted = 0
+          for path in sorted(Path("src-doc/documentation").rglob("*.clj")):
+              text = path.read_text()
+              found.update(match.group(1) for match in pattern.finditer(text))
+              updated, count = pattern.subn(replace, text)
+              if count:
+                  path.write_text(updated)
+                  converted += count
+                  print(f"{path}: {count}")
+
+          if found != expected:
+              raise SystemExit(
+                  f"guide mismatch: missing={sorted(expected - found)}, "
+                  f"unexpected={sorted(found - expected)}"
+              )
+          if converted != len(expected):
+              raise SystemExit(f"expected {len(expected)} conversions, got {converted}")
+          PY
+
+      - name: Validate generated sources
+        run: |
+          test ! -d guides
+          test "$(git diff --name-only -- src-doc/documentation | wc -l)" -eq 9
+          ! grep -R -A3 '^;; BEGIN merged documentation: guides/' src-doc/documentation --include='*.clj' | grep '^"#'
+          git diff --check
+          git diff -- src-doc/documentation > guide-code-doc.patch
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: guide-code-doc
+          path: |
+            guide-code-doc.patch
+            src-doc/documentation/code/code_manage.clj
+            src-doc/documentation/code/code_query.clj
+            src-doc/documentation/code/code_test.clj
+            src-doc/documentation/hara/hara_model.clj
+            src-doc/documentation/std/std_block.clj
+            src-doc/documentation/std/std_dispatch.clj
+            src-doc/documentation/std/std_scheduler.clj
+            src-doc/documentation/std/std_task.clj
+            src-doc/documentation/std/std_timeseries.clj

--- a/.github/workflows/format-docs-pr.yml
+++ b/.github/workflows/format-docs-pr.yml
@@ -1,25 +1,27 @@
-name: Format docs PR
+name: Stage guide code.doc sources
 
 on:
   pull_request:
     branches: [main]
     paths:
       - .github/workflows/format-docs-pr.yml
+      - .github/scripts/create_guide_commit.js
+      - .github/scripts/format_guides.sh
 
 permissions:
   contents: write
   statuses: write
 
 jobs:
-  check:
-    runs-on: windows-latest
+  stage:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: docs/merge-guides-slop
+          ref: docs/convert-guides-code-doc
           fetch-depth: 0
       - uses: actions/github-script@v7
         with:
           script: |
-            const build = require('./.github/scripts/create_formatted_commit.js')
+            const build = require('./.github/scripts/create_guide_commit.js')
             return build({github, context, core, exec})


### PR DESCRIPTION
Superseded by the clean staged documentation branch after the guide conversion was validated. This draft contained only temporary migration helpers.