### PR TITLE
Render imported Clojure examples as code.test facts

### DIFF
--- a/.github/summary-facts-pr-note.md
+++ b/.github/summary-facts-pr-note.md
@@ -1,1 +1,1 @@
-Temporary validation marker refreshed after the final std.block fact patch. This file will be removed before review.
+Temporary validation marker refreshed after simplifying the std.block parse fact. This file will be removed before review.

--- a/.github/summary-facts-pr-note.md
+++ b/.github/summary-facts-pr-note.md
@@ -1,1 +1,1 @@
-Temporary validation marker. This file will be removed before review.
+Temporary validation marker refreshed after the fact patches. This file will be removed before review.

--- a/.github/summary-facts-pr-note.md
+++ b/.github/summary-facts-pr-note.md
@@ -1,1 +1,1 @@
-Temporary validation marker refreshed after the fact patches. This file will be removed before review.
+Temporary validation marker refreshed after the final std.block fact patch. This file will be removed before review.

--- a/.github/summary-facts-pr-note.md
+++ b/.github/summary-facts-pr-note.md
@@ -1,0 +1,1 @@
+Temporary validation marker. This file will be removed before review.

--- a/.github/summary-facts-pr-trigger.md
+++ b/.github/summary-facts-pr-trigger.md
@@ -1,0 +1,1 @@
+Temporary trigger for pull-request validation. Removed before review.

--- a/.github/workflows/apply-summary-facts.yml
+++ b/.github/workflows/apply-summary-facts.yml
@@ -26,11 +26,33 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check committed fact counts
+      - name: Repair reader-unsafe expected value
         run: |
           set -euo pipefail
-          test "$(grep -Rh '^\^{:id merged-plans-slop-summary-.*-example-' src-doc/documentation/{code/code_query.clj,std/lib_index.clj,std/std_block.clj,std/std_lib_apply.clj,std/std_lib_bin.clj,std/std_lib_component.clj,std_lang_introduction.clj,xt/xt_lang.clj} | wc -l | tr -d ' ')" = "277"
-          test "$(grep -Rh '\[\[:code {:lang "clojure"}' src-doc/documentation/{code/code_query.clj,std/lib_index.clj,std/std_block.clj,std/std_lib_apply.clj,std/std_lib_bin.clj,std/std_lib_component.clj,std_lang_introduction.clj,xt/xt_lang.clj} | wc -l | tr -d ' ')" = "0"
+          python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path("src-doc/documentation/std/std_block.clj")
+          text = path.read_text()
+          before = '''  (modifier-block :hash-uneval "#_" (fn [acc _] acc))
+            => #std.block.type.ModifierBlock{:tag :hash-uneval, :string "#_", :command #function[...]}
+          '''
+          after = '''  (select-keys (modifier-block :hash-uneval "#_" (fn [acc _] acc))
+               [:tag :string])
+            => {:tag :hash-uneval, :string "#_"}
+          '''
+          if before not in text:
+              raise SystemExit("modifier-block example was not found")
+          path.write_text(text.replace(before, after, 1))
+          PY
+
+      - name: Check generated fact counts
+        run: |
+          set -euo pipefail
+          fact_count=$(grep -Rh '^\^{:id merged-plans-slop-summary-.*-example-' src-doc/documentation/{code/code_query.clj,std/lib_index.clj,std/std_block.clj,std/std_lib_apply.clj,std/std_lib_bin.clj,std/std_lib_component.clj,std_lang_introduction.clj,xt/xt_lang.clj} | wc -l | tr -d ' ')
+          code_count=$(( (grep -Rh '\[\[:code {:lang "clojure"}' src-doc/documentation/{code/code_query.clj,std/lib_index.clj,std/std_block.clj,std/std_lib_apply.clj,std/std_lib_bin.clj,std/std_lib_component.clj,std_lang_introduction.clj,xt/xt_lang.clj} || true) | wc -l | tr -d ' ' ))
+          test "$fact_count" = "277"
+          test "$code_count" = "0"
           git diff --check
 
       - name: Extract generated facts

--- a/.github/workflows/apply-summary-facts.yml
+++ b/.github/workflows/apply-summary-facts.yml
@@ -1,4 +1,4 @@
-name: Apply summary fact examples
+name: Validate summary fact examples
 
 on:
   push:
@@ -7,10 +7,11 @@ on:
       - .github/workflows/apply-summary-facts.yml
 
 permissions:
-  contents: write
+  contents: read
+  packages: read
 
 jobs:
-  apply:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,35 +19,155 @@ jobs:
           ref: docs/summary-fact-examples
           fetch-depth: 0
 
-      - name: Generate fact examples
+      - name: Check committed fact counts
         run: |
           set -euo pipefail
-          python3 .github/scripts/format_summary_facts.py
-          python3 - <<'PY'
-          from pathlib import Path
-          path = Path("src-doc/documentation/std/std_block.clj")
-          text = path.read_text()
-          before = '''  ;; Throws exception if string is not a valid comment
-            ;; (str (comment "hello"))
-            => ExceptionInfo: "Not a valid comment string."
-          '''
-          after = '''  ;; Throws exception if string is not a valid comment
-            (str (comment "hello"))
-            => (throws clojure.lang.ExceptionInfo "Not a valid comment string.")
-          '''
-          if before not in text:
-              raise SystemExit("exception example was not found")
-          path.write_text(text.replace(before, after, 1))
-          PY
-          test "$(git diff --name-only -- src-doc/documentation | wc -l | tr -d ' ')" = "8"
           test "$(grep -Rh '^\^{:id merged-plans-slop-summary-.*-example-' src-doc/documentation/{code/code_query.clj,std/lib_index.clj,std/std_block.clj,std/std_lib_apply.clj,std/std_lib_bin.clj,std/std_lib_component.clj,std_lang_introduction.clj,xt/xt_lang.clj} | wc -l | tr -d ' ')" = "277"
+          test "$(grep -Rh '\[\[:code {:lang "clojure"}' src-doc/documentation/{code/code_query.clj,std/lib_index.clj,std/std_block.clj,std/std_lib_apply.clj,std/std_lib_bin.clj,std/std_lib_component.clj,std_lang_introduction.clj,xt/xt_lang.clj} | wc -l | tr -d ' ')" = "0"
           git diff --check
 
-      - name: Commit generated pages
+      - name: Extract generated facts
         run: |
           set -euo pipefail
-          git add src-doc/documentation
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git commit -m "Represent imported Clojure examples as facts"
-          git push origin HEAD:docs/summary-fact-examples
+          python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          files = [
+              Path("src-doc/documentation/code/code_query.clj"),
+              Path("src-doc/documentation/std/lib_index.clj"),
+              Path("src-doc/documentation/std/std_block.clj"),
+              Path("src-doc/documentation/std/std_lib_apply.clj"),
+              Path("src-doc/documentation/std/std_lib_bin.clj"),
+              Path("src-doc/documentation/std/std_lib_component.clj"),
+              Path("src-doc/documentation/std_lang_introduction.clj"),
+              Path("src-doc/documentation/xt/xt_lang.clj"),
+          ]
+          out = Path(".tmp/generated-facts")
+          out.mkdir(parents=True, exist_ok=True)
+          marker = re.compile(r'^\^\{:id (merged-plans-slop-summary-[^ ]+-example-\d+) :added "4\.0"\}\n', re.M)
+
+          def extract_fact(text, start):
+              start = text.index("(fact ", start)
+              depth = 0
+              string = False
+              escape = False
+              comment = False
+              index = start
+              while index < len(text):
+                  char = text[index]
+                  if comment:
+                      if char == "\n":
+                          comment = False
+                      index += 1
+                      continue
+                  if string:
+                      if escape:
+                          escape = False
+                      elif char == "\\":
+                          escape = True
+                      elif char == '"':
+                          string = False
+                      index += 1
+                      continue
+                  if char == ";":
+                      comment = True
+                  elif char == '"':
+                      string = True
+                  elif char == "\\":
+                      index += 2
+                      continue
+                  elif char == "(":
+                      depth += 1
+                  elif char == ")":
+                      depth -= 1
+                      if depth == 0:
+                          return text[start:index + 1]
+                  index += 1
+              raise ValueError("unterminated fact")
+
+          count = 0
+          for path in files:
+              text = path.read_text()
+              for match in marker.finditer(text):
+                  identifier = match.group(1)
+                  (out / f"{identifier}.clj").write_text(
+                      extract_fact(text, match.end()) + "\n"
+                  )
+                  count += 1
+          if count != 277:
+              raise SystemExit(f"expected 277 extracted facts, found {count}")
+          print("Extracted", count, "generated facts.")
+          PY
+
+      - name: Log into GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Parse every generated fact and page
+        run: |
+          set -euo pipefail
+          cat > .tmp/validate_summary_facts.clj <<'CLJ'
+          (require '[clojure.java.io :as io]
+                   '[code.doc.parse :as parse]
+                   '[std.block.navigate :as nav])
+
+          (def page-files
+            ["src-doc/documentation/code/code_query.clj"
+             "src-doc/documentation/std/lib_index.clj"
+             "src-doc/documentation/std/std_block.clj"
+             "src-doc/documentation/std/std_lib_apply.clj"
+             "src-doc/documentation/std/std_lib_bin.clj"
+             "src-doc/documentation/std/std_lib_component.clj"
+             "src-doc/documentation/std_lang_introduction.clj"
+             "src-doc/documentation/xt/xt_lang.clj"])
+
+          (def failures (atom []))
+
+          (doseq [file (sort-by #(.getName %) (file-seq (io/file ".tmp/generated-facts")))
+                  :when (.isFile file)]
+            (try
+              (nav/parse-string (slurp file))
+              (catch Throwable t
+                (println "FACT-FAIL" (.getName file) "::" (.getMessage t))
+                (swap! failures conj (.getName file)))))
+
+          (when (seq @failures)
+            (throw (ex-info "Generated facts failed parsing"
+                            {:failures @failures})))
+
+          (doseq [file page-files]
+            (println "Parsing page" file)
+            (let [elements (parse/parse-file file {})]
+              (when-not (seq elements)
+                (throw (ex-info "Documentation page produced no elements"
+                                {:file file})))))
+
+          (println "Parsed all generated facts and" (count page-files) "documentation pages.")
+          CLJ
+
+          set +e
+          docker run --rm \
+            -e 'CI=true' \
+            -e "LEIN_JVM_OPTS=-Xms512m -Xmx3g -XX:+UseG1GC" \
+            -v "$(pwd):$(pwd)" \
+            -w "$(pwd)" \
+            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
+            bash -lc 'set -euo pipefail; lein javac; java -cp "$(lein classpath)" clojure.main .tmp/validate_summary_facts.clj' \
+            > .tmp/parse.log 2>&1
+          status=$?
+          echo "$status" > .tmp/parse.status
+          cat .tmp/parse.log
+          exit "$status"
+
+      - name: Upload parser diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: summary-fact-validation
+          path: |
+            .tmp/parse.log
+            .tmp/parse.status

--- a/.github/workflows/apply-summary-facts.yml
+++ b/.github/workflows/apply-summary-facts.yml
@@ -1,0 +1,52 @@
+name: Apply summary fact examples
+
+on:
+  push:
+    branches: [docs/summary-fact-examples]
+    paths:
+      - .github/workflows/apply-summary-facts.yml
+
+permissions:
+  contents: write
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: docs/summary-fact-examples
+          fetch-depth: 0
+
+      - name: Generate fact examples
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/format_summary_facts.py
+          python3 - <<'PY'
+          from pathlib import Path
+          path = Path("src-doc/documentation/std/std_block.clj")
+          text = path.read_text()
+          before = '''  ;; Throws exception if string is not a valid comment
+            ;; (str (comment "hello"))
+            => ExceptionInfo: "Not a valid comment string."
+          '''
+          after = '''  ;; Throws exception if string is not a valid comment
+            (str (comment "hello"))
+            => (throws clojure.lang.ExceptionInfo "Not a valid comment string.")
+          '''
+          if before not in text:
+              raise SystemExit("exception example was not found")
+          path.write_text(text.replace(before, after, 1))
+          PY
+          test "$(git diff --name-only -- src-doc/documentation | wc -l | tr -d ' ')" = "8"
+          test "$(grep -Rh '^\^{:id merged-plans-slop-summary-.*-example-' src-doc/documentation/{code/code_query.clj,std/lib_index.clj,std/std_block.clj,std/std_lib_apply.clj,std/std_lib_bin.clj,std/std_lib_component.clj,std_lang_introduction.clj,xt/xt_lang.clj} | wc -l | tr -d ' ')" = "277"
+          git diff --check
+
+      - name: Commit generated pages
+        run: |
+          set -euo pipefail
+          git add src-doc/documentation
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git commit -m "Represent imported Clojure examples as facts"
+          git push origin HEAD:docs/summary-fact-examples

--- a/.github/workflows/apply-summary-facts.yml
+++ b/.github/workflows/apply-summary-facts.yml
@@ -7,7 +7,7 @@ on:
       - .github/workflows/apply-summary-facts.yml
 
 permissions:
-  contents: read
+  contents: write
   packages: read
 
 jobs:
@@ -157,17 +157,15 @@ jobs:
             -w "$(pwd)" \
             ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
             bash -lc 'set -euo pipefail; lein javac; java -cp "$(lein classpath)" clojure.main .tmp/validate_summary_facts.clj' \
-            > .tmp/parse.log 2>&1
-          status=$?
-          echo "$status" > .tmp/parse.status
-          cat .tmp/parse.log
-          exit "$status"
+            > .github/summary-facts-validation.log 2>&1
+          echo "$?" > .github/summary-facts-validation.status
+          set -e
 
-      - name: Upload parser diagnostics
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: summary-fact-validation
-          path: |
-            .tmp/parse.log
-            .tmp/parse.status
+      - name: Publish validation result
+        run: |
+          set -euo pipefail
+          git add .github/summary-facts-validation.log .github/summary-facts-validation.status
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git commit -m "Record summary fact validation"
+          git push origin HEAD:docs/summary-fact-examples

--- a/.github/workflows/apply-summary-facts.yml
+++ b/.github/workflows/apply-summary-facts.yml
@@ -49,11 +49,35 @@ jobs:
       - name: Check generated fact counts
         run: |
           set -euo pipefail
-          fact_count=$(grep -Rh '^\^{:id merged-plans-slop-summary-.*-example-' src-doc/documentation/{code/code_query.clj,std/lib_index.clj,std/std_block.clj,std/std_lib_apply.clj,std/std_lib_bin.clj,std/std_lib_component.clj,std_lang_introduction.clj,xt/xt_lang.clj} | wc -l | tr -d ' ')
-          code_count=$( (grep -Rh '\[\[:code {:lang "clojure"}' src-doc/documentation/{code/code_query.clj,std/lib_index.clj,std/std_block.clj,std/std_lib_apply.clj,std/std_lib_bin.clj,std/std_lib_component.clj,std_lang_introduction.clj,xt/xt_lang.clj} || true) | wc -l | tr -d ' ' )
-          test "$fact_count" = "277"
-          test "$code_count" = "0"
-          git diff --check
+          python3 - <<'PY'
+          from pathlib import Path
+
+          files = [
+              Path("src-doc/documentation/code/code_query.clj"),
+              Path("src-doc/documentation/std/lib_index.clj"),
+              Path("src-doc/documentation/std/std_block.clj"),
+              Path("src-doc/documentation/std/std_lib_apply.clj"),
+              Path("src-doc/documentation/std/std_lib_bin.clj"),
+              Path("src-doc/documentation/std/std_lib_component.clj"),
+              Path("src-doc/documentation/std_lang_introduction.clj"),
+              Path("src-doc/documentation/xt/xt_lang.clj"),
+          ]
+          text = "\n".join(path.read_text() for path in files)
+          fact_count = sum(
+              1 for line in text.splitlines()
+              if line.startswith("^{:id merged-plans-slop-summary-")
+              and "-example-" in line
+          )
+          code_count = text.count('[[:code {:lang "clojure"}')
+          print({"facts": fact_count, "clojure-code-directives": code_count})
+          if fact_count != 277:
+              raise SystemExit(f"expected 277 generated facts, found {fact_count}")
+          if code_count != 0:
+              raise SystemExit(f"expected no imported Clojure code directives, found {code_count}")
+          PY
+
+      - name: Check patch formatting
+        run: git diff --check
 
       - name: Extract generated facts
         run: |

--- a/.github/workflows/apply-summary-facts.yml
+++ b/.github/workflows/apply-summary-facts.yml
@@ -19,17 +19,27 @@ jobs:
           ref: docs/summary-fact-examples
           fetch-depth: 0
 
-      - name: Check committed fact counts
-        run: |
-          set -euo pipefail
-          test "$(grep -Rh '^\^{:id merged-plans-slop-summary-.*-example-' src-doc/documentation/{code/code_query.clj,std/lib_index.clj,std/std_block.clj,std/std_lib_apply.clj,std/std_lib_bin.clj,std/std_lib_component.clj,std_lang_introduction.clj,xt/xt_lang.clj} | wc -l | tr -d ' ')" = "277"
-          test "$(grep -Rh '\[\[:code {:lang "clojure"}' src-doc/documentation/{code/code_query.clj,std/lib_index.clj,std/std_block.clj,std/std_lib_apply.clj,std/std_lib_bin.clj,std/std_lib_component.clj,std_lang_introduction.clj,xt/xt_lang.clj} | wc -l | tr -d ' ')" = "0"
-          git diff --check
+      - name: Log into GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract generated facts
+      - name: Validate and publish diagnostics
         run: |
-          set -euo pipefail
-          python3 - <<'PY'
+          set +e
+          mkdir -p .tmp/generated-facts
+          : > .github/summary-facts-validation.log
+          status=0
+
+          count=$(grep -Rh '^\^{:id merged-plans-slop-summary-.*-example-' src-doc/documentation/{code/code_query.clj,std/lib_index.clj,std/std_block.clj,std/std_lib_apply.clj,std/std_lib_bin.clj,std/std_lib_component.clj,std_lang_introduction.clj,xt/xt_lang.clj} | wc -l | tr -d ' ')
+          echo "Generated fact count: $count" >> .github/summary-facts-validation.log
+          if [ "$count" != "277" ]; then
+            status=1
+          fi
+
+          python3 - <<'PY' >> .github/summary-facts-validation.log 2>&1
           import re
           from pathlib import Path
 
@@ -44,7 +54,6 @@ jobs:
               Path("src-doc/documentation/xt/xt_lang.clj"),
           ]
           out = Path(".tmp/generated-facts")
-          out.mkdir(parents=True, exist_ok=True)
           marker = re.compile(r'^\^\{:id (merged-plans-slop-summary-[^ ]+-example-\d+) :added "4\.0"\}\n', re.M)
 
           def extract_fact(text, start):
@@ -99,17 +108,11 @@ jobs:
               raise SystemExit(f"expected 277 extracted facts, found {count}")
           print("Extracted", count, "generated facts.")
           PY
+          extract_status=$?
+          if [ "$extract_status" != "0" ]; then
+            status=$extract_status
+          fi
 
-      - name: Log into GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Parse every generated fact and page
-        run: |
-          set -euo pipefail
           cat > .tmp/validate_summary_facts.clj <<'CLJ'
           (require '[clojure.java.io :as io]
                    '[code.doc.parse :as parse]
@@ -149,21 +152,24 @@ jobs:
           (println "Parsed all generated facts and" (count page-files) "documentation pages.")
           CLJ
 
-          set +e
-          docker run --rm \
-            -e 'CI=true' \
-            -e "LEIN_JVM_OPTS=-Xms512m -Xmx3g -XX:+UseG1GC" \
-            -v "$(pwd):$(pwd)" \
-            -w "$(pwd)" \
-            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
-            bash -lc 'set -euo pipefail; lein javac; java -cp "$(lein classpath)" clojure.main .tmp/validate_summary_facts.clj' \
-            > .github/summary-facts-validation.log 2>&1
-          echo "$?" > .github/summary-facts-validation.status
-          set -e
+          if [ "$extract_status" = "0" ]; then
+            docker run --rm \
+              -e 'CI=true' \
+              -e "LEIN_JVM_OPTS=-Xms512m -Xmx3g -XX:+UseG1GC" \
+              -v "$(pwd):$(pwd)" \
+              -w "$(pwd)" \
+              ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
+              bash -lc 'set -euo pipefail; lein javac; java -cp "$(lein classpath)" clojure.main .tmp/validate_summary_facts.clj' \
+              >> .github/summary-facts-validation.log 2>&1
+            parse_status=$?
+            if [ "$parse_status" != "0" ]; then
+              status=$parse_status
+            fi
+          fi
 
-      - name: Publish validation result
-        run: |
-          set -euo pipefail
+          echo "$status" > .github/summary-facts-validation.status
+          cat .github/summary-facts-validation.log
+
           git add .github/summary-facts-validation.log .github/summary-facts-validation.status
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/.github/workflows/apply-summary-facts.yml
+++ b/.github/workflows/apply-summary-facts.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           set -euo pipefail
           fact_count=$(grep -Rh '^\^{:id merged-plans-slop-summary-.*-example-' src-doc/documentation/{code/code_query.clj,std/lib_index.clj,std/std_block.clj,std/std_lib_apply.clj,std/std_lib_bin.clj,std/std_lib_component.clj,std_lang_introduction.clj,xt/xt_lang.clj} | wc -l | tr -d ' ')
-          code_count=$(( (grep -Rh '\[\[:code {:lang "clojure"}' src-doc/documentation/{code/code_query.clj,std/lib_index.clj,std/std_block.clj,std/std_lib_apply.clj,std/std_lib_bin.clj,std/std_lib_component.clj,std_lang_introduction.clj,xt/xt_lang.clj} || true) | wc -l | tr -d ' ' ))
+          code_count=$( (grep -Rh '\[\[:code {:lang "clojure"}' src-doc/documentation/{code/code_query.clj,std/lib_index.clj,std/std_block.clj,std/std_lib_apply.clj,std/std_lib_bin.clj,std/std_lib_component.clj,std_lang_introduction.clj,xt/xt_lang.clj} || true) | wc -l | tr -d ' ' )
           test "$fact_count" = "277"
           test "$code_count" = "0"
           git diff --check

--- a/.github/workflows/apply-summary-facts.yml
+++ b/.github/workflows/apply-summary-facts.yml
@@ -1,13 +1,21 @@
 name: Validate summary fact examples
 
 on:
-  push:
-    branches: [docs/summary-fact-examples]
+  pull_request:
+    branches: [main]
     paths:
       - .github/workflows/apply-summary-facts.yml
+      - src-doc/documentation/code/code_query.clj
+      - src-doc/documentation/std/lib_index.clj
+      - src-doc/documentation/std/std_block.clj
+      - src-doc/documentation/std/std_lib_apply.clj
+      - src-doc/documentation/std/std_lib_bin.clj
+      - src-doc/documentation/std/std_lib_component.clj
+      - src-doc/documentation/std_lang_introduction.clj
+      - src-doc/documentation/xt/xt_lang.clj
 
 permissions:
-  contents: write
+  contents: read
   packages: read
 
 jobs:
@@ -16,30 +24,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: docs/summary-fact-examples
           fetch-depth: 0
 
-      - name: Log into GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Validate and publish diagnostics
+      - name: Check committed fact counts
         run: |
-          set +e
+          set -euo pipefail
+          test "$(grep -Rh '^\^{:id merged-plans-slop-summary-.*-example-' src-doc/documentation/{code/code_query.clj,std/lib_index.clj,std/std_block.clj,std/std_lib_apply.clj,std/std_lib_bin.clj,std/std_lib_component.clj,std_lang_introduction.clj,xt/xt_lang.clj} | wc -l | tr -d ' ')" = "277"
+          test "$(grep -Rh '\[\[:code {:lang "clojure"}' src-doc/documentation/{code/code_query.clj,std/lib_index.clj,std/std_block.clj,std/std_lib_apply.clj,std/std_lib_bin.clj,std/std_lib_component.clj,std_lang_introduction.clj,xt/xt_lang.clj} | wc -l | tr -d ' ')" = "0"
+          git diff --check
+
+      - name: Extract generated facts
+        run: |
+          set -euo pipefail
           mkdir -p .tmp/generated-facts
-          : > .github/summary-facts-validation.log
-          status=0
-
-          count=$(grep -Rh '^\^{:id merged-plans-slop-summary-.*-example-' src-doc/documentation/{code/code_query.clj,std/lib_index.clj,std/std_block.clj,std/std_lib_apply.clj,std/std_lib_bin.clj,std/std_lib_component.clj,std_lang_introduction.clj,xt/xt_lang.clj} | wc -l | tr -d ' ')
-          echo "Generated fact count: $count" >> .github/summary-facts-validation.log
-          if [ "$count" != "277" ]; then
-            status=1
-          fi
-
-          python3 - <<'PY' >> .github/summary-facts-validation.log 2>&1
+          python3 - <<'PY'
           import re
           from pathlib import Path
 
@@ -108,11 +106,17 @@ jobs:
               raise SystemExit(f"expected 277 extracted facts, found {count}")
           print("Extracted", count, "generated facts.")
           PY
-          extract_status=$?
-          if [ "$extract_status" != "0" ]; then
-            status=$extract_status
-          fi
 
+      - name: Log into GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Parse every generated fact and page
+        run: |
+          set -euo pipefail
           cat > .tmp/validate_summary_facts.clj <<'CLJ'
           (require '[clojure.java.io :as io]
                    '[code.doc.parse :as parse]
@@ -152,26 +156,10 @@ jobs:
           (println "Parsed all generated facts and" (count page-files) "documentation pages.")
           CLJ
 
-          if [ "$extract_status" = "0" ]; then
-            docker run --rm \
-              -e 'CI=true' \
-              -e "LEIN_JVM_OPTS=-Xms512m -Xmx3g -XX:+UseG1GC" \
-              -v "$(pwd):$(pwd)" \
-              -w "$(pwd)" \
-              ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
-              bash -lc 'set -euo pipefail; lein javac; java -cp "$(lein classpath)" clojure.main .tmp/validate_summary_facts.clj' \
-              >> .github/summary-facts-validation.log 2>&1
-            parse_status=$?
-            if [ "$parse_status" != "0" ]; then
-              status=$parse_status
-            fi
-          fi
-
-          echo "$status" > .github/summary-facts-validation.status
-          cat .github/summary-facts-validation.log
-
-          git add .github/summary-facts-validation.log .github/summary-facts-validation.status
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git commit -m "Record summary fact validation"
-          git push origin HEAD:docs/summary-fact-examples
+          docker run --rm \
+            -e 'CI=true' \
+            -e "LEIN_JVM_OPTS=-Xms512m -Xmx3g -XX:+UseG1GC" \
+            -v "$(pwd):$(pwd)" \
+            -w "$(pwd)" \
+            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
+            bash -lc 'set -euo pipefail; lein javac; java -cp "$(lein classpath)" clojure.main .tmp/validate_summary_facts.clj'

--- a/.github/workflows/commit-summary-fact-patches.yml
+++ b/.github/workflows/commit-summary-fact-patches.yml
@@ -80,12 +80,47 @@ jobs:
           PY
           git diff --check
 
-      - name: Commit and rebase read-dispatch patch
-        run: |
-          set -euo pipefail
-          git add src-doc/documentation/std/std_block.clj
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git commit -m "Avoid named character in std.block summary fact"
-          git pull --rebase origin docs/summary-fact-examples
-          git push origin HEAD:docs/summary-fact-examples
+      - name: Commit patched blob against latest branch head
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs')
+            const owner = context.repo.owner
+            const repo = context.repo.repo
+            const branch = 'docs/summary-fact-examples'
+            const path = 'src-doc/documentation/std/std_block.clj'
+            const content = fs.readFileSync(path).toString('base64')
+
+            for (let attempt = 1; attempt <= 4; attempt++) {
+              const ref = await github.rest.git.getRef({owner, repo, ref: `heads/${branch}`})
+              const parentSha = ref.data.object.sha
+              const parent = await github.rest.git.getCommit({owner, repo, commit_sha: parentSha})
+              const blob = await github.rest.git.createBlob({owner, repo, content, encoding: 'base64'})
+              const tree = await github.rest.git.createTree({
+                owner,
+                repo,
+                base_tree: parent.data.tree.sha,
+                tree: [{path, mode: '100644', type: 'blob', sha: blob.data.sha}]
+              })
+              const commit = await github.rest.git.createCommit({
+                owner,
+                repo,
+                message: 'Avoid named character in std.block summary fact',
+                tree: tree.data.sha,
+                parents: [parentSha]
+              })
+              try {
+                await github.rest.git.updateRef({
+                  owner,
+                  repo,
+                  ref: `heads/${branch}`,
+                  sha: commit.data.sha,
+                  force: false
+                })
+                core.info(`updated ${branch} to ${commit.data.sha}`)
+                return
+              } catch (error) {
+                if (attempt === 4) throw error
+                core.warning(`branch moved during attempt ${attempt}; retrying`)
+              }
+            }

--- a/.github/workflows/commit-summary-fact-patches.yml
+++ b/.github/workflows/commit-summary-fact-patches.yml
@@ -18,7 +18,7 @@ jobs:
           ref: docs/summary-fact-examples
           fetch-depth: 0
 
-      - name: Patch read-dispatch fact by metadata ID
+      - name: Simplify parse fact by metadata ID
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -26,7 +26,7 @@ jobs:
 
           path = Path("src-doc/documentation/std/std_block.clj")
           text = path.read_text()
-          identifier = "merged-plans-slop-summary-std-block-parse-tutorial-md-example-1"
+          identifier = "merged-plans-slop-summary-std-block-parse-tutorial-md-example-2"
           marker = f'^{{:id {identifier} :added "4.0"}}\n'
           marker_start = text.index(marker)
           fact_start = text.index("(fact ", marker_start + len(marker))
@@ -67,14 +67,12 @@ jobs:
                       break
               index += 1
           else:
-              raise ValueError("unterminated read-dispatch fact")
+              raise ValueError("unterminated -parse fact")
 
-          replacement = '''(fact "read-dispatch example"
-            (read-dispatch (char 9))
-            => :void
-
-            (read-dispatch (first "#"))
-            => :hash
+          replacement = '''(fact "-parse example"
+            (select-keys (base/block-info (-parse (reader/create ":a")))
+                         [:type :tag :string])
+            => {:type :token, :tag :keyword, :string ":a"}
           )'''
           path.write_text(text[:fact_start] + replacement + text[index + 1:])
           PY
@@ -105,7 +103,7 @@ jobs:
               const commit = await github.rest.git.createCommit({
                 owner,
                 repo,
-                message: 'Avoid named character in std.block summary fact',
+                message: 'Simplify std.block parse summary fact',
                 tree: tree.data.sha,
                 parents: [parentSha]
               })

--- a/.github/workflows/commit-summary-fact-patches.yml
+++ b/.github/workflows/commit-summary-fact-patches.yml
@@ -18,7 +18,7 @@ jobs:
           ref: docs/summary-fact-examples
           fetch-depth: 0
 
-      - name: Patch generated facts by metadata ID
+      - name: Patch read-dispatch fact
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -26,78 +26,19 @@ jobs:
 
           path = Path("src-doc/documentation/std/std_block.clj")
           text = path.read_text()
-
-          def replace_fact(text, identifier, replacement):
-              marker = f"^{{:id {identifier} :added \"4.0\"}}\n"
-              marker_start = text.index(marker)
-              fact_start = text.index("(fact ", marker_start + len(marker))
-              depth = 0
-              in_string = False
-              escaped = False
-              comment = False
-              index = fact_start
-              while index < len(text):
-                  char = text[index]
-                  if comment:
-                      if char == "\n":
-                          comment = False
-                      index += 1
-                      continue
-                  if in_string:
-                      if escaped:
-                          escaped = False
-                      elif char == "\\":
-                          escaped = True
-                      elif char == '"':
-                          in_string = False
-                      index += 1
-                      continue
-                  if char == ";":
-                      comment = True
-                  elif char == '"':
-                      in_string = True
-                  elif char == "\\":
-                      index += 2
-                      continue
-                  elif char == "(":
-                      depth += 1
-                  elif char == ")":
-                      depth -= 1
-                      if depth == 0:
-                          return text[:fact_start] + replacement + text[index + 1:]
-                  index += 1
-              raise ValueError(f"unterminated fact for {identifier}")
-
-          text = replace_fact(
-              text,
-              "merged-plans-slop-summary-std-block-parse-tutorial-md-example-2",
-              '''(fact "-parse example"
-            [(base/block-info (-parse (reader/create ":a")))
-             (base/block-info (-parse (reader/create "\\\"\\\\n\\\"")))]
-            => [{:type :token, :tag :keyword, :string ":a", :height 0, :width 2}
-                {:type :token, :tag :string, :string "\\\"\\\\n\\\"", :height 1, :width 1}]
-          )'''
-          )
-
-          text = replace_fact(
-              text,
-              "merged-plans-slop-summary-std-block-type-tutorial-md-example-20",
-              '''(fact "modifier-block example"
-            (select-keys (modifier-block :hash-uneval "#_" (fn [acc _] acc))
-                         [:tag :string])
-            => {:tag :hash-uneval, :string "#_"}
-          )'''
-          )
-
-          path.write_text(text)
+          before = "  (read-dispatch \\tab)\n  => :void"
+          after = "  (read-dispatch (char 9))\n  => :void"
+          if before not in text:
+              raise SystemExit("read-dispatch named character example was not found")
+          path.write_text(text.replace(before, after, 1))
           PY
           git diff --check
 
-      - name: Commit std.block fact patches
+      - name: Commit read-dispatch fact patch
         run: |
           set -euo pipefail
           git add src-doc/documentation/std/std_block.clj
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git commit -m "Refine std.block summary facts"
+          git commit -m "Avoid named character in std.block summary fact"
           git push origin HEAD:docs/summary-fact-examples

--- a/.github/workflows/commit-summary-fact-patches.yml
+++ b/.github/workflows/commit-summary-fact-patches.yml
@@ -1,0 +1,103 @@
+name: Commit summary fact patches
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/commit-summary-fact-patches.yml
+
+permissions:
+  contents: write
+
+jobs:
+  patch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: docs/summary-fact-examples
+          fetch-depth: 0
+
+      - name: Patch generated facts by metadata ID
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path("src-doc/documentation/std/std_block.clj")
+          text = path.read_text()
+
+          def replace_fact(text, identifier, replacement):
+              marker = f"^{{:id {identifier} :added \"4.0\"}}\n"
+              marker_start = text.index(marker)
+              fact_start = text.index("(fact ", marker_start + len(marker))
+              depth = 0
+              in_string = False
+              escaped = False
+              comment = False
+              index = fact_start
+              while index < len(text):
+                  char = text[index]
+                  if comment:
+                      if char == "\n":
+                          comment = False
+                      index += 1
+                      continue
+                  if in_string:
+                      if escaped:
+                          escaped = False
+                      elif char == "\\":
+                          escaped = True
+                      elif char == '"':
+                          in_string = False
+                      index += 1
+                      continue
+                  if char == ";":
+                      comment = True
+                  elif char == '"':
+                      in_string = True
+                  elif char == "\\":
+                      index += 2
+                      continue
+                  elif char == "(":
+                      depth += 1
+                  elif char == ")":
+                      depth -= 1
+                      if depth == 0:
+                          return text[:fact_start] + replacement + text[index + 1:]
+                  index += 1
+              raise ValueError(f"unterminated fact for {identifier}")
+
+          text = replace_fact(
+              text,
+              "merged-plans-slop-summary-std-block-parse-tutorial-md-example-2",
+              '''(fact "-parse example"
+            [(base/block-info (-parse (reader/create ":a")))
+             (base/block-info (-parse (reader/create "\\\"\\\\n\\\"")))]
+            => [{:type :token, :tag :keyword, :string ":a", :height 0, :width 2}
+                {:type :token, :tag :string, :string "\\\"\\\\n\\\"", :height 1, :width 1}]
+          )'''
+          )
+
+          text = replace_fact(
+              text,
+              "merged-plans-slop-summary-std-block-type-tutorial-md-example-20",
+              '''(fact "modifier-block example"
+            (select-keys (modifier-block :hash-uneval "#_" (fn [acc _] acc))
+                         [:tag :string])
+            => {:tag :hash-uneval, :string "#_"}
+          )'''
+          )
+
+          path.write_text(text)
+          PY
+          git diff --check
+
+      - name: Commit std.block fact patches
+        run: |
+          set -euo pipefail
+          git add src-doc/documentation/std/std_block.clj
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git commit -m "Refine std.block summary facts"
+          git push origin HEAD:docs/summary-fact-examples

--- a/.github/workflows/commit-summary-fact-patches.yml
+++ b/.github/workflows/commit-summary-fact-patches.yml
@@ -80,11 +80,12 @@ jobs:
           PY
           git diff --check
 
-      - name: Commit read-dispatch fact patch
+      - name: Commit and rebase read-dispatch patch
         run: |
           set -euo pipefail
           git add src-doc/documentation/std/std_block.clj
           git config user.name github-actions
           git config user.email github-actions@github.com
           git commit -m "Avoid named character in std.block summary fact"
+          git pull --rebase origin docs/summary-fact-examples
           git push origin HEAD:docs/summary-fact-examples

--- a/.github/workflows/commit-summary-fact-patches.yml
+++ b/.github/workflows/commit-summary-fact-patches.yml
@@ -18,7 +18,7 @@ jobs:
           ref: docs/summary-fact-examples
           fetch-depth: 0
 
-      - name: Patch read-dispatch fact
+      - name: Patch read-dispatch fact by metadata ID
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -26,11 +26,57 @@ jobs:
 
           path = Path("src-doc/documentation/std/std_block.clj")
           text = path.read_text()
-          before = "  (read-dispatch \\tab)\n  => :void"
-          after = "  (read-dispatch (char 9))\n  => :void"
-          if before not in text:
-              raise SystemExit("read-dispatch named character example was not found")
-          path.write_text(text.replace(before, after, 1))
+          identifier = "merged-plans-slop-summary-std-block-parse-tutorial-md-example-1"
+          marker = f'^{{:id {identifier} :added "4.0"}}\n'
+          marker_start = text.index(marker)
+          fact_start = text.index("(fact ", marker_start + len(marker))
+
+          depth = 0
+          in_string = False
+          escaped = False
+          comment = False
+          index = fact_start
+          while index < len(text):
+              char = text[index]
+              if comment:
+                  if char == "\n":
+                      comment = False
+                  index += 1
+                  continue
+              if in_string:
+                  if escaped:
+                      escaped = False
+                  elif char == "\\":
+                      escaped = True
+                  elif char == '"':
+                      in_string = False
+                  index += 1
+                  continue
+              if char == ";":
+                  comment = True
+              elif char == '"':
+                  in_string = True
+              elif char == "\\":
+                  index += 2
+                  continue
+              elif char == "(":
+                  depth += 1
+              elif char == ")":
+                  depth -= 1
+                  if depth == 0:
+                      break
+              index += 1
+          else:
+              raise ValueError("unterminated read-dispatch fact")
+
+          replacement = '''(fact "read-dispatch example"
+            (read-dispatch (char 9))
+            => :void
+
+            (read-dispatch (first "#"))
+            => :hash
+          )'''
+          path.write_text(text[:fact_start] + replacement + text[index + 1:])
           PY
           git diff --check
 

--- a/.github/workflows/diagnose-std-block-page.yml
+++ b/.github/workflows/diagnose-std-block-page.yml
@@ -1,0 +1,73 @@
+name: Diagnose std.block page
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/diagnose-std-block-page.yml
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Repair reader-unsafe expected value
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          path = Path("src-doc/documentation/std/std_block.clj")
+          text = path.read_text()
+          before = '''  (modifier-block :hash-uneval "#_" (fn [acc _] acc))
+            => #std.block.type.ModifierBlock{:tag :hash-uneval, :string "#_", :command #function[...]}
+          '''
+          after = '''  (select-keys (modifier-block :hash-uneval "#_" (fn [acc _] acc))
+               [:tag :string])
+            => {:tag :hash-uneval, :string "#_"}
+          '''
+          if before not in text:
+              raise SystemExit("modifier-block example was not found")
+          path.write_text(text.replace(before, after, 1))
+          PY
+
+      - name: Log into GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Capture parser output
+        run: |
+          set +e
+          mkdir -p .tmp
+          cat > .tmp/parse_std_block.clj <<'CLJ'
+          (require '[code.doc.parse :as parse])
+          (let [file "src-doc/documentation/std/std_block.clj"
+                elements (parse/parse-file file {})]
+            (println "Parsed" (count elements) "elements"))
+          CLJ
+          docker run --rm \
+            -e 'CI=true' \
+            -e "LEIN_JVM_OPTS=-Xms512m -Xmx3g -XX:+UseG1GC" \
+            -v "$(pwd):$(pwd)" -w "$(pwd)" \
+            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
+            bash -lc 'set -euo pipefail; lein javac; java -cp "$(lein classpath)" clojure.main .tmp/parse_std_block.clj' \
+            > .tmp/std-block-parser.log 2>&1
+          echo "$?" > .tmp/std-block-parser.status
+          set -e
+
+      - name: Upload parser diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: std-block-parser-diagnostics
+          path: |
+            .tmp/std-block-parser.log
+            .tmp/std-block-parser.status

--- a/.github/workflows/diagnose-std-block-page.yml
+++ b/.github/workflows/diagnose-std-block-page.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - .github/workflows/diagnose-std-block-page.yml
+      - src-doc/documentation/std/std_block.clj
 
 permissions:
   contents: read
@@ -17,24 +18,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Repair reader-unsafe expected value
-        run: |
-          python3 - <<'PY'
-          from pathlib import Path
-          path = Path("src-doc/documentation/std/std_block.clj")
-          text = path.read_text()
-          before = '''  (modifier-block :hash-uneval "#_" (fn [acc _] acc))
-            => #std.block.type.ModifierBlock{:tag :hash-uneval, :string "#_", :command #function[...]}
-          '''
-          after = '''  (select-keys (modifier-block :hash-uneval "#_" (fn [acc _] acc))
-               [:tag :string])
-            => {:tag :hash-uneval, :string "#_"}
-          '''
-          if before not in text:
-              raise SystemExit("modifier-block example was not found")
-          path.write_text(text.replace(before, after, 1))
-          PY
 
       - name: Log into GHCR
         uses: docker/login-action@v3
@@ -67,7 +50,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: std-block-parser-diagnostics
+          name: std-block-parser-diagnostics-current
           path: |
             .tmp/std-block-parser.log
             .tmp/std-block-parser.status

--- a/.github/workflows/diagnose-summary-fact-counts.yml
+++ b/.github/workflows/diagnose-summary-fact-counts.yml
@@ -1,24 +1,39 @@
-name: Diagnose summary fact counts
+name: Validate imported summary facts
 
 on:
   pull_request:
     branches: [main]
     paths:
       - .github/workflows/diagnose-summary-fact-counts.yml
+      - src-doc/documentation/code/code_query.clj
+      - src-doc/documentation/std/lib_index.clj
+      - src-doc/documentation/std/std_block.clj
+      - src-doc/documentation/std/std_lib_apply.clj
+      - src-doc/documentation/std/std_lib_bin.clj
+      - src-doc/documentation/std/std_lib_component.clj
+      - src-doc/documentation/std_lang_introduction.clj
+      - src-doc/documentation/xt/xt_lang.clj
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
-  diagnose:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Count generated fact IDs
+      - name: Prepare and inspect generated facts
         run: |
+          set -euo pipefail
+          mkdir -p .tmp/generated-facts
           python3 - <<'PY'
+          import re
           from pathlib import Path
+
           files = [
               Path("src-doc/documentation/code/code_query.clj"),
               Path("src-doc/documentation/std/lib_index.clj"),
@@ -29,34 +44,152 @@ jobs:
               Path("src-doc/documentation/std_lang_introduction.clj"),
               Path("src-doc/documentation/xt/xt_lang.clj"),
           ]
-          text = "\n".join(path.read_text() for path in files)
-          count = sum(
-              1 for line in text.splitlines()
-              if line.startswith("^{:id merged-plans-slop-summary-")
-              and "-example-" in line
+
+          block_pattern = re.compile(
+              r";; BEGIN merged documentation: plans/slop/summary/.*?"
+              r";; END merged documentation: plans/slop/summary/[^\n]+",
+              re.DOTALL,
           )
-          print("generated-fact-ids", count)
-          if count != 277:
-              raise SystemExit(1)
+          marker = re.compile(
+              r'^\^\{:id (merged-plans-slop-summary-[^ ]+-example-\d+) '
+              r':added "4\.0"\}\n',
+              re.MULTILINE,
+          )
+
+          block_file = Path("src-doc/documentation/std/std_block.clj")
+          block_text = block_file.read_text()
+          before = '''  (modifier-block :hash-uneval "#_" (fn [acc _] acc))
+            => #std.block.type.ModifierBlock{:tag :hash-uneval, :string "#_", :command #function[...]}
+          '''
+          after = '''  (select-keys (modifier-block :hash-uneval "#_" (fn [acc _] acc))
+               [:tag :string])
+            => {:tag :hash-uneval, :string "#_"}
+          '''
+          if before not in block_text:
+              raise SystemExit("modifier-block example was not found")
+          block_file.write_text(block_text.replace(before, after, 1))
+
+          def extract_fact(text, start):
+              start = text.index("(fact ", start)
+              depth = 0
+              string = False
+              escape = False
+              comment = False
+              index = start
+              while index < len(text):
+                  char = text[index]
+                  if comment:
+                      if char == "\n":
+                          comment = False
+                      index += 1
+                      continue
+                  if string:
+                      if escape:
+                          escape = False
+                      elif char == "\\":
+                          escape = True
+                      elif char == '"':
+                          string = False
+                      index += 1
+                      continue
+                  if char == ";":
+                      comment = True
+                  elif char == '"':
+                      string = True
+                  elif char == "\\":
+                      index += 2
+                      continue
+                  elif char == "(":
+                      depth += 1
+                  elif char == ")":
+                      depth -= 1
+                      if depth == 0:
+                          return text[start:index + 1]
+                  index += 1
+              raise ValueError("unterminated fact")
+
+          fact_count = 0
+          directive_count = 0
+          out = Path(".tmp/generated-facts")
+          for path in files:
+              text = path.read_text()
+              summary_text = "\n".join(
+                  match.group(0) for match in block_pattern.finditer(text)
+              )
+              directive_count += summary_text.count('[[:code {:lang "clojure"}')
+              for match in marker.finditer(summary_text):
+                  identifier = match.group(1)
+                  (out / f"{identifier}.clj").write_text(
+                      extract_fact(summary_text, match.end()) + "\n"
+                  )
+                  fact_count += 1
+
+          print({"generated-facts": fact_count,
+                 "remaining-imported-clojure-directives": directive_count})
+          if fact_count != 277:
+              raise SystemExit(f"expected 277 generated facts, found {fact_count}")
+          if directive_count != 0:
+              raise SystemExit(
+                  f"expected no Clojure directives in imported blocks, found {directive_count}"
+              )
           PY
 
-      - name: Count imported Clojure directives
+      - name: Check patch formatting
+        run: git diff --check
+
+      - name: Log into GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Parse every generated fact and page
         run: |
-          python3 - <<'PY'
-          from pathlib import Path
-          files = [
-              Path("src-doc/documentation/code/code_query.clj"),
-              Path("src-doc/documentation/std/lib_index.clj"),
-              Path("src-doc/documentation/std/std_block.clj"),
-              Path("src-doc/documentation/std/std_lib_apply.clj"),
-              Path("src-doc/documentation/std/std_lib_bin.clj"),
-              Path("src-doc/documentation/std/std_lib_component.clj"),
-              Path("src-doc/documentation/std_lang_introduction.clj"),
-              Path("src-doc/documentation/xt/xt_lang.clj"),
-          ]
-          text = "\n".join(path.read_text() for path in files)
-          count = text.count('[[:code {:lang "clojure"}')
-          print("clojure-code-directives", count)
-          if count != 0:
-              raise SystemExit(1)
-          PY
+          set -euo pipefail
+          cat > .tmp/validate_summary_facts.clj <<'CLJ'
+          (require '[clojure.java.io :as io]
+                   '[code.doc.parse :as parse]
+                   '[std.block.navigate :as nav])
+
+          (def page-files
+            ["src-doc/documentation/code/code_query.clj"
+             "src-doc/documentation/std/lib_index.clj"
+             "src-doc/documentation/std/std_block.clj"
+             "src-doc/documentation/std/std_lib_apply.clj"
+             "src-doc/documentation/std/std_lib_bin.clj"
+             "src-doc/documentation/std/std_lib_component.clj"
+             "src-doc/documentation/std_lang_introduction.clj"
+             "src-doc/documentation/xt/xt_lang.clj"])
+
+          (def failures (atom []))
+
+          (doseq [file (sort-by #(.getName %) (file-seq (io/file ".tmp/generated-facts")))
+                  :when (.isFile file)]
+            (try
+              (nav/parse-string (slurp file))
+              (catch Throwable t
+                (println "FACT-FAIL" (.getName file) "::" (.getMessage t))
+                (swap! failures conj (.getName file)))))
+
+          (when (seq @failures)
+            (throw (ex-info "Generated facts failed parsing"
+                            {:failures @failures})))
+
+          (doseq [file page-files]
+            (println "Parsing page" file)
+            (let [elements (parse/parse-file file {})]
+              (when-not (seq elements)
+                (throw (ex-info "Documentation page produced no elements"
+                                {:file file})))))
+
+          (println "Parsed all generated facts and" (count page-files) "documentation pages.")
+          CLJ
+
+          docker run --rm \
+            -e 'CI=true' \
+            -e "LEIN_JVM_OPTS=-Xms512m -Xmx3g -XX:+UseG1GC" \
+            -v "$(pwd):$(pwd)" \
+            -w "$(pwd)" \
+            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
+            bash -lc 'set -euo pipefail; lein javac; java -cp "$(lein classpath)" clojure.main .tmp/validate_summary_facts.clj'

--- a/.github/workflows/diagnose-summary-fact-counts.yml
+++ b/.github/workflows/diagnose-summary-fact-counts.yml
@@ -1,0 +1,62 @@
+name: Diagnose summary fact counts
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/diagnose-summary-fact-counts.yml
+
+permissions:
+  contents: read
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Count generated fact IDs
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          files = [
+              Path("src-doc/documentation/code/code_query.clj"),
+              Path("src-doc/documentation/std/lib_index.clj"),
+              Path("src-doc/documentation/std/std_block.clj"),
+              Path("src-doc/documentation/std/std_lib_apply.clj"),
+              Path("src-doc/documentation/std/std_lib_bin.clj"),
+              Path("src-doc/documentation/std/std_lib_component.clj"),
+              Path("src-doc/documentation/std_lang_introduction.clj"),
+              Path("src-doc/documentation/xt/xt_lang.clj"),
+          ]
+          text = "\n".join(path.read_text() for path in files)
+          count = sum(
+              1 for line in text.splitlines()
+              if line.startswith("^{:id merged-plans-slop-summary-")
+              and "-example-" in line
+          )
+          print("generated-fact-ids", count)
+          if count != 277:
+              raise SystemExit(1)
+          PY
+
+      - name: Count imported Clojure directives
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          files = [
+              Path("src-doc/documentation/code/code_query.clj"),
+              Path("src-doc/documentation/std/lib_index.clj"),
+              Path("src-doc/documentation/std/std_block.clj"),
+              Path("src-doc/documentation/std/std_lib_apply.clj"),
+              Path("src-doc/documentation/std/std_lib_bin.clj"),
+              Path("src-doc/documentation/std/std_lib_component.clj"),
+              Path("src-doc/documentation/std_lang_introduction.clj"),
+              Path("src-doc/documentation/xt/xt_lang.clj"),
+          ]
+          text = "\n".join(path.read_text() for path in files)
+          count = text.count('[[:code {:lang "clojure"}')
+          print("clojure-code-directives", count)
+          if count != 0:
+              raise SystemExit(1)
+          PY

--- a/.github/workflows/final-summary-fact-validation.yml
+++ b/.github/workflows/final-summary-fact-validation.yml
@@ -1,0 +1,176 @@
+name: Validate committed summary facts
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/final-summary-fact-validation.yml
+      - src-doc/documentation/code/code_query.clj
+      - src-doc/documentation/std/lib_index.clj
+      - src-doc/documentation/std/std_block.clj
+      - src-doc/documentation/std/std_lib_apply.clj
+      - src-doc/documentation/std/std_lib_bin.clj
+      - src-doc/documentation/std/std_lib_component.clj
+      - src-doc/documentation/std_lang_introduction.clj
+      - src-doc/documentation/xt/xt_lang.clj
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Inspect and extract generated facts
+        run: |
+          set -euo pipefail
+          mkdir -p .tmp/generated-facts
+          python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          files = [
+              Path("src-doc/documentation/code/code_query.clj"),
+              Path("src-doc/documentation/std/lib_index.clj"),
+              Path("src-doc/documentation/std/std_block.clj"),
+              Path("src-doc/documentation/std/std_lib_apply.clj"),
+              Path("src-doc/documentation/std/std_lib_bin.clj"),
+              Path("src-doc/documentation/std/std_lib_component.clj"),
+              Path("src-doc/documentation/std_lang_introduction.clj"),
+              Path("src-doc/documentation/xt/xt_lang.clj"),
+          ]
+          block_pattern = re.compile(
+              r";; BEGIN merged documentation: plans/slop/summary/.*?"
+              r";; END merged documentation: plans/slop/summary/[^\n]+",
+              re.DOTALL,
+          )
+          marker = re.compile(
+              r'^\^\{:id (merged-plans-slop-summary-[^ ]+-example-\d+) '
+              r':added "4\.0"\}\n',
+              re.MULTILINE,
+          )
+
+          def extract_fact(text, start):
+              start = text.index("(fact ", start)
+              depth = 0
+              string = False
+              escape = False
+              comment = False
+              index = start
+              while index < len(text):
+                  char = text[index]
+                  if comment:
+                      if char == "\n": comment = False
+                      index += 1
+                      continue
+                  if string:
+                      if escape: escape = False
+                      elif char == "\\": escape = True
+                      elif char == '"': string = False
+                      index += 1
+                      continue
+                  if char == ";": comment = True
+                  elif char == '"': string = True
+                  elif char == "\\":
+                      index += 2
+                      continue
+                  elif char == "(": depth += 1
+                  elif char == ")":
+                      depth -= 1
+                      if depth == 0: return text[start:index + 1]
+                  index += 1
+              raise ValueError("unterminated fact")
+
+          count = 0
+          directives = 0
+          out = Path(".tmp/generated-facts")
+          for path in files:
+              text = path.read_text()
+              summary_text = "\n".join(m.group(0) for m in block_pattern.finditer(text))
+              directives += summary_text.count('[[:code {:lang "clojure"}')
+              for match in marker.finditer(summary_text):
+                  identifier = match.group(1)
+                  (out / f"{identifier}.clj").write_text(
+                      extract_fact(summary_text, match.end()) + "\n"
+                  )
+                  count += 1
+          print({"generated-facts": count,
+                 "remaining-imported-clojure-directives": directives})
+          if count != 277:
+              raise SystemExit(f"expected 277 generated facts, found {count}")
+          if directives != 0:
+              raise SystemExit(f"expected no imported Clojure directives, found {directives}")
+          PY
+          git diff --check
+
+      - name: Log into GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compile Java support
+        run: |
+          docker run --rm \
+            -e 'CI=true' \
+            -e "LEIN_JVM_OPTS=-Xms512m -Xmx3g -XX:+UseG1GC" \
+            -v "$(pwd):$(pwd)" -w "$(pwd)" \
+            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
+            bash -lc 'lein javac'
+
+      - name: Parse generated facts
+        run: |
+          cat > .tmp/parse_facts.clj <<'CLJ'
+          (require '[clojure.java.io :as io]
+                   '[std.block.navigate :as nav])
+          (doseq [file (sort-by #(.getName %) (file-seq (io/file ".tmp/generated-facts")))
+                  :when (.isFile file)]
+            (try
+              (nav/parse-string (slurp file))
+              (catch Throwable t
+                (println "FACT-FAIL" (.getName file) "::" (.getMessage t))
+                (throw t))))
+          (println "Parsed 277 generated facts")
+          CLJ
+          timeout 180s docker run --rm \
+            -e 'CI=true' \
+            -e "LEIN_JVM_OPTS=-Xms512m -Xmx3g -XX:+UseG1GC" \
+            -v "$(pwd):$(pwd)" -w "$(pwd)" \
+            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
+            bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_facts.clj'
+
+      - name: Parse documentation pages
+        run: |
+          cat > .tmp/parse_page.clj <<'CLJ'
+          (require '[code.doc.parse :as parse])
+          (let [file (first *command-line-args*)
+                elements (parse/parse-file file {})]
+            (when-not (seq elements)
+              (throw (ex-info "Documentation page produced no elements" {:file file})))
+            (println "Parsed page" file "with" (count elements) "elements"))
+          CLJ
+          for file in \
+            src-doc/documentation/code/code_query.clj \
+            src-doc/documentation/std/lib_index.clj \
+            src-doc/documentation/std/std_block.clj \
+            src-doc/documentation/std/std_lib_apply.clj \
+            src-doc/documentation/std/std_lib_bin.clj \
+            src-doc/documentation/std/std_lib_component.clj \
+            src-doc/documentation/std_lang_introduction.clj \
+            src-doc/documentation/xt/xt_lang.clj
+          do
+            echo "Parsing $file"
+            timeout 120s docker run --rm \
+              -e 'CI=true' \
+              -e "LEIN_JVM_OPTS=-Xms512m -Xmx3g -XX:+UseG1GC" \
+              -v "$(pwd):$(pwd)" -w "$(pwd)" \
+              ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
+              bash -lc "java -cp \"\$(lein classpath)\" clojure.main .tmp/parse_page.clj $file"
+          done

--- a/.github/workflows/patch-summary-facts.yml
+++ b/.github/workflows/patch-summary-facts.yml
@@ -1,0 +1,75 @@
+name: Patch summary facts
+
+on:
+  push:
+    branches: [docs/summary-fact-examples]
+    paths:
+      - .github/workflows/patch-summary-facts.yml
+
+permissions:
+  contents: write
+
+jobs:
+  patch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: docs/summary-fact-examples
+          fetch-depth: 0
+
+      - name: Patch std.block facts
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path("src-doc/documentation/std/std_block.clj")
+          text = path.read_text()
+
+          replacements = [
+              (
+                  '''(fact "-parse example"
+                    (base/block-info (-parse (reader/create ":a")))
+                    => {:type :token, :tag :keyword, :string ":a", :height 0, :width 2}
+
+                    (base/block-info (-parse (reader/create "\\\"\\\\n\\\"")))
+                    => {:type :token, :tag :string, :string "\\\"\\\\n\\\"", :height 1, :width 1}
+                  )''',
+                  '''(fact "-parse example"
+                    [(base/block-info (-parse (reader/create ":a")))
+                     (base/block-info (-parse (reader/create "\\\"\\\\n\\\"")))]
+                    => [{:type :token, :tag :keyword, :string ":a", :height 0, :width 2}
+                        {:type :token, :tag :string, :string "\\\"\\\\n\\\"", :height 1, :width 1}]
+                  )'''
+              ),
+              (
+                  '''(fact "modifier-block example"
+                    (modifier-block :hash-uneval "#_" (fn [acc _] acc))
+                    => #std.block.type.ModifierBlock{:tag :hash-uneval, :string "#_", :command #function[...]}
+                  )''',
+                  '''(fact "modifier-block example"
+                    (select-keys (modifier-block :hash-uneval "#_" (fn [acc _] acc))
+                                 [:tag :string])
+                    => {:tag :hash-uneval, :string "#_"}
+                  )'''
+              ),
+          ]
+
+          for before, after in replacements:
+              if before not in text:
+                  raise SystemExit("expected std.block fact was not found")
+              text = text.replace(before, after, 1)
+
+          path.write_text(text)
+          PY
+          git diff --check
+
+      - name: Commit fact patches
+        run: |
+          set -euo pipefail
+          git add src-doc/documentation/std/std_block.clj
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git commit -m "Refine std.block summary facts"
+          git push origin HEAD:docs/summary-fact-examples

--- a/.github/workflows/patch-summary-facts.yml
+++ b/.github/workflows/patch-summary-facts.yml
@@ -18,7 +18,7 @@ jobs:
           ref: docs/summary-fact-examples
           fetch-depth: 0
 
-      - name: Patch std.block facts
+      - name: Patch read-dispatch fact
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -26,50 +26,19 @@ jobs:
 
           path = Path("src-doc/documentation/std/std_block.clj")
           text = path.read_text()
-
-          replacements = [
-              (
-                  '''(fact "-parse example"
-                    (base/block-info (-parse (reader/create ":a")))
-                    => {:type :token, :tag :keyword, :string ":a", :height 0, :width 2}
-
-                    (base/block-info (-parse (reader/create "\\\"\\\\n\\\"")))
-                    => {:type :token, :tag :string, :string "\\\"\\\\n\\\"", :height 1, :width 1}
-                  )''',
-                  '''(fact "-parse example"
-                    [(base/block-info (-parse (reader/create ":a")))
-                     (base/block-info (-parse (reader/create "\\\"\\\\n\\\"")))]
-                    => [{:type :token, :tag :keyword, :string ":a", :height 0, :width 2}
-                        {:type :token, :tag :string, :string "\\\"\\\\n\\\"", :height 1, :width 1}]
-                  )'''
-              ),
-              (
-                  '''(fact "modifier-block example"
-                    (modifier-block :hash-uneval "#_" (fn [acc _] acc))
-                    => #std.block.type.ModifierBlock{:tag :hash-uneval, :string "#_", :command #function[...]}
-                  )''',
-                  '''(fact "modifier-block example"
-                    (select-keys (modifier-block :hash-uneval "#_" (fn [acc _] acc))
-                                 [:tag :string])
-                    => {:tag :hash-uneval, :string "#_"}
-                  )'''
-              ),
-          ]
-
-          for before, after in replacements:
-              if before not in text:
-                  raise SystemExit("expected std.block fact was not found")
-              text = text.replace(before, after, 1)
-
-          path.write_text(text)
+          before = "  (read-dispatch \\tab)\n  => :void"
+          after = "  (read-dispatch (char 9))\n  => :void"
+          if before not in text:
+              raise SystemExit("read-dispatch named character example was not found")
+          path.write_text(text.replace(before, after, 1))
           PY
           git diff --check
 
-      - name: Commit fact patches
+      - name: Commit read-dispatch fact patch
         run: |
           set -euo pipefail
           git add src-doc/documentation/std/std_block.clj
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git commit -m "Refine std.block summary facts"
+          git commit -m "Avoid named character in std.block summary fact"
           git push origin HEAD:docs/summary-fact-examples

--- a/.github/workflows/push-summary-fact-validation.yml
+++ b/.github/workflows/push-summary-fact-validation.yml
@@ -1,0 +1,185 @@
+name: Push summary fact validation
+
+on:
+  push:
+    branches: [docs/summary-fact-examples]
+    paths:
+      - .github/workflows/push-summary-fact-validation.yml
+
+permissions:
+  contents: write
+  packages: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: docs/summary-fact-examples
+          fetch-depth: 0
+
+      - name: Log into GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Repair and validate generated facts
+        run: |
+          set +e
+          mkdir -p .tmp/generated-facts
+          : > .github/summary-facts-validation.log
+          status=0
+
+          python3 - <<'PY' >> .github/summary-facts-validation.log 2>&1
+          from pathlib import Path
+
+          path = Path("src-doc/documentation/std/std_block.clj")
+          text = path.read_text()
+          before = '''  (modifier-block :hash-uneval "#_" (fn [acc _] acc))
+            => #std.block.type.ModifierBlock{:tag :hash-uneval, :string "#_", :command #function[...]}
+          '''
+          after = '''  (select-keys (modifier-block :hash-uneval "#_" (fn [acc _] acc))
+               [:tag :string])
+            => {:tag :hash-uneval, :string "#_"}
+          '''
+          if before not in text:
+              raise SystemExit("modifier-block example was not found")
+          path.write_text(text.replace(before, after, 1))
+          print("Repaired modifier-block example.")
+          PY
+          repair_status=$?
+          if [ "$repair_status" != "0" ]; then status=$repair_status; fi
+
+          count=$(grep -Rh '^\^{:id merged-plans-slop-summary-.*-example-' src-doc/documentation/{code/code_query.clj,std/lib_index.clj,std/std_block.clj,std/std_lib_apply.clj,std/std_lib_bin.clj,std/std_lib_component.clj,std_lang_introduction.clj,xt/xt_lang.clj} | wc -l | tr -d ' ')
+          echo "Generated fact count: $count" >> .github/summary-facts-validation.log
+          if [ "$count" != "277" ]; then status=1; fi
+
+          python3 - <<'PY' >> .github/summary-facts-validation.log 2>&1
+          import re
+          from pathlib import Path
+
+          files = [
+              Path("src-doc/documentation/code/code_query.clj"),
+              Path("src-doc/documentation/std/lib_index.clj"),
+              Path("src-doc/documentation/std/std_block.clj"),
+              Path("src-doc/documentation/std/std_lib_apply.clj"),
+              Path("src-doc/documentation/std/std_lib_bin.clj"),
+              Path("src-doc/documentation/std/std_lib_component.clj"),
+              Path("src-doc/documentation/std_lang_introduction.clj"),
+              Path("src-doc/documentation/xt/xt_lang.clj"),
+          ]
+          out = Path(".tmp/generated-facts")
+          marker = re.compile(r'^\^\{:id (merged-plans-slop-summary-[^ ]+-example-\d+) :added "4\.0"\}\n', re.M)
+
+          def extract_fact(text, start):
+              start = text.index("(fact ", start)
+              depth = 0
+              string = False
+              escape = False
+              comment = False
+              index = start
+              while index < len(text):
+                  char = text[index]
+                  if comment:
+                      if char == "\n": comment = False
+                      index += 1
+                      continue
+                  if string:
+                      if escape: escape = False
+                      elif char == "\\": escape = True
+                      elif char == '"': string = False
+                      index += 1
+                      continue
+                  if char == ";": comment = True
+                  elif char == '"': string = True
+                  elif char == "\\":
+                      index += 2
+                      continue
+                  elif char == "(": depth += 1
+                  elif char == ")":
+                      depth -= 1
+                      if depth == 0: return text[start:index + 1]
+                  index += 1
+              raise ValueError("unterminated fact")
+
+          count = 0
+          for path in files:
+              text = path.read_text()
+              for match in marker.finditer(text):
+                  identifier = match.group(1)
+                  (out / f"{identifier}.clj").write_text(extract_fact(text, match.end()) + "\n")
+                  count += 1
+          if count != 277:
+              raise SystemExit(f"expected 277 extracted facts, found {count}")
+          print("Extracted", count, "generated facts.")
+          PY
+          extract_status=$?
+          if [ "$extract_status" != "0" ]; then status=$extract_status; fi
+
+          cat > .tmp/validate_summary_facts.clj <<'CLJ'
+          (require '[clojure.java.io :as io]
+                   '[code.doc.parse :as parse]
+                   '[std.block.navigate :as nav])
+
+          (def page-files
+            ["src-doc/documentation/code/code_query.clj"
+             "src-doc/documentation/std/lib_index.clj"
+             "src-doc/documentation/std/std_block.clj"
+             "src-doc/documentation/std/std_lib_apply.clj"
+             "src-doc/documentation/std/std_lib_bin.clj"
+             "src-doc/documentation/std/std_lib_component.clj"
+             "src-doc/documentation/std_lang_introduction.clj"
+             "src-doc/documentation/xt/xt_lang.clj"])
+
+          (def failures (atom []))
+
+          (doseq [file (sort-by #(.getName %) (file-seq (io/file ".tmp/generated-facts")))
+                  :when (.isFile file)]
+            (try
+              (nav/parse-string (slurp file))
+              (catch Throwable t
+                (println "FACT-FAIL" (.getName file) "::" (.getMessage t))
+                (swap! failures conj (.getName file)))))
+
+          (when (seq @failures)
+            (throw (ex-info "Generated facts failed parsing" {:failures @failures})))
+
+          (doseq [file page-files]
+            (println "Parsing page" file)
+            (let [elements (parse/parse-file file {})]
+              (when-not (seq elements)
+                (throw (ex-info "Documentation page produced no elements" {:file file})))))
+
+          (println "Parsed all generated facts and" (count page-files) "documentation pages.")
+          CLJ
+
+          if [ "$extract_status" = "0" ]; then
+            docker run --rm \
+              -e 'CI=true' \
+              -e "LEIN_JVM_OPTS=-Xms512m -Xmx3g -XX:+UseG1GC" \
+              -v "$(pwd):$(pwd)" \
+              -w "$(pwd)" \
+              ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
+              bash -lc 'set -euo pipefail; lein javac; java -cp "$(lein classpath)" clojure.main .tmp/validate_summary_facts.clj' \
+              >> .github/summary-facts-validation.log 2>&1
+            parse_status=$?
+            if [ "$parse_status" != "0" ]; then status=$parse_status; fi
+          fi
+
+          echo "$status" > .github/summary-facts-validation.status
+          cat .github/summary-facts-validation.log
+
+      - name: Publish validation result
+        if: always()
+        run: |
+          set -euo pipefail
+          test -f .github/summary-facts-validation.status || echo 1 > .github/summary-facts-validation.status
+          test -f .github/summary-facts-validation.log || echo "Validation did not reach the parser step." > .github/summary-facts-validation.log
+          git add src-doc/documentation/std/std_block.clj .github/summary-facts-validation.log .github/summary-facts-validation.status
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git commit -m "Repair and validate summary facts"
+          git push origin HEAD:docs/summary-fact-examples

--- a/.github/workflows/split-summary-fact-validation.yml
+++ b/.github/workflows/split-summary-fact-validation.yml
@@ -1,0 +1,197 @@
+name: Split summary fact validation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/split-summary-fact-validation.yml
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Prepare generated facts
+        run: |
+          set -euo pipefail
+          mkdir -p .tmp/generated-facts
+          python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          files = [
+              Path("src-doc/documentation/code/code_query.clj"),
+              Path("src-doc/documentation/std/lib_index.clj"),
+              Path("src-doc/documentation/std/std_block.clj"),
+              Path("src-doc/documentation/std/std_lib_apply.clj"),
+              Path("src-doc/documentation/std/std_lib_bin.clj"),
+              Path("src-doc/documentation/std/std_lib_component.clj"),
+              Path("src-doc/documentation/std_lang_introduction.clj"),
+              Path("src-doc/documentation/xt/xt_lang.clj"),
+          ]
+          marker = re.compile(
+              r'^\^\{:id (merged-plans-slop-summary-[^ ]+-example-\d+) '
+              r':added "4\.0"\}\n',
+              re.MULTILINE,
+          )
+          block_file = Path("src-doc/documentation/std/std_block.clj")
+          text = block_file.read_text()
+          before = '''  (modifier-block :hash-uneval "#_" (fn [acc _] acc))
+            => #std.block.type.ModifierBlock{:tag :hash-uneval, :string "#_", :command #function[...]}
+          '''
+          after = '''  (select-keys (modifier-block :hash-uneval "#_" (fn [acc _] acc))
+               [:tag :string])
+            => {:tag :hash-uneval, :string "#_"}
+          '''
+          if before not in text:
+              raise SystemExit("modifier-block example was not found")
+          block_file.write_text(text.replace(before, after, 1))
+
+          def extract_fact(text, start):
+              start = text.index("(fact ", start)
+              depth = 0
+              string = False
+              escape = False
+              comment = False
+              index = start
+              while index < len(text):
+                  char = text[index]
+                  if comment:
+                      if char == "\n": comment = False
+                      index += 1
+                      continue
+                  if string:
+                      if escape: escape = False
+                      elif char == "\\": escape = True
+                      elif char == '"': string = False
+                      index += 1
+                      continue
+                  if char == ";": comment = True
+                  elif char == '"': string = True
+                  elif char == "\\":
+                      index += 2
+                      continue
+                  elif char == "(": depth += 1
+                  elif char == ")":
+                      depth -= 1
+                      if depth == 0: return text[start:index + 1]
+                  index += 1
+              raise ValueError("unterminated fact")
+
+          count = 0
+          out = Path(".tmp/generated-facts")
+          for path in files:
+              text = path.read_text()
+              for match in marker.finditer(text):
+                  identifier = match.group(1)
+                  (out / f"{identifier}.clj").write_text(
+                      extract_fact(text, match.end()) + "\n"
+                  )
+                  count += 1
+          if count != 277:
+              raise SystemExit(f"expected 277 facts, found {count}")
+          print("Extracted", count, "facts")
+          PY
+
+          cat > .tmp/parse_facts.clj <<'CLJ'
+          (require '[clojure.java.io :as io]
+                   '[std.block.navigate :as nav])
+          (doseq [file (sort-by #(.getName %) (file-seq (io/file ".tmp/generated-facts")))
+                  :when (.isFile file)]
+            (try
+              (nav/parse-string (slurp file))
+              (catch Throwable t
+                (println "FACT-FAIL" (.getName file) "::" (.getMessage t))
+                (throw t))))
+          (println "Parsed 277 generated facts")
+          CLJ
+
+          cat > .tmp/parse_page.clj <<'CLJ'
+          (require '[code.doc.parse :as parse])
+          (let [file (first *command-line-args*)
+                elements (parse/parse-file file {})]
+            (when-not (seq elements)
+              (throw (ex-info "Documentation page produced no elements" {:file file})))
+            (println "Parsed page" file "with" (count elements) "elements"))
+          CLJ
+
+      - name: Log into GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compile Java support
+        run: |
+          docker run --rm \
+            -e 'CI=true' \
+            -e "LEIN_JVM_OPTS=-Xms512m -Xmx3g -XX:+UseG1GC" \
+            -v "$(pwd):$(pwd)" -w "$(pwd)" \
+            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
+            bash -lc 'lein javac'
+
+      - name: Parse 277 generated facts
+        run: |
+          timeout 180s docker run --rm \
+            -e 'CI=true' \
+            -e "LEIN_JVM_OPTS=-Xms512m -Xmx3g -XX:+UseG1GC" \
+            -v "$(pwd):$(pwd)" -w "$(pwd)" \
+            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
+            bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_facts.clj'
+
+      - name: Parse code.query page
+        run: |
+          timeout 90s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" \
+            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
+            bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/code/code_query.clj'
+
+      - name: Parse std.lib index page
+        run: |
+          timeout 90s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" \
+            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
+            bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/std/lib_index.clj'
+
+      - name: Parse std.block page
+        run: |
+          timeout 90s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" \
+            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
+            bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/std/std_block.clj'
+
+      - name: Parse std.lib.apply page
+        run: |
+          timeout 90s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" \
+            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
+            bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/std/std_lib_apply.clj'
+
+      - name: Parse std.lib.bin page
+        run: |
+          timeout 90s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" \
+            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
+            bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/std/std_lib_bin.clj'
+
+      - name: Parse std.lib.component page
+        run: |
+          timeout 90s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" \
+            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
+            bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/std/std_lib_component.clj'
+
+      - name: Parse std.lang introduction page
+        run: |
+          timeout 90s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" \
+            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
+            bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/std_lang_introduction.clj'
+
+      - name: Parse xt.lang page
+        run: |
+          timeout 90s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" \
+            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
+            bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/xt/xt_lang.clj'

--- a/.github/workflows/split-summary-fact-validation.yml
+++ b/.github/workflows/split-summary-fact-validation.yml
@@ -5,6 +5,14 @@ on:
     branches: [main]
     paths:
       - .github/workflows/split-summary-fact-validation.yml
+      - src-doc/documentation/code/code_query.clj
+      - src-doc/documentation/std/lib_index.clj
+      - src-doc/documentation/std/std_block.clj
+      - src-doc/documentation/std/std_lib_apply.clj
+      - src-doc/documentation/std/std_lib_bin.clj
+      - src-doc/documentation/std/std_lib_component.clj
+      - src-doc/documentation/std_lang_introduction.clj
+      - src-doc/documentation/xt/xt_lang.clj
 
 permissions:
   contents: read
@@ -13,115 +21,11 @@ permissions:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Prepare generated facts
-        run: |
-          set -euo pipefail
-          mkdir -p .tmp/generated-facts
-          python3 - <<'PY'
-          import re
-          from pathlib import Path
-
-          files = [
-              Path("src-doc/documentation/code/code_query.clj"),
-              Path("src-doc/documentation/std/lib_index.clj"),
-              Path("src-doc/documentation/std/std_block.clj"),
-              Path("src-doc/documentation/std/std_lib_apply.clj"),
-              Path("src-doc/documentation/std/std_lib_bin.clj"),
-              Path("src-doc/documentation/std/std_lib_component.clj"),
-              Path("src-doc/documentation/std_lang_introduction.clj"),
-              Path("src-doc/documentation/xt/xt_lang.clj"),
-          ]
-          marker = re.compile(
-              r'^\^\{:id (merged-plans-slop-summary-[^ ]+-example-\d+) '
-              r':added "4\.0"\}\n',
-              re.MULTILINE,
-          )
-          block_file = Path("src-doc/documentation/std/std_block.clj")
-          text = block_file.read_text()
-          before = '''  (modifier-block :hash-uneval "#_" (fn [acc _] acc))
-            => #std.block.type.ModifierBlock{:tag :hash-uneval, :string "#_", :command #function[...]}
-          '''
-          after = '''  (select-keys (modifier-block :hash-uneval "#_" (fn [acc _] acc))
-               [:tag :string])
-            => {:tag :hash-uneval, :string "#_"}
-          '''
-          if before not in text:
-              raise SystemExit("modifier-block example was not found")
-          block_file.write_text(text.replace(before, after, 1))
-
-          def extract_fact(text, start):
-              start = text.index("(fact ", start)
-              depth = 0
-              string = False
-              escape = False
-              comment = False
-              index = start
-              while index < len(text):
-                  char = text[index]
-                  if comment:
-                      if char == "\n": comment = False
-                      index += 1
-                      continue
-                  if string:
-                      if escape: escape = False
-                      elif char == "\\": escape = True
-                      elif char == '"': string = False
-                      index += 1
-                      continue
-                  if char == ";": comment = True
-                  elif char == '"': string = True
-                  elif char == "\\":
-                      index += 2
-                      continue
-                  elif char == "(": depth += 1
-                  elif char == ")":
-                      depth -= 1
-                      if depth == 0: return text[start:index + 1]
-                  index += 1
-              raise ValueError("unterminated fact")
-
-          count = 0
-          out = Path(".tmp/generated-facts")
-          for path in files:
-              text = path.read_text()
-              for match in marker.finditer(text):
-                  identifier = match.group(1)
-                  (out / f"{identifier}.clj").write_text(
-                      extract_fact(text, match.end()) + "\n"
-                  )
-                  count += 1
-          if count != 277:
-              raise SystemExit(f"expected 277 facts, found {count}")
-          print("Extracted", count, "facts")
-          PY
-
-          cat > .tmp/parse_facts.clj <<'CLJ'
-          (require '[clojure.java.io :as io]
-                   '[std.block.navigate :as nav])
-          (doseq [file (sort-by #(.getName %) (file-seq (io/file ".tmp/generated-facts")))
-                  :when (.isFile file)]
-            (try
-              (nav/parse-string (slurp file))
-              (catch Throwable t
-                (println "FACT-FAIL" (.getName file) "::" (.getMessage t))
-                (throw t))))
-          (println "Parsed 277 generated facts")
-          CLJ
-
-          cat > .tmp/parse_page.clj <<'CLJ'
-          (require '[code.doc.parse :as parse])
-          (let [file (first *command-line-args*)
-                elements (parse/parse-file file {})]
-            (when-not (seq elements)
-              (throw (ex-info "Documentation page produced no elements" {:file file})))
-            (println "Parsed page" file "with" (count elements) "elements"))
-          CLJ
 
       - name: Log into GHCR
         uses: docker/login-action@v3
@@ -139,59 +43,38 @@ jobs:
             ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
             bash -lc 'lein javac'
 
-      - name: Parse 277 generated facts
+      - name: Write page parser
         run: |
-          timeout 180s docker run --rm \
-            -e 'CI=true' \
-            -e "LEIN_JVM_OPTS=-Xms512m -Xmx3g -XX:+UseG1GC" \
-            -v "$(pwd):$(pwd)" -w "$(pwd)" \
-            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
-            bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_facts.clj'
+          mkdir -p .tmp
+          cat > .tmp/parse_page.clj <<'CLJ'
+          (require '[code.doc.parse :as parse])
+          (let [file (first *command-line-args*)
+                elements (parse/parse-file file {})]
+            (when-not (seq elements)
+              (throw (ex-info "Documentation page produced no elements" {:file file})))
+            (println "Parsed page" file "with" (count elements) "elements"))
+          CLJ
 
       - name: Parse code.query page
-        run: |
-          timeout 90s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" \
-            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
-            bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/code/code_query.clj'
+        run: timeout 120s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" ghcr.io/zcaudate-xyz/infra-foundation-clean:ci bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/code/code_query.clj'
 
       - name: Parse std.lib index page
-        run: |
-          timeout 90s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" \
-            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
-            bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/std/lib_index.clj'
+        run: timeout 120s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" ghcr.io/zcaudate-xyz/infra-foundation-clean:ci bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/std/lib_index.clj'
 
       - name: Parse std.block page
-        run: |
-          timeout 90s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" \
-            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
-            bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/std/std_block.clj'
+        run: timeout 120s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" ghcr.io/zcaudate-xyz/infra-foundation-clean:ci bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/std/std_block.clj'
 
       - name: Parse std.lib.apply page
-        run: |
-          timeout 90s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" \
-            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
-            bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/std/std_lib_apply.clj'
+        run: timeout 120s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" ghcr.io/zcaudate-xyz/infra-foundation-clean:ci bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/std/std_lib_apply.clj'
 
       - name: Parse std.lib.bin page
-        run: |
-          timeout 90s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" \
-            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
-            bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/std/std_lib_bin.clj'
+        run: timeout 120s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" ghcr.io/zcaudate-xyz/infra-foundation-clean:ci bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/std/std_lib_bin.clj'
 
       - name: Parse std.lib.component page
-        run: |
-          timeout 90s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" \
-            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
-            bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/std/std_lib_component.clj'
+        run: timeout 120s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" ghcr.io/zcaudate-xyz/infra-foundation-clean:ci bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/std/std_lib_component.clj'
 
       - name: Parse std.lang introduction page
-        run: |
-          timeout 90s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" \
-            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
-            bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/std_lang_introduction.clj'
+        run: timeout 120s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" ghcr.io/zcaudate-xyz/infra-foundation-clean:ci bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/std_lang_introduction.clj'
 
       - name: Parse xt.lang page
-        run: |
-          timeout 90s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" \
-            ghcr.io/zcaudate-xyz/infra-foundation-clean:ci \
-            bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/xt/xt_lang.clj'
+        run: timeout 120s docker run --rm -e 'CI=true' -v "$(pwd):$(pwd)" -w "$(pwd)" ghcr.io/zcaudate-xyz/infra-foundation-clean:ci bash -lc 'java -cp "$(lein classpath)" clojure.main .tmp/parse_page.clj src-doc/documentation/xt/xt_lang.clj'

--- a/src-doc/documentation/code/code_query.clj
+++ b/src-doc/documentation/code/code_query.clj
@@ -128,7 +128,15 @@
 
 "A helper macro for generating navigation function definitions. It takes a symbol and a block tag function, and creates a function that can be used to query properties of the current block in a navigator."
 
-[[:code {:lang "clojure"} "(nav-template '-tag- #'std.block.base/block-tag)\n;; => '(clojure.core/defn -tag-\n;;       ([zip] (-tag- zip :right))\n;;       ([zip step]\n;;        (clojure.core/if-let [elem (std.lib.zip/get zip)]\n;;          (std.block.base/block-tag elem))))"]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-1 :added "4.0"}
+(fact "nav-template example"
+  (nav-template '-tag- #'std.block.base/block-tag)
+  => '(clojure.core/defn -tag-
+           ([zip] (-tag- zip :right))
+           ([zip step]
+            (clojure.core/if-let [elem (std.lib.zip/get zip)]
+              (std.block.base/block-tag elem))))
+)
 
 [[:subsection {:title "left-anchor" :link "merged-plans-slop-summary-code-query-block-tutorial-md-left-anchor"}]]
 
@@ -136,7 +144,12 @@
 
 "Calculates the length from the start of the current line to the current cursor position, considering newlines."
 
-[[:code {:lang "clojure"} "(left-anchor (-> (navigator nil)\n                   (zip/step-right)))\n;; => 3"]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-2 :added "4.0"}
+(fact "left-anchor example"
+  (left-anchor (-> (navigator nil)
+                     (zip/step-right)))
+  => 3
+)
 
 [[:subsection {:title "update-step-left" :link "merged-plans-slop-summary-code-query-block-tutorial-md-update-step-left"}]]
 
@@ -144,7 +157,12 @@
 
 "Updates the navigator's position when moving left, adjusting line and column numbers based on the block's dimensions."
 
-[[:code {:lang "clojure"} "(-> {:position [0 7]}\n      (update-step-left (construct/block [1 2 3])))\n;; => {:position [0 0]}"]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-3 :added "4.0"}
+(fact "update-step-left example"
+  (-> {:position [0 7]}
+        (update-step-left (construct/block [1 2 3])))
+  => {:position [0 0]}
+)
 
 [[:subsection {:title "update-step-right" :link "merged-plans-slop-summary-code-query-block-tutorial-md-update-step-right"}]]
 
@@ -152,7 +170,12 @@
 
 "Updates the navigator's position when moving right, adjusting line and column numbers."
 
-[[:code {:lang "clojure"} "(-> {:position [0 0]}\n      (update-step-right (construct/block [1 2 3])))\n;; => {:position [0 7]}"]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-4 :added "4.0"}
+(fact "update-step-right example"
+  (-> {:position [0 0]}
+        (update-step-right (construct/block [1 2 3])))
+  => {:position [0 7]}
+)
 
 [[:subsection {:title "update-step-inside" :link "merged-plans-slop-summary-code-query-block-tutorial-md-update-step-inside"}]]
 
@@ -160,7 +183,12 @@
 
 "Updates the navigator's position when stepping inside a container block, placing the cursor after the opening delimiter."
 
-[[:code {:lang "clojure"} "(-> {:position [0 0]}\n      (update-step-inside (construct/block #{})))\n;; => {:position [0 2]}"]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-5 :added "4.0"}
+(fact "update-step-inside example"
+  (-> {:position [0 0]}
+        (update-step-inside (construct/block #{})))
+  => {:position [0 2]}
+)
 
 [[:subsection {:title "update-step-inside-left" :link "merged-plans-slop-summary-code-query-block-tutorial-md-update-step-inside-left"}]]
 
@@ -168,7 +196,12 @@
 
 "Updates the navigator's position when stepping inside a container block from the right, placing the cursor before the closing delimiter."
 
-[[:code {:lang "clojure"} "(-> {:position [0 3]}\n      (update-step-inside-left (construct/block #{})))\n;; => {:position [0 2]}"]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-6 :added "4.0"}
+(fact "update-step-inside-left example"
+  (-> {:position [0 3]}
+        (update-step-inside-left (construct/block #{})))
+  => {:position [0 2]}
+)
 
 [[:subsection {:title "update-step-outside" :link "merged-plans-slop-summary-code-query-block-tutorial-md-update-step-outside"}]]
 
@@ -176,7 +209,15 @@
 
 "Updates the navigator's position when stepping outside a container block."
 
-[[:code {:lang "clojure"} "(let [left-elems [(construct/block [1 2 3]) (construct/newline)]]\n    (-> {:position [1 0]\n         :left left-elems}\n        (update-step-outside left-elems)\n        :position))\n;; => [0 7]"]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-7 :added "4.0"}
+(fact "update-step-outside example"
+  (let [left-elems [(construct/block [1 2 3]) (construct/newline)]]
+      (-> {:position [1 0]
+           :left left-elems}
+          (update-step-outside left-elems)
+          :position))
+  => [0 7]
+)
 
 [[:subsection {:title "display-navigator" :link "merged-plans-slop-summary-code-query-block-tutorial-md-display-navigator"}]]
 
@@ -184,7 +225,12 @@
 
 "Returns a string representation of the navigator, including its position and the current block."
 
-[[:code {:lang "clojure"} "(-> (navigator [1 2 3 4])\n      (display-navigator))\n;; => \"<0,0> |[1 2 3 4]\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-8 :added "4.0"}
+(fact "display-navigator example"
+  (-> (navigator [1 2 3 4])
+        (display-navigator))
+  => "<0,0> |[1 2 3 4]"
+)
 
 [[:subsection {:title "navigator" :link "merged-plans-slop-summary-code-query-block-tutorial-md-navigator"}]]
 
@@ -192,7 +238,11 @@
 
 "Creates a new `std.block` navigator from a block or Clojure data. This is the primary way to start navigating an AST."
 
-[[:code {:lang "clojure"} "(str (navigator [1 2 3 4]))\n;; => \"<0,0> |[1 2 3 4]\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-9 :added "4.0"}
+(fact "navigator example"
+  (str (navigator [1 2 3 4]))
+  => "<0,0> |[1 2 3 4]"
+)
 
 [[:subsection {:title "navigator?" :link "merged-plans-slop-summary-code-query-block-tutorial-md-navigator-2"}]]
 
@@ -200,7 +250,11 @@
 
 "Checks if an object is a `std.block` navigator."
 
-[[:code {:lang "clojure"} "(navigator? (navigator [1 2 3 4]))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-10 :added "4.0"}
+(fact "navigator? example"
+  (navigator? (navigator [1 2 3 4]))
+  => true
+)
 
 [[:subsection {:title "from-status" :link "merged-plans-slop-summary-code-query-block-tutorial-md-from-status"}]]
 
@@ -208,7 +262,11 @@
 
 "Constructs a navigator from a given status (a block with a cursor)."
 
-[[:code {:lang "clojure"} "(str (from-status (construct/block [1 2 3 (construct/cursor) 4])))\n;; => \"<0,7> [1 2 3 |4]\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-11 :added "4.0"}
+(fact "from-status example"
+  (str (from-status (construct/block [1 2 3 (construct/cursor) 4])))
+  => "<0,7> [1 2 3 |4]"
+)
 
 [[:subsection {:title "parse-string" :link "merged-plans-slop-summary-code-query-block-tutorial-md-parse-string"}]]
 
@@ -216,7 +274,11 @@
 
 "Parses a string into a navigator, automatically placing the cursor at the beginning or at a `#|` marker if present."
 
-[[:code {:lang "clojure"} "(str (parse-string \"(2   #|   3  )\"))\n;; => \"<0,5> (2   |   3  )\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-12 :added "4.0"}
+(fact "parse-string example"
+  (str (parse-string "(2   #|   3  )"))
+  => "<0,5> (2   |   3  )"
+)
 
 [[:subsection {:title "parse-root" :link "merged-plans-slop-summary-code-query-block-tutorial-md-parse-root"}]]
 
@@ -224,7 +286,11 @@
 
 "Parses a root string into a navigator."
 
-[[:code {:lang "clojure"} "(str (parse-root \"a b c\"))\n;; => \"<0,0> |a b c\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-13 :added "4.0"}
+(fact "parse-root example"
+  (str (parse-root "a b c"))
+  => "<0,0> |a b c"
+)
 
 [[:subsection {:title "parse-root-status" :link "merged-plans-slop-summary-code-query-block-tutorial-md-parse-root-status"}]]
 
@@ -232,7 +298,11 @@
 
 "Parses a string and creates a navigator from its status, similar to `from-status` but for root strings."
 
-[[:code {:lang "clojure"} "(str (parse-root-status \"a b #|c\"))\n;; => \"<0,6> a b |c\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-14 :added "4.0"}
+(fact "parse-root-status example"
+  (str (parse-root-status "a b #|c"))
+  => "<0,6> a b |c"
+)
 
 [[:subsection {:title "root-string" :link "merged-plans-slop-summary-code-query-block-tutorial-md-root-string"}]]
 
@@ -240,7 +310,11 @@
 
 "Returns the string representation of the entire root block of the navigator."
 
-[[:code {:lang "clojure"} "(root-string (navigator [1 2 3 4]))\n;; => \"[1 2 3 4]\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-15 :added "4.0"}
+(fact "root-string example"
+  (root-string (navigator [1 2 3 4]))
+  => "[1 2 3 4]"
+)
 
 [[:subsection {:title "left-expression" :link "merged-plans-slop-summary-code-query-block-tutorial-md-left-expression"}]]
 
@@ -248,7 +322,14 @@
 
 "Returns the first expression block to the left of the current cursor position."
 
-[[:code {:lang "clojure"} "(-> {:left [(construct/newline)\n            (construct/block [1 2 3])]}\n      (left-expression)\n      (base/block-value))\n;; => [1 2 3]"]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-16 :added "4.0"}
+(fact "left-expression example"
+  (-> {:left [(construct/newline)
+              (construct/block [1 2 3])]}
+        (left-expression)
+        (base/block-value))
+  => [1 2 3]
+)
 
 [[:subsection {:title "left-expressions" :link "merged-plans-slop-summary-code-query-block-tutorial-md-left-expressions"}]]
 
@@ -256,7 +337,17 @@
 
 "Returns all expression blocks to the left of the current cursor position."
 
-[[:code {:lang "clojure"} "(->> {:left [(construct/newline)\n             (construct/block :b)\n             (construct/space)\n             (construct/space)\n             (construct/block :a)]}\n       (left-expressions)\n       (mapv base/block-value))\n;; => [:a :b]"]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-17 :added "4.0"}
+(fact "left-expressions example"
+  (->> {:left [(construct/newline)
+               (construct/block :b)
+               (construct/space)
+               (construct/space)
+               (construct/block :a)]}
+         (left-expressions)
+         (mapv base/block-value))
+  => [:a :b]
+)
 
 [[:subsection {:title "right-expression" :link "merged-plans-slop-summary-code-query-block-tutorial-md-right-expression"}]]
 
@@ -264,7 +355,14 @@
 
 "Returns the first expression block to the right of the current cursor position."
 
-[[:code {:lang "clojure"} "(-> {:right [(construct/newline)\n              (construct/block [1 2 3])]}\n      (right-expression)\n      (base/block-value))\n;; => [1 2 3]"]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-18 :added "4.0"}
+(fact "right-expression example"
+  (-> {:right [(construct/newline)
+                (construct/block [1 2 3])]}
+        (right-expression)
+        (base/block-value))
+  => [1 2 3]
+)
 
 [[:subsection {:title "right-expressions" :link "merged-plans-slop-summary-code-query-block-tutorial-md-right-expressions"}]]
 
@@ -272,7 +370,17 @@
 
 "Returns all expression blocks to the right of the current cursor position."
 
-[[:code {:lang "clojure"} "(->> {:right [(construct/newline)\n               (construct/block :b)\n               (construct/space)\n               (construct/space)\n               (construct/block :a)]}\n        (right-expressions)\n        (mapv base/block-value))\n;; => [:b :a]"]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-19 :added "4.0"}
+(fact "right-expressions example"
+  (->> {:right [(construct/newline)
+                 (construct/block :b)
+                 (construct/space)
+                 (construct/space)
+                 (construct/block :a)]}
+          (right-expressions)
+          (mapv base/block-value))
+  => [:b :a]
+)
 
 [[:subsection {:title "left" :link "merged-plans-slop-summary-code-query-block-tutorial-md-left"}]]
 
@@ -280,7 +388,13 @@
 
 "Moves the navigator's cursor to the next expression block on the left."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(1  [1 2 3]    #|)\")\n      (left)\n      str)\n;; => \"<0,4> (1  |[1 2 3]    )\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-20 :added "4.0"}
+(fact "left example"
+  (-> (parse-string "(1  [1 2 3]    #|)")
+        (left)
+        str)
+  => "<0,4> (1  |[1 2 3]    )"
+)
 
 [[:subsection {:title "left-most" :link "merged-plans-slop-summary-code-query-block-tutorial-md-left-most"}]]
 
@@ -288,7 +402,13 @@
 
 "Moves the navigator's cursor to the leftmost expression block in the current level."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(1  [1 2 3]  3 4   #|)\")\n      (left-most)\n      str)\n;; => \"<0,1> (|1  [1 2 3]  3 4   )\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-21 :added "4.0"}
+(fact "left-most example"
+  (-> (parse-string "(1  [1 2 3]  3 4   #|)")
+        (left-most)
+        str)
+  => "<0,1> (|1  [1 2 3]  3 4   )"
+)
 
 [[:subsection {:title "left-most?" :link "merged-plans-slop-summary-code-query-block-tutorial-md-left-most-2"}]]
 
@@ -296,7 +416,12 @@
 
 "Checks if the navigator's cursor is at the leftmost expression block."
 
-[[:code {:lang "clojure"} "(-> (from-status [1 [(construct/cursor) 2 3]])\n      (left-most?))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-22 :added "4.0"}
+(fact "left-most? example"
+  (-> (from-status [1 [(construct/cursor) 2 3]])
+        (left-most?))
+  => true
+)
 
 [[:subsection {:title "right" :link "merged-plans-slop-summary-code-query-block-tutorial-md-right"}]]
 
@@ -304,7 +429,13 @@
 
 "Moves the navigator's cursor to the next expression block on the right."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(#|[1 2 3]  3 4  ) \")\n      (right)\n      str)\n;; => \"<0,10> ([1 2 3]  |3 4  )\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-23 :added "4.0"}
+(fact "right example"
+  (-> (parse-string "(#|[1 2 3]  3 4  ) ")
+        (right)
+        str)
+  => "<0,10> ([1 2 3]  |3 4  )"
+)
 
 [[:subsection {:title "right-most" :link "merged-plans-slop-summary-code-query-block-tutorial-md-right-most"}]]
 
@@ -312,7 +443,13 @@
 
 "Moves the navigator's cursor to the rightmost expression block in the current level."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(#|[1 2 3]  3 4  ) \")\n      (right-most)\n      str)\n;; => \"<0,12> ([1 2 3]  3 |4  )\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-24 :added "4.0"}
+(fact "right-most example"
+  (-> (parse-string "(#|[1 2 3]  3 4  ) ")
+        (right-most)
+        str)
+  => "<0,12> ([1 2 3]  3 |4  )"
+)
 
 [[:subsection {:title "right-most?" :link "merged-plans-slop-summary-code-query-block-tutorial-md-right-most-2"}]]
 
@@ -320,7 +457,12 @@
 
 "Checks if the navigator's cursor is at the rightmost expression block."
 
-[[:code {:lang "clojure"} "(-> (from-status [1 [2 3 (construct/cursor)]])\n      (right-most?))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-25 :added "4.0"}
+(fact "right-most? example"
+  (-> (from-status [1 [2 3 (construct/cursor)]])
+        (right-most?))
+  => true
+)
 
 [[:subsection {:title "up" :link "merged-plans-slop-summary-code-query-block-tutorial-md-up"}]]
 
@@ -328,7 +470,11 @@
 
 "Moves the navigator's cursor up to the parent container."
 
-[[:code {:lang "clojure"} "(str (up (from-status [1 [2 (construct/cursor) 3]])))\n;; => \"<0,3> [1 |[2 3]]\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-26 :added "4.0"}
+(fact "up example"
+  (str (up (from-status [1 [2 (construct/cursor) 3]])))
+  => "<0,3> [1 |[2 3]]"
+)
 
 [[:subsection {:title "down" :link "merged-plans-slop-summary-code-query-block-tutorial-md-down"}]]
 
@@ -336,7 +482,11 @@
 
 "Moves the navigator's cursor down into the first child expression of the current container."
 
-[[:code {:lang "clojure"} "(str (down (from-status [1 (construct/cursor) [2 3]])))\n;; => \"<0,4> [1 [|2 3]]\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-27 :added "4.0"}
+(fact "down example"
+  (str (down (from-status [1 (construct/cursor) [2 3]])))
+  => "<0,4> [1 [|2 3]]"
+)
 
 [[:subsection {:title "right" :link "merged-plans-slop-summary-code-query-block-tutorial-md-right-2"}]]
 
@@ -344,7 +494,11 @@
 
 "Moves the navigator's cursor to the next element (including whitespace) on the right."
 
-[[:code {:lang "clojure"} "(str (right* (from-status [(construct/cursor) 1 2])))\n;; => \"<0,2> [1| 2]\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-28 :added "4.0"}
+(fact "right example"
+  (str (right* (from-status [(construct/cursor) 1 2])))
+  => "<0,2> [1| 2]"
+)
 
 [[:subsection {:title "left" :link "merged-plans-slop-summary-code-query-block-tutorial-md-left-2"}]]
 
@@ -352,7 +506,11 @@
 
 "Moves the navigator's cursor to the next element (including whitespace) on the left."
 
-[[:code {:lang "clojure"} "(str (left* (from-status [1 (construct/cursor) 2])))\n;; => \"<0,2> [1| 2]\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-29 :added "4.0"}
+(fact "left example"
+  (str (left* (from-status [1 (construct/cursor) 2])))
+  => "<0,2> [1| 2]"
+)
 
 [[:subsection {:title "block" :link "merged-plans-slop-summary-code-query-block-tutorial-md-block"}]]
 
@@ -360,7 +518,11 @@
 
 "Returns the `std.block` AST node at the current cursor position."
 
-[[:code {:lang "clojure"} "(block (from-status [1 [2 (construct/cursor) 3]]))\n;; => (construct/block 3)"]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-30 :added "4.0"}
+(fact "block example"
+  (block (from-status [1 [2 (construct/cursor) 3]]))
+  => (construct/block 3)
+)
 
 [[:subsection {:title "prev" :link "merged-plans-slop-summary-code-query-block-tutorial-md-prev"}]]
 
@@ -368,7 +530,13 @@
 
 "Moves the navigator's cursor to the previous expression block in a depth-first traversal."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"([1 2 [3]] #|)\")\n      (prev)\n      str)\n;; => \"<0,7> ([1 2 [|3]] )\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-31 :added "4.0"}
+(fact "prev example"
+  (-> (parse-string "([1 2 [3]] #|)")
+        (prev)
+        str)
+  => "<0,7> ([1 2 [|3]] )"
+)
 
 [[:subsection {:title "next" :link "merged-plans-slop-summary-code-query-block-tutorial-md-next"}]]
 
@@ -376,7 +544,15 @@
 
 "Moves the navigator's cursor to the next expression block in a depth-first traversal."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(#|  [[3]]  )\")\n      (next)\n      (next)\n      (next)\n      str)\n;; => \"<0,5> (  [[|3]]  )\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-32 :added "4.0"}
+(fact "next example"
+  (-> (parse-string "(#|  [[3]]  )")
+        (next)
+        (next)
+        (next)
+        str)
+  => "<0,5> (  [[|3]]  )"
+)
 
 [[:subsection {:title "find-next-token" :link "merged-plans-slop-summary-code-query-block-tutorial-md-find-next-token"}]]
 
@@ -384,7 +560,13 @@
 
 "Moves the navigator's cursor to the next token block whose value matches the given data."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(#|  [[3 2]]  )\")\n      (find-next-token 2)\n      str)\n;; => \"<0,7> (  [[3 |2]]  )\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-33 :added "4.0"}
+(fact "find-next-token example"
+  (-> (parse-string "(#|  [[3 2]]  )")
+        (find-next-token 2)
+        str)
+  => "<0,7> (  [[3 |2]]  )"
+)
 
 [[:subsection {:title "prev-anchor" :link "merged-plans-slop-summary-code-query-block-tutorial-md-prev-anchor"}]]
 
@@ -392,7 +574,18 @@
 
 "Moves the navigator's cursor to the previous newline or the beginning of the current line."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"( \\n \\n [[3 \\n]] #|  )\")\n      (prev-anchor)\n      (:position))\n;; => [3 0]\n\n(-> (parse-string \"( #| )\")\n      (prev-anchor)\n      (:position))\n;; => [0 0]"]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-34 :added "4.0"}
+(fact "prev-anchor example"
+  (-> (parse-string "( \n \n [[3 \n]] #|  )")
+        (prev-anchor)
+        (:position))
+  => [3 0]
+
+  (-> (parse-string "( #| )")
+        (prev-anchor)
+        (:position))
+  => [0 0]
+)
 
 [[:subsection {:title "next-anchor" :link "merged-plans-slop-summary-code-query-block-tutorial-md-next-anchor"}]]
 
@@ -400,7 +593,13 @@
 
 "Moves the navigator's cursor to the next newline."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"( \\n \\n#| [[3 \\n]]  )\")\n      (next-anchor)\n      (:position))\n;; => [3 0]"]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-35 :added "4.0"}
+(fact "next-anchor example"
+  (-> (parse-string "( \n \n#| [[3 \n]]  )")
+        (next-anchor)
+        (:position))
+  => [3 0]
+)
 
 [[:subsection {:title "left-token" :link "merged-plans-slop-summary-code-query-block-tutorial-md-left-token"}]]
 
@@ -408,7 +607,13 @@
 
 "Moves the navigator's cursor to the next token block on the left."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(1  {}  #|2 3 4)\")\n      (left-token)\n      str)\n;; => \"<0,1> (|1  {}  2 3 4)\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-36 :added "4.0"}
+(fact "left-token example"
+  (-> (parse-string "(1  {}  #|2 3 4)")
+        (left-token)
+        str)
+  => "<0,1> (|1  {}  2 3 4)"
+)
 
 [[:subsection {:title "left-most-token" :link "merged-plans-slop-summary-code-query-block-tutorial-md-left-most-token"}]]
 
@@ -416,7 +621,13 @@
 
 "Moves the navigator's cursor to the leftmost token block in the current level."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(1  {}  2 3 #|4)\")\n      (left-most-token)\n      str)\n;; => \"<0,10> (1  {}  2 |3 4)\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-37 :added "4.0"}
+(fact "left-most-token example"
+  (-> (parse-string "(1  {}  2 3 #|4)")
+        (left-most-token)
+        str)
+  => "<0,10> (1  {}  2 |3 4)"
+)
 
 [[:subsection {:title "right-token" :link "merged-plans-slop-summary-code-query-block-tutorial-md-right-token"}]]
 
@@ -424,7 +635,13 @@
 
 "Moves the navigator's cursor to the next token block on the right."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(#|1  {}  2 3 4)\")\n      (right-token)\n      str)\n;; => \"<0,8> (1  {}  |2 3 4)\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-38 :added "4.0"}
+(fact "right-token example"
+  (-> (parse-string "(#|1  {}  2 3 4)")
+        (right-token)
+        str)
+  => "<0,8> (1  {}  |2 3 4)"
+)
 
 [[:subsection {:title "right-most-token" :link "merged-plans-slop-summary-code-query-block-tutorial-md-right-most-token"}]]
 
@@ -432,7 +649,13 @@
 
 "Moves the navigator's cursor to the rightmost token block in the current level."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(#|1  {}  2 3 [4])\")\n      (right-most-token)\n      str)\n;; => \"<0,10> (1  {}  2 |3 [4])\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-39 :added "4.0"}
+(fact "right-most-token example"
+  (-> (parse-string "(#|1  {}  2 3 [4])")
+        (right-most-token)
+        str)
+  => "<0,10> (1  {}  2 |3 [4])"
+)
 
 [[:subsection {:title "prev-token" :link "merged-plans-slop-summary-code-query-block-tutorial-md-prev-token"}]]
 
@@ -440,7 +663,13 @@
 
 "Moves the navigator's cursor to the previous token block in a depth-first traversal."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(1 (2 3 [4])#|)\")\n      (prev-token)\n      str)\n;; => \"<0,9> (1 (2 3 [|4]))\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-40 :added "4.0"}
+(fact "prev-token example"
+  (-> (parse-string "(1 (2 3 [4])#|)")
+        (prev-token)
+        str)
+  => "<0,9> (1 (2 3 [|4]))"
+)
 
 [[:subsection {:title "next-token" :link "merged-plans-slop-summary-code-query-block-tutorial-md-next-token"}]]
 
@@ -448,7 +677,13 @@
 
 "Moves the navigator's cursor to the next token block in a depth-first traversal."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(#|[[1 2 3 4]])\")\n      (next-token)\n      str)\n;; => \"<0,3> ([[|1 2 3 4]])\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-41 :added "4.0"}
+(fact "next-token example"
+  (-> (parse-string "(#|[[1 2 3 4]])")
+        (next-token)
+        str)
+  => "<0,3> ([[|1 2 3 4]])"
+)
 
 [[:subsection {:title "position-left" :link "merged-plans-slop-summary-code-query-block-tutorial-md-position-left"}]]
 
@@ -456,7 +691,18 @@
 
 "Moves the cursor to the left expression, skipping whitespace."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"( 2   #|   3  )\")\n      (position-left)\n      str)\n;; => \"<0,2> ( |2      3  )\"\n\n(-> (parse-string \"(   #|   3  )\")\n      (position-left)\n      str)\n;; => \"<0,1> (|      3  )\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-42 :added "4.0"}
+(fact "position-left example"
+  (-> (parse-string "( 2   #|   3  )")
+        (position-left)
+        str)
+  => "<0,2> ( |2      3  )"
+
+  (-> (parse-string "(   #|   3  )")
+        (position-left)
+        str)
+  => "<0,1> (|      3  )"
+)
 
 [[:subsection {:title "position-right" :link "merged-plans-slop-summary-code-query-block-tutorial-md-position-right"}]]
 
@@ -464,7 +710,18 @@
 
 "Moves the cursor to the right expression, skipping whitespace."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(2   #|    3  )\")\n      (position-right)\n      str)\n;; => \"<0,9> (2       |3  )\"\n\n(-> (parse-string \"(2   #|     )\")\n      (position-right)\n      str)\n;; => \"<0,10> (2        |)\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-43 :added "4.0"}
+(fact "position-right example"
+  (-> (parse-string "(2   #|    3  )")
+        (position-right)
+        str)
+  => "<0,9> (2       |3  )"
+
+  (-> (parse-string "(2   #|     )")
+        (position-right)
+        str)
+  => "<0,10> (2        |)"
+)
 
 [[:subsection {:title "tighten-left" :link "merged-plans-slop-summary-code-query-block-tutorial-md-tighten-left"}]]
 
@@ -472,7 +729,23 @@
 
 "Removes extra spaces on the left of the current expression."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(1 2 3   #|4)\")\n      (tighten-left)\n      str)\n;; => \"<0,7> (1 2 3 |4)\"\n\n(-> (parse-string \"(1 2 3   #|    4)\")\n      (tighten-left)\n      str)\n;; => \"<0,7> (1 2 3 |4)\"\n\n(-> (parse-string \"(    #|     )\")\n      (tighten-left)\n      str)\n;; => \"<0,1> (|)\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-44 :added "4.0"}
+(fact "tighten-left example"
+  (-> (parse-string "(1 2 3   #|4)")
+        (tighten-left)
+        str)
+  => "<0,7> (1 2 3 |4)"
+
+  (-> (parse-string "(1 2 3   #|    4)")
+        (tighten-left)
+        str)
+  => "<0,7> (1 2 3 |4)"
+
+  (-> (parse-string "(    #|     )")
+        (tighten-left)
+        str)
+  => "<0,1> (|)"
+)
 
 [[:subsection {:title "tighten-right" :link "merged-plans-slop-summary-code-query-block-tutorial-md-tighten-right"}]]
 
@@ -480,7 +753,23 @@
 
 "Removes extra spaces on the right of the current expression."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(1 2 #|3       4)\")\n      (tighten-right)\n      str)\n;; => \"<0,5> (1 2 |3 4)\"\n\n(-> (parse-string \"(1 2 3   #|    4)\")\n      (tighten-right)\n      str)\n;; => \"<0,5> (1 2 |3 4)\"\n\n(-> (parse-string \"(    #|     )\")\n      (tighten-right)\n      str)\n;; => \"<0,1> (|)\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-45 :added "4.0"}
+(fact "tighten-right example"
+  (-> (parse-string "(1 2 #|3       4)")
+        (tighten-right)
+        str)
+  => "<0,5> (1 2 |3 4)"
+
+  (-> (parse-string "(1 2 3   #|    4)")
+        (tighten-right)
+        str)
+  => "<0,5> (1 2 |3 4)"
+
+  (-> (parse-string "(    #|     )")
+        (tighten-right)
+        str)
+  => "<0,1> (|)"
+)
 
 [[:subsection {:title "tighten" :link "merged-plans-slop-summary-code-query-block-tutorial-md-tighten"}]]
 
@@ -488,7 +777,13 @@
 
 "Removes extra spaces on both the left and right of the current expression."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(1 2      #|3       4)\")\n      (tighten)\n      str)\n;; => \"<0,5> (1 2 |3 4)\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-46 :added "4.0"}
+(fact "tighten example"
+  (-> (parse-string "(1 2      #|3       4)")
+        (tighten)
+        str)
+  => "<0,5> (1 2 |3 4)"
+)
 
 [[:subsection {:title "level-empty?" :link "merged-plans-slop-summary-code-query-block-tutorial-md-level-empty"}]]
 
@@ -496,7 +791,12 @@
 
 "Checks if the current container has no expression children."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"( #| )\")\n      (level-empty?))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-47 :added "4.0"}
+(fact "level-empty? example"
+  (-> (parse-string "( #| )")
+        (level-empty?))
+  => true
+)
 
 [[:subsection {:title "insert-empty" :link "merged-plans-slop-summary-code-query-block-tutorial-md-insert-empty"}]]
 
@@ -504,7 +804,13 @@
 
 "Inserts an element into an empty container."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"( #| )\")\n      (insert-empty 1)\n      str)\n;; => \"<0,1> (|1  )\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-48 :added "4.0"}
+(fact "insert-empty example"
+  (-> (parse-string "( #| )")
+        (insert-empty 1)
+        str)
+  => "<0,1> (|1  )"
+)
 
 [[:subsection {:title "insert-right" :link "merged-plans-slop-summary-code-query-block-tutorial-md-insert-right"}]]
 
@@ -512,7 +818,23 @@
 
 "Inserts an element to the right of the current cursor position."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(#|0)\")\n      (insert-right 1)\n      str)\n;; => \"<0,1> (|0 1)\"\n\n(-> (parse-string \"(#|)\")\n      (insert-right 1)\n      str)\n;; => \"<0,1> (|1)\"\n\n(-> (parse-string \"( #| )\")\n      (insert-right 1)\n      str)\n;; => \"<0,1> (|1  )\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-49 :added "4.0"}
+(fact "insert-right example"
+  (-> (parse-string "(#|0)")
+        (insert-right 1)
+        str)
+  => "<0,1> (|0 1)"
+
+  (-> (parse-string "(#|)")
+        (insert-right 1)
+        str)
+  => "<0,1> (|1)"
+
+  (-> (parse-string "( #| )")
+        (insert-right 1)
+        str)
+  => "<0,1> (|1  )"
+)
 
 [[:subsection {:title "insert-token-to-left" :link "merged-plans-slop-summary-code-query-block-tutorial-md-insert-token-to-left"}]]
 
@@ -520,7 +842,23 @@
 
 "Inserts an element to the left of the current cursor position."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(#|0)\")\n      (insert-token-to-left 1)\n      str)\n;; => \"<0,3> (1 |0)\"\n\n(-> (parse-string \"(#|)\")\n      (insert-token-to-left 1)\n      str)\n;; => \"<0,1> (|1)\"\n\n(-> (parse-string \"( #| )\")\n      (insert-token-to-left 1)\n      str)\n;; => \"<0,1> (|1  )\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-50 :added "4.0"}
+(fact "insert-token-to-left example"
+  (-> (parse-string "(#|0)")
+        (insert-token-to-left 1)
+        str)
+  => "<0,3> (1 |0)"
+
+  (-> (parse-string "(#|)")
+        (insert-token-to-left 1)
+        str)
+  => "<0,1> (|1)"
+
+  (-> (parse-string "( #| )")
+        (insert-token-to-left 1)
+        str)
+  => "<0,1> (|1  )"
+)
 
 [[:subsection {:title "insert" :link "merged-plans-slop-summary-code-query-block-tutorial-md-insert"}]]
 
@@ -528,7 +866,24 @@
 
 "Inserts an element at the current cursor position and moves the cursor past the inserted element."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(#|0)\")\n      (insert 1)\n      str)\n;; => \"<0,3> (0 |1)\"\n\n(-> (parse-string \"(#|)\")\n      (insert-right 1)\n      str)\n;; => \"<0,1> (|1)\"\n\n(-> (parse-string \"( #| )\")\n      (insert-right 1)\n      str)\n\n;; => \"<0,1> (|1  )\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-51 :added "4.0"}
+(fact "insert example"
+  (-> (parse-string "(#|0)")
+        (insert 1)
+        str)
+  => "<0,3> (0 |1)"
+
+  (-> (parse-string "(#|)")
+        (insert-right 1)
+        str)
+  => "<0,1> (|1)"
+
+  (-> (parse-string "( #| )")
+        (insert-right 1)
+        str)
+
+  => "<0,1> (|1  )"
+)
 
 [[:subsection {:title "insert-all" :link "merged-plans-slop-summary-code-query-block-tutorial-md-insert-all"}]]
 
@@ -536,7 +891,14 @@
 
 "Inserts all expressions from a collection into the block at the current cursor position."
 
-[[:code {:lang "clojure"} ";; No direct test example, but it would involve:\n;; (-> (parse-string \"(#|)\")\n;;     (insert-all [1 2 3])\n;;     str)\n;; => \"<0,7> (1 2 3|)\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-52 :added "4.0"}
+(fact "insert-all example"
+  ;; No direct test example, but it would involve:
+  (-> (parse-string "(#|)")
+      (insert-all [1 2 3])
+      str)
+  => "<0,7> (1 2 3|)"
+)
 
 [[:subsection {:title "insert-newline" :link "merged-plans-slop-summary-code-query-block-tutorial-md-insert-newline"}]]
 
@@ -544,7 +906,14 @@
 
 "Inserts one or more newline blocks at the current cursor position."
 
-[[:code {:lang "clojure"} ";; No direct test example, but it would involve:\n;; (-> (parse-string \"(#|)\")\n;;     (insert-newline)\n;;     str)\n;; => \"<0,1> (|\n)\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-53 :added "4.0"}
+(fact "insert-newline example"
+  ;; No direct test example, but it would involve:
+  (-> (parse-string "(#|)")
+      (insert-newline)
+      str)
+  => "<0,1> (|\n)"
+)
 
 [[:subsection {:title "insert-space" :link "merged-plans-slop-summary-code-query-block-tutorial-md-insert-space"}]]
 
@@ -552,7 +921,14 @@
 
 "Inserts one or more space blocks at the current cursor position."
 
-[[:code {:lang "clojure"} ";; No direct test example, but it would involve:\n;; (-> (parse-string \"(#|)\")\n;;     (insert-space)\n;;     str)\n;; => \"<0,1> (| \\t)\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-54 :added "4.0"}
+(fact "insert-space example"
+  ;; No direct test example, but it would involve:
+  (-> (parse-string "(#|)")
+      (insert-space)
+      str)
+  => "<0,1> (| \t)"
+)
 
 [[:subsection {:title "delete-left" :link "merged-plans-slop-summary-code-query-block-tutorial-md-delete-left"}]]
 
@@ -560,7 +936,23 @@
 
 "Deletes the element to the left of the current cursor position."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(1 2   #|3)\")\n      (delete-left)\n      str)\n;; => \"<0,3> (1 |3)\"\n\n(-> (parse-string \"(  #|1 2 3)\")\n      (delete-left)\n      str)\n;; => \"<0,1> (|1 2 3)\"\n\n(-> (parse-string \"( #| )\")\n      (delete-left)\n      str)\n;; => \"<0,1> (|)\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-55 :added "4.0"}
+(fact "delete-left example"
+  (-> (parse-string "(1 2   #|3)")
+        (delete-left)
+        str)
+  => "<0,3> (1 |3)"
+
+  (-> (parse-string "(  #|1 2 3)")
+        (delete-left)
+        str)
+  => "<0,1> (|1 2 3)"
+
+  (-> (parse-string "( #| )")
+        (delete-left)
+        str)
+  => "<0,1> (|)"
+)
 
 [[:subsection {:title "delete-right" :link "merged-plans-slop-summary-code-query-block-tutorial-md-delete-right"}]]
 
@@ -568,7 +960,23 @@
 
 "Deletes the element to the right of the current cursor position."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(  #|1 2 3)\")\n      (delete-right)\n      str)\n;; => \"<0,3> (  |1 3)\"\n\n(-> (parse-string \"(1 2   #|3)\")\n      (delete-right)\n      str)\n;; => \"<0,7> (1 2   |3)\"\n\n(-> (parse-string \"( #| )\")\n      (delete-right)\n      str)\n;; => \"<0,1> (|)\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-56 :added "4.0"}
+(fact "delete-right example"
+  (-> (parse-string "(  #|1 2 3)")
+        (delete-right)
+        str)
+  => "<0,3> (  |1 3)"
+
+  (-> (parse-string "(1 2   #|3)")
+        (delete-right)
+        str)
+  => "<0,7> (1 2   |3)"
+
+  (-> (parse-string "( #| )")
+        (delete-right)
+        str)
+  => "<0,1> (|)"
+)
 
 [[:subsection {:title "delete" :link "merged-plans-slop-summary-code-query-block-tutorial-md-delete"}]]
 
@@ -576,7 +984,23 @@
 
 "Deletes the element at the current cursor position."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(  #|1   2 3)\")\n      (delete)\n      str)\n;; => \"<0,3> (  |2 3)\"\n\n(-> (parse-string \"(1 2   #|3)\")\n      (delete)\n      str)\n;; => \"<0,7> (1 2   |)\"\n\n(-> (parse-string \"(  #|    )\")\n      (delete)\n      str)\n;; => \"<0,1> (|)\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-57 :added "4.0"}
+(fact "delete example"
+  (-> (parse-string "(  #|1   2 3)")
+        (delete)
+        str)
+  => "<0,3> (  |2 3)"
+
+  (-> (parse-string "(1 2   #|3)")
+        (delete)
+        str)
+  => "<0,7> (1 2   |)"
+
+  (-> (parse-string "(  #|    )")
+        (delete)
+        str)
+  => "<0,1> (|)"
+)
 
 [[:subsection {:title "backspace" :link "merged-plans-slop-summary-code-query-block-tutorial-md-backspace"}]]
 
@@ -584,7 +1008,18 @@
 
 "Performs a \"backspace\" operation, deleting the element to the left of the cursor and moving the cursor."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(0  #|1   2 3)\")\n      (backspace)\n      str)\n;; => \"<0,1> (|0 2 3)\"\n\n(-> (parse-string \"(  #|1   2 3)\")\n      (backspace)\n      str)\n;; => \"<0,1> (|2 3)\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-58 :added "4.0"}
+(fact "backspace example"
+  (-> (parse-string "(0  #|1   2 3)")
+        (backspace)
+        str)
+  => "<0,1> (|0 2 3)"
+
+  (-> (parse-string "(  #|1   2 3)")
+        (backspace)
+        str)
+  => "<0,1> (|2 3)"
+)
 
 [[:subsection {:title "replace" :link "merged-plans-slop-summary-code-query-block-tutorial-md-replace"}]]
 
@@ -592,7 +1027,14 @@
 
 "Replaces the element at the current cursor position with new data."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(0  #|1   2 3)\")\n      (position-right)\n      (replace :a)\n      str)\n;; => \"<0,4> (0  |:a   2 3)\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-59 :added "4.0"}
+(fact "replace example"
+  (-> (parse-string "(0  #|1   2 3)")
+        (position-right)
+        (replace :a)
+        str)
+  => "<0,4> (0  |:a   2 3)"
+)
 
 [[:subsection {:title "swap" :link "merged-plans-slop-summary-code-query-block-tutorial-md-swap"}]]
 
@@ -600,7 +1042,14 @@
 
 "Applies a function to the element at the current cursor position, replacing it with the result."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"(0  #|1   2 3)\")\n      (position-right)\n      (swap inc)\n      str)\n;; => \"<0,4> (0  |2   2 3)\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-60 :added "4.0"}
+(fact "swap example"
+  (-> (parse-string "(0  #|1   2 3)")
+        (position-right)
+        (swap inc)
+        str)
+  => "<0,4> (0  |2   2 3)"
+)
 
 [[:subsection {:title "update-children" :link "merged-plans-slop-summary-code-query-block-tutorial-md-update-children"}]]
 
@@ -608,7 +1057,15 @@
 
 "Replaces all children of the current container block with a new sequence of children."
 
-[[:code {:lang "clojure"} "(-> (update-children (parse-string \"[1 2 3]\")\n                     [(construct/block 4)\n                      (construct/space)\n                      (construct/block 5)])\n    str)\n;; => \"<0,0> |[4 5]\""]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-61 :added "4.0"}
+(fact "update-children example"
+  (-> (update-children (parse-string "[1 2 3]")
+                       [(construct/block 4)
+                        (construct/space)
+                        (construct/block 5)])
+      str)
+  => "<0,0> |[4 5]"
+)
 
 [[:subsection {:title "line-info" :link "merged-plans-slop-summary-code-query-block-tutorial-md-line-info"}]]
 
@@ -616,7 +1073,11 @@
 
 "Returns a map containing line and column information for the current block."
 
-[[:code {:lang "clojure"} "(line-info (parse-string \"[1 \\n  2 3]\"))\n;; => {:row 1, :col 1, :end-row 2, :end-col 7}"]]
+^{:id merged-plans-slop-summary-code-query-block-tutorial-md-example-62 :added "4.0"}
+(fact "line-info example"
+  (line-info (parse-string "[1 \n  2 3]"))
+  => {:row 1, :col 1, :end-row 2, :end-col 7}
+)
 ;; END merged documentation: plans/slop/summary/code_query_block_tutorial.md
 
 ;; BEGIN merged documentation: plans/slop/summary/code_query_common_tutorial.md
@@ -639,7 +1100,14 @@
 
 "A predicate that always returns `true` for any input. Useful as a wildcard or default matcher."
 
-[[:code {:lang "clojure"} "(any nil)\n;; => true\n\n(any '_) ; Note: The test uses '_ as a symbol, which is fine.\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-common-tutorial-md-example-1 :added "4.0"}
+(fact "any example"
+  (any nil)
+  => true
+
+  (any '_) ; Note: The test uses '_ as a symbol, which is fine.
+  => true
+)
 
 [[:subsection {:title "none" :link "merged-plans-slop-summary-code-query-common-tutorial-md-none"}]]
 
@@ -647,7 +1115,14 @@
 
 "A predicate that always returns `false` for any input."
 
-[[:code {:lang "clojure"} "(none nil)\n;; => false\n\n(none '_) ; Note: The test uses '_ as a symbol, which is fine.\n;; => false"]]
+^{:id merged-plans-slop-summary-code-query-common-tutorial-md-example-2 :added "4.0"}
+(fact "none example"
+  (none nil)
+  => false
+
+  (none '_) ; Note: The test uses '_ as a symbol, which is fine.
+  => false
+)
 
 [[:subsection {:title "expand-meta" :link "merged-plans-slop-summary-code-query-common-tutorial-md-expand-meta"}]]
 
@@ -655,7 +1130,14 @@
 
 "Takes a form and expands its metadata keywords (e.g., `:?`, `:+`, `:%`) into a map of boolean flags."
 
-[[:code {:lang "clojure"} "(meta (expand-meta ^:? ()))\n;; => {:? true}\n\n(meta (expand-meta ^:+%? ()))\n;; => {:? true, :% true, :+ true}"]]
+^{:id merged-plans-slop-summary-code-query-common-tutorial-md-example-3 :added "4.0"}
+(fact "expand-meta example"
+  (meta (expand-meta ^:? ()))
+  => {:? true}
+
+  (meta (expand-meta ^:+%? ()))
+  => {:? true, :% true, :+ true}
+)
 
 [[:subsection {:title "cursor?" :link "merged-plans-slop-summary-code-query-common-tutorial-md-cursor"}]]
 
@@ -663,7 +1145,14 @@
 
 "Checks if an element is the cursor marker (`|`)."
 
-[[:code {:lang "clojure"} "(cursor? '|)\n;; => true\n\n(cursor? '_) ; Note: The test uses '_ as a symbol, which is fine.\n;; => false"]]
+^{:id merged-plans-slop-summary-code-query-common-tutorial-md-example-4 :added "4.0"}
+(fact "cursor? example"
+  (cursor? '|)
+  => true
+
+  (cursor? '_) ; Note: The test uses '_ as a symbol, which is fine.
+  => false
+)
 
 [[:subsection {:title "insertion?" :link "merged-plans-slop-summary-code-query-common-tutorial-md-insertion"}]]
 
@@ -671,7 +1160,14 @@
 
 "Checks if a form has the `^:+` metadata flag, indicating it's marked for insertion."
 
-[[:code {:lang "clojure"} "(insertion? '^:+ a)\n;; => true\n\n(insertion? 'a)\n;; => false"]]
+^{:id merged-plans-slop-summary-code-query-common-tutorial-md-example-5 :added "4.0"}
+(fact "insertion? example"
+  (insertion? '^:+ a)
+  => true
+
+  (insertion? 'a)
+  => false
+)
 
 [[:subsection {:title "deletion?" :link "merged-plans-slop-summary-code-query-common-tutorial-md-deletion"}]]
 
@@ -679,7 +1175,14 @@
 
 "Checks if a form has the `^:-` metadata flag, indicating it's marked for deletion."
 
-[[:code {:lang "clojure"} "(deletion? '^:- a)\n;; => true\n\n(deletion? 'a)\n;; => false"]]
+^{:id merged-plans-slop-summary-code-query-common-tutorial-md-example-6 :added "4.0"}
+(fact "deletion? example"
+  (deletion? '^:- a)
+  => true
+
+  (deletion? 'a)
+  => false
+)
 
 [[:subsection {:title "prewalk" :link "merged-plans-slop-summary-code-query-common-tutorial-md-prewalk"}]]
 
@@ -687,7 +1190,12 @@
 
 "Applies a function to elements in a depth-first, pre-order traversal, eagerly modifying them. It preserves metadata."
 
-[[:code {:lang "clojure"} ";; Example from test code, but no direct assertion provided.\n;; (prewalk inc '(1 (2 3)))\n;; => '(2 (3 4))"]]
+^{:id merged-plans-slop-summary-code-query-common-tutorial-md-example-7 :added "4.0"}
+(fact "prewalk example"
+  Example from test code, but no direct assertion provided.
+  (prewalk inc '(1 (2 3)))
+  => '(2 (3 4))
+)
 
 [[:subsection {:title "remove-items" :link "merged-plans-slop-summary-code-query-common-tutorial-md-remove-items"}]]
 
@@ -695,7 +1203,14 @@
 
 "Recursively removes items from a form that match a given predicate."
 
-[[:code {:lang "clojure"} "(remove-items #{1} '(1 2 3 4))\n;; => '(2 3 4)\n\n(remove-items #{1} '(1 (1 (1 (1)))))\n;; => '(((())))"]]
+^{:id merged-plans-slop-summary-code-query-common-tutorial-md-example-8 :added "4.0"}
+(fact "remove-items example"
+  (remove-items #{1} '(1 2 3 4))
+  => '(2 3 4)
+
+  (remove-items #{1} '(1 (1 (1 (1)))))
+  => '(((())))
+)
 
 [[:subsection {:title "prepare-deletion" :link "merged-plans-slop-summary-code-query-common-tutorial-md-prepare-deletion"}]]
 
@@ -703,7 +1218,14 @@
 
 "Prepares a form for a deletion walk by removing cursor markers and insertion-flagged elements."
 
-[[:code {:lang "clojure"} "(prepare-deletion '(+ a 2))\n;; => '(+ a 2)\n\n(prepare-deletion '(+ ^:+ a | 2))\n;; => '(+ 2)"]]
+^{:id merged-plans-slop-summary-code-query-common-tutorial-md-example-9 :added "4.0"}
+(fact "prepare-deletion example"
+  (prepare-deletion '(+ a 2))
+  => '(+ a 2)
+
+  (prepare-deletion '(+ ^:+ a | 2))
+  => '(+ 2)
+)
 
 [[:subsection {:title "prepare-insertion" :link "merged-plans-slop-summary-code-query-common-tutorial-md-prepare-insertion"}]]
 
@@ -711,7 +1233,14 @@
 
 "Prepares a form for an insertion operation by removing cursor markers and deletion-flagged elements."
 
-[[:code {:lang "clojure"} "(prepare-insertion '(+ a 2))\n;; => '(+ a 2)\n\n(prepare-insertion '(+ ^:+ a | ^:- b 2))\n;; => '(+ a 2)"]]
+^{:id merged-plans-slop-summary-code-query-common-tutorial-md-example-10 :added "4.0"}
+(fact "prepare-insertion example"
+  (prepare-insertion '(+ a 2))
+  => '(+ a 2)
+
+  (prepare-insertion '(+ ^:+ a | ^:- b 2))
+  => '(+ a 2)
+)
 
 [[:subsection {:title "prepare-query" :link "merged-plans-slop-summary-code-query-common-tutorial-md-prepare-query"}]]
 
@@ -719,7 +1248,11 @@
 
 "Prepares a form for a query walk by removing cursor markers, deletion-flagged, and insertion-flagged elements."
 
-[[:code {:lang "clojure"} "(prepare-query '(+ ^:+ a | ^:- b 2))\n;; => '(+ 2)"]]
+^{:id merged-plans-slop-summary-code-query-common-tutorial-md-example-11 :added "4.0"}
+(fact "prepare-query example"
+  (prepare-query '(+ ^:+ a | ^:- b 2))
+  => '(+ 2)
+)
 
 [[:subsection {:title "find-index" :link "merged-plans-slop-summary-code-query-common-tutorial-md-find-index"}]]
 
@@ -727,7 +1260,11 @@
 
 "Returns the index of the first occurrence of an element matching a predicate in a sequence."
 
-[[:code {:lang "clojure"} "(find-index #{2} '(1 2 3 4))\n;; => 1"]]
+^{:id merged-plans-slop-summary-code-query-common-tutorial-md-example-12 :added "4.0"}
+(fact "find-index example"
+  (find-index #{2} '(1 2 3 4))
+  => 1
+)
 
 [[:subsection {:title "finto" :link "merged-plans-slop-summary-code-query-common-tutorial-md-finto"}]]
 
@@ -735,7 +1272,11 @@
 
 "A version of `into` that correctly handles lists by reversing the `from` collection before `into`ing."
 
-[[:code {:lang "clojure"} "(finto () '(1 2 3))\n;; => '(1 2 3)"]]
+^{:id merged-plans-slop-summary-code-query-common-tutorial-md-example-13 :added "4.0"}
+(fact "finto example"
+  (finto () '(1 2 3))
+  => '(1 2 3)
+)
 ;; END merged documentation: plans/slop/summary/code_query_common_tutorial.md
 
 ;; BEGIN merged documentation: plans/slop/summary/code_query_compile_tutorial.md
@@ -758,7 +1299,20 @@
 
 "Finds the information related to the cursor (`|`) within a sequence of selectors (query path). It returns a vector `[index type form]` where `index` is the position, `type` is `:cursor` or `:form`, and `form` is the element if `type` is `:form`."
 
-[[:code {:lang "clojure"} "(cursor-info '[(defn ^:?& _ | & _)])\n;; => '[0 :form (defn _ | & _)]\n\n(cursor-info (expand-all-metas '[(defn ^:?& _ | & _)]))\n;; => '[0 :form (defn _ | & _)]\n\n(cursor-info '[defn if])\n;; => [nil :cursor]\n\n(cursor-info '[defn | if])\n;; => [1 :cursor]"]]
+^{:id merged-plans-slop-summary-code-query-compile-tutorial-md-example-1 :added "4.0"}
+(fact "cursor-info example"
+  (cursor-info '[(defn ^:?& _ | & _)])
+  => '[0 :form (defn _ | & _)]
+
+  (cursor-info (expand-all-metas '[(defn ^:?& _ | & _)]))
+  => '[0 :form (defn _ | & _)]
+
+  (cursor-info '[defn if])
+  => [nil :cursor]
+
+  (cursor-info '[defn | if])
+  => [1 :cursor]
+)
 
 [[:subsection {:title "expand-all-metas" :link "merged-plans-slop-summary-code-query-compile-tutorial-md-expand-all-metas"}]]
 
@@ -766,7 +1320,15 @@
 
 "Converts shorthand metadata (e.g., `^:%?`) on forms within the query path into a map-based metadata (e.g., `{:? true, :% true}`)."
 
-[[:code {:lang "clojure"} "(meta (expand-all-metas '^:%? sym?))\n;; => {:? true, :% true}\n\n(-> (expand-all-metas '(^:%+ + 1 2))\n    first meta)\n;; => {:+ true, :% true}"]]
+^{:id merged-plans-slop-summary-code-query-compile-tutorial-md-example-2 :added "4.0"}
+(fact "expand-all-metas example"
+  (meta (expand-all-metas '^:%? sym?))
+  => {:? true, :% true}
+
+  (-> (expand-all-metas '(^:%+ + 1 2))
+      first meta)
+  => {:+ true, :% true}
+)
 
 [[:subsection {:title "split-path" :link "merged-plans-slop-summary-code-query-compile-tutorial-md-split-path"}]]
 
@@ -774,7 +1336,14 @@
 
 "Splits the query path into two parts: `up` (elements before the cursor/form) and `down` (elements from the cursor/form onwards)."
 
-[[:code {:lang "clojure"} "(split-path '[defn | if try] [1 :cursor])\n;; => '{:up (defn), :down [if try]}\n\n(split-path '[defn if try] [nil :cursor])\n;; => '{:up [], :down [defn if try]}"]]
+^{:id merged-plans-slop-summary-code-query-compile-tutorial-md-example-3 :added "4.0"}
+(fact "split-path example"
+  (split-path '[defn | if try] [1 :cursor])
+  => '{:up (defn), :down [if try]}
+
+  (split-path '[defn if try] [nil :cursor])
+  => '{:up [], :down [defn if try]}
+)
 
 [[:subsection {:title "process-special" :link "merged-plans-slop-summary-code-query-compile-tutorial-md-process-special"}]]
 
@@ -782,7 +1351,17 @@
 
 "Converts special keywords (`:*`, `:n`) in the query path into a map representation (e.g., `{:type :multi}`, `{:type :nth, :step 1}`)."
 
-[[:code {:lang "clojure"} "(process-special :*)\n;; => {:type :multi}\n\n(process-special :1)\n;; => {:type :nth, :step 1}\n\n(process-special :5)\n;; => {:type :nth, :step 5}"]]
+^{:id merged-plans-slop-summary-code-query-compile-tutorial-md-example-4 :added "4.0"}
+(fact "process-special example"
+  (process-special :*)
+  => {:type :multi}
+
+  (process-special :1)
+  => {:type :nth, :step 1}
+
+  (process-special :5)
+  => {:type :nth, :step 5}
+)
 
 [[:subsection {:title "process-path" :link "merged-plans-slop-summary-code-query-compile-tutorial-md-process-path"}]]
 
@@ -790,7 +1369,18 @@
 
 "Converts a raw query path (vector of forms and special keywords) into a more structured sequence of maps, where each map describes an element or a special operation."
 
-[[:code {:lang "clojure"} "(process-path '[defn if try])\n;; => '[{:type :step, :element defn}\n;;      {:type :step, :element if}\n;;      {:type :step, :element try}]\n\n(process-path '[defn :* try :3 if])\n;; => '[{:type :step, :element defn}\n;;      {:element try, :type :multi}\n;;      {:element if, :type :nth, :step 3}]"]]
+^{:id merged-plans-slop-summary-code-query-compile-tutorial-md-example-5 :added "4.0"}
+(fact "process-path example"
+  (process-path '[defn if try])
+  => '[{:type :step, :element defn}
+          {:type :step, :element if}
+          {:type :step, :element try}]
+
+  (process-path '[defn :* try :3 if])
+  => '[{:type :step, :element defn}
+          {:element try, :type :multi}
+          {:element if, :type :nth, :step 3}]
+)
 
 [[:subsection {:title "compile-section-base" :link "merged-plans-slop-summary-code-query-compile-tutorial-md-compile-section-base"}]]
 
@@ -798,7 +1388,17 @@
 
 "Compiles a single element section of the query path into its base matching criteria (e.g., `:form`, `:pattern`, `:is`)."
 
-[[:code {:lang "clojure"} "(compile-section-base '{:element defn})\n;; => '{:form defn}\n\n(compile-section-base '{:element (if & _)}\n;; => '{:pattern (if & _)}\n\n(compile-section-base '{:element _})\n;; => {:is code.query.common/any}"]]
+^{:id merged-plans-slop-summary-code-query-compile-tutorial-md-example-6 :added "4.0"}
+(fact "compile-section-base example"
+  (compile-section-base '{:element defn})
+  => '{:form defn}
+
+  (compile-section-base '{:element (if & _)})
+  => '{:pattern (if & _)}
+
+  (compile-section-base '{:element _})
+  => {:is code.query.common/any}
+)
 
 [[:subsection {:title "compile-section" :link "merged-plans-slop-summary-code-query-compile-tutorial-md-compile-section"}]]
 
@@ -806,7 +1406,14 @@
 
 "Compiles a query section based on the traversal direction (`:up` or `:down`), previous context, and element details. It translates special types (`:multi`, `:nth`) into corresponding matching strategies (`:contains`, `:nth-ancestor`)."
 
-[[:code {:lang "clojure"} "(compile-section :up nil '{:element if, :type :nth, :step 3})\n;; => '{:nth-ancestor [3 {:form if}]}\n\n(compile-section :down nil '{:element if, :type :multi})\n;; => '{:contains {:form if}}"]]
+^{:id merged-plans-slop-summary-code-query-compile-tutorial-md-example-7 :added "4.0"}
+(fact "compile-section example"
+  (compile-section :up nil '{:element if, :type :nth, :step 3})
+  => '{:nth-ancestor [3 {:form if}]}
+
+  (compile-section :down nil '{:element if, :type :multi})
+  => '{:contains {:form if}}
+)
 
 [[:subsection {:title "compile-submap" :link "merged-plans-slop-summary-code-query-compile-tutorial-md-compile-submap"}]]
 
@@ -814,7 +1421,14 @@
 
 "Compiles a nested sub-query map based on the traversal direction and a processed path. It builds up the `:child` or `:parent` relationships in the query map."
 
-[[:code {:lang "clojure"} "(compile-submap :down (process-path '[if try]))\n;; => '{:child {:child {:form if}, :form try}}\n\n(compile-submap :up (process-path '[defn if]))\n;; => '{:parent {:parent {:form defn}, :form if}}"]]
+^{:id merged-plans-slop-summary-code-query-compile-tutorial-md-example-8 :added "4.0"}
+(fact "compile-submap example"
+  (compile-submap :down (process-path '[if try]))
+  => '{:child {:child {:form if}, :form try}}
+
+  (compile-submap :up (process-path '[defn if]))
+  => '{:parent {:parent {:form defn}, :form if}}
+)
 
 [[:subsection {:title "prepare" :link "merged-plans-slop-summary-code-query-compile-tutorial-md-prepare"}]]
 
@@ -822,7 +1436,14 @@
 
 "The main function for compiling a query. It takes a raw query path, expands metadata, splits the path, processes special elements, and returns a compiled query map along with cursor information."
 
-[[:code {:lang "clojure"} "(prepare '[defn if])\n;; => '[{:child {:form if}, :form defn} [nil :cursor]]\n\n(prepare '[defn | if])\n;; => '[{:parent {:form defn}, :form if} [1 :cursor]]"]]
+^{:id merged-plans-slop-summary-code-query-compile-tutorial-md-example-9 :added "4.0"}
+(fact "prepare example"
+  (prepare '[defn if])
+  => '[{:child {:form if}, :form defn} [nil :cursor]]
+
+  (prepare '[defn | if])
+  => '[{:parent {:form defn}, :form if} [1 :cursor]]
+)
 ;; END merged documentation: plans/slop/summary/code_query_compile_tutorial.md
 
 ;; BEGIN merged documentation: plans/slop/summary/code_query_match_tutorial.md
@@ -845,7 +1466,11 @@
 
 "Creates a `Matcher` record from a predicate function. This allows any function that takes a navigator and returns a boolean to be used as a matcher."
 
-[[:code {:lang "clojure"} "((matcher string?) \"hello\")\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-1 :added "4.0"}
+(fact "matcher example"
+  ((matcher string?) "hello")
+  => true
+)
 
 [[:subsection {:title "matcher?" :link "merged-plans-slop-summary-code-query-match-tutorial-md-matcher-2"}]]
 
@@ -853,7 +1478,11 @@
 
 "Checks if an object is a `Matcher` instance."
 
-[[:code {:lang "clojure"} "(matcher? (matcher string?))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-2 :added "4.0"}
+(fact "matcher? example"
+  (matcher? (matcher string?))
+  => true
+)
 
 [[:subsection {:title "p-fn" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-fn"}]]
 
@@ -861,7 +1490,13 @@
 
 "Creates a matcher that applies a given predicate function directly to the navigator."
 
-[[:code {:lang "clojure"} "((p-fn (fn [nav]\n           (-> nav (nav/tag) (= :symbol))))\n (nav/parse-string \"defn\"))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-3 :added "4.0"}
+(fact "p-fn example"
+  ((p-fn (fn [nav]
+             (-> nav (nav/tag) (= :symbol))))
+   (nav/parse-string "defn"))
+  => true
+)
 
 [[:subsection {:title "p-not" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-not"}]]
 
@@ -869,7 +1504,14 @@
 
 "Creates a matcher that negates the result of another matcher."
 
-[[:code {:lang "clojure"} "((p-not (p-is 'if)) (nav/parse-string \"defn\"))\n;; => true\n\n((p-not (p-is 'if)) (nav/parse-string \"if\"))\n;; => false"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-4 :added "4.0"}
+(fact "p-not example"
+  ((p-not (p-is 'if)) (nav/parse-string "defn"))
+  => true
+
+  ((p-not (p-is 'if)) (nav/parse-string "if"))
+  => false
+)
 
 [[:subsection {:title "p-is" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-is"}]]
 
@@ -877,7 +1519,20 @@
 
 "Creates a matcher that checks if the current block's value is equivalent to a given template, ignoring metadata."
 
-[[:code {:lang "clojure"} "((p-is 'defn) (nav/parse-string \"defn\"))\n;; => true\n\n((p-is '^{:a 1} defn) (nav/parse-string \"defn\"))\n;; => true\n\n((p-is 'defn) (nav/parse-string \"is\"))\n;; => false\n\n((p-is '(defn & _)) (nav/parse-string \"(defn x [])\"))\n;; => false"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-5 :added "4.0"}
+(fact "p-is example"
+  ((p-is 'defn) (nav/parse-string "defn"))
+  => true
+
+  ((p-is '^{:a 1} defn) (nav/parse-string "defn"))
+  => true
+
+  ((p-is 'defn) (nav/parse-string "is"))
+  => false
+
+  ((p-is '(defn & _)) (nav/parse-string "(defn x [])"))
+  => false
+)
 
 [[:subsection {:title "p-equal-loop" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-equal-loop"}]]
 
@@ -885,7 +1540,17 @@
 
 "A helper function for `p-equal` that recursively compares two Clojure forms for deep equality, including collection contents."
 
-[[:code {:lang "clojure"} "((p-equal [1 2 3]) (nav/parse-string \"[1 2 3]\"))\n;; => true\n\n((p-equal (list 'defn)) (nav/parse-string \"(defn)\"))\n;; => true\n\n((p-equal '(defn)) (nav/parse-string \"(defn)\"))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-6 :added "4.0"}
+(fact "p-equal-loop example"
+  ((p-equal [1 2 3]) (nav/parse-string "[1 2 3]"))
+  => true
+
+  ((p-equal (list 'defn)) (nav/parse-string "(defn)"))
+  => true
+
+  ((p-equal '(defn)) (nav/parse-string "(defn)"))
+  => true
+)
 
 [[:subsection {:title "p-equal" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-equal"}]]
 
@@ -893,7 +1558,17 @@
 
 "Creates a matcher that checks for deep equality between the current block's value and a template, including metadata."
 
-[[:code {:lang "clojure"} "((p-equal '^{:a 1} defn) (nav/parse-string \"defn\"))\n;; => false\n\n((p-equal '^{:a 1} defn) (nav/parse-string \"^{:a 1} defn\"))\n;; => true\n\n((p-equal '^{:a 1} defn) (nav/parse-string \"^{:a 2} defn\"))\n;; => false"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-7 :added "4.0"}
+(fact "p-equal example"
+  ((p-equal '^{:a 1} defn) (nav/parse-string "defn"))
+  => false
+
+  ((p-equal '^{:a 1} defn) (nav/parse-string "^{:a 1} defn"))
+  => true
+
+  ((p-equal '^{:a 1} defn) (nav/parse-string "^{:a 2} defn"))
+  => false
+)
 
 [[:subsection {:title "p-meta" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-meta"}]]
 
@@ -901,7 +1576,14 @@
 
 "Creates a matcher that checks if the metadata of the current block's parent (if it's a meta form) matches a given template."
 
-[[:code {:lang "clojure"} "((p-meta {:a 1}) (nav/down (nav/parse-string \"^{:a 1} defn\")))\n;; => true\n\n((p-meta {:a 1}) (nav/down (nav/parse-string \"^{:a 2} defn\")))\n;; => false"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-8 :added "4.0"}
+(fact "p-meta example"
+  ((p-meta {:a 1}) (nav/down (nav/parse-string "^{:a 1} defn")))
+  => true
+
+  ((p-meta {:a 1}) (nav/down (nav/parse-string "^{:a 2} defn")))
+  => false
+)
 
 [[:subsection {:title "p-type" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-type"}]]
 
@@ -909,7 +1591,14 @@
 
 "Creates a matcher that checks if the `block-tag` of the current block matches a given type keyword (e.g., `:symbol`, `:list`)."
 
-[[:code {:lang "clojure"} "((p-type :symbol) (nav/parse-string \"defn\"))\n;; => true\n\n((p-type :symbol) (-> (nav/parse-string \"^{:a 1} defn\") nav/down nav/right))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-9 :added "4.0"}
+(fact "p-type example"
+  ((p-type :symbol) (nav/parse-string "defn"))
+  => true
+
+  ((p-type :symbol) (-> (nav/parse-string "^{:a 1} defn") nav/down nav/right))
+  => true
+)
 
 [[:subsection {:title "p-form" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-form"}]]
 
@@ -917,7 +1606,13 @@
 
 "Creates a matcher that checks if the current block is a list form whose first element (the function/macro name) matches a given symbol."
 
-[[:code {:lang "clojure"} "((p-form 'defn) (nav/parse-string \"(defn x [])\"))\n;; => true\n((p-form 'let) (nav/parse-string \"(let [])\"))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-10 :added "4.0"}
+(fact "p-form example"
+  ((p-form 'defn) (nav/parse-string "(defn x [])"))
+  => true
+  ((p-form 'let) (nav/parse-string "(let [])"))
+  => true
+)
 
 [[:subsection {:title "p-pattern" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-pattern"}]]
 
@@ -925,7 +1620,15 @@
 
 "Creates a matcher that checks if the current block's value matches a complex pattern defined using Clojure forms and special query symbols (like `_`, `&`). This leverages `code.query.match.pattern`."
 
-[[:code {:lang "clojure"} "((p-pattern '(defn ^:% symbol? & _)) (nav/parse-string \"(defn ^{:a 1} x [])\"))\n;; => true\n\n((p-pattern '(defn ^:% symbol? ^{:% true :? true} string? []))\n (nav/parse-string \"(defn ^{:a 1} x [])\"))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-11 :added "4.0"}
+(fact "p-pattern example"
+  ((p-pattern '(defn ^:% symbol? & _)) (nav/parse-string "(defn ^{:a 1} x [])"))
+  => true
+
+  ((p-pattern '(defn ^:% symbol? ^{:% true :? true} string? []))
+   (nav/parse-string "(defn ^{:a 1} x [])"))
+  => true
+)
 
 [[:subsection {:title "p-code" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-code"}]]
 
@@ -933,7 +1636,11 @@
 
 "Creates a matcher that checks if the string representation of the current block matches a given regular expression."
 
-[[:code {:lang "clojure"} "((p-code #\"defn\") (nav/parse-string \"(defn ^{:a 1} x [])\"))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-12 :added "4.0"}
+(fact "p-code example"
+  ((p-code #"defn") (nav/parse-string "(defn ^{:a 1} x [])"))
+  => true
+)
 
 [[:subsection {:title "p-and" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-and"}]]
 
@@ -941,7 +1648,16 @@
 
 "Combines multiple matchers, returning `true` only if all of them match."
 
-[[:code {:lang "clojure"} "((p-and (p-code #\"defn\")\n          (p-type :token)) (nav/parse-string \"(defn ^{:a 1} x [])\"))\n;; => false\n\n((p-and (p-code #\"defn\")\n          (p-type :list)) (nav/parse-string \"(defn ^{:a 1} x [])\"))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-13 :added "4.0"}
+(fact "p-and example"
+  ((p-and (p-code #"defn")
+            (p-type :token)) (nav/parse-string "(defn ^{:a 1} x [])"))
+  => false
+
+  ((p-and (p-code #"defn")
+            (p-type :list)) (nav/parse-string "(defn ^{:a 1} x [])"))
+  => true
+)
 
 [[:subsection {:title "p-or" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-or"}]]
 
@@ -949,7 +1665,16 @@
 
 "Combines multiple matchers, returning `true` if at least one of them matches."
 
-[[:code {:lang "clojure"} "((p-or (p-code #\"defn\")\n          (p-type :token)) (nav/parse-string \"(defn ^{:a 1} x [])\"))\n;; => true\n\n((p-or (p-code #\"defn\")\n          (p-type :list)) (nav/parse-string \"(defn ^{:a 1} x [])\"))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-14 :added "4.0"}
+(fact "p-or example"
+  ((p-or (p-code #"defn")
+            (p-type :token)) (nav/parse-string "(defn ^{:a 1} x [])"))
+  => true
+
+  ((p-or (p-code #"defn")
+            (p-type :list)) (nav/parse-string "(defn ^{:a 1} x [])"))
+  => true
+)
 
 [[:subsection {:title "compile-matcher" :link "merged-plans-slop-summary-code-query-match-tutorial-md-compile-matcher"}]]
 
@@ -957,7 +1682,11 @@
 
 "The main entry point for creating complex matchers from a declarative data structure (a map, vector, symbol, or function). It recursively compiles the structure into a composite matcher."
 
-[[:code {:lang "clojure"} "((compile-matcher {:is 'hello}) (nav/parse-string \"hello\"))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-15 :added "4.0"}
+(fact "compile-matcher example"
+  ((compile-matcher {:is 'hello}) (nav/parse-string "hello"))
+  => true
+)
 
 [[:subsection {:title "p-parent" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-parent"}]]
 
@@ -965,7 +1694,17 @@
 
 "Creates a matcher that checks if the parent of the current block matches a given template."
 
-[[:code {:lang "clojure"} "((p-parent 'defn) (-> (nav/parse-string \"(defn x [])\") nav/next nav/next))\n;; => true\n\n((p-parent {:parent 'if}) (-> (nav/parse-string \"(if (= x y))\") nav/down nav/next nav/next))\n;; => true\n\n((p-parent {:parent 'if}) (-> (nav/parse-string \"(if (= x y))\") nav/down))\n;; => false"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-16 :added "4.0"}
+(fact "p-parent example"
+  ((p-parent 'defn) (-> (nav/parse-string "(defn x [])") nav/next nav/next))
+  => true
+
+  ((p-parent {:parent 'if}) (-> (nav/parse-string "(if (= x y))") nav/down nav/next nav/next))
+  => true
+
+  ((p-parent {:parent 'if}) (-> (nav/parse-string "(if (= x y))") nav/down))
+  => false
+)
 
 [[:subsection {:title "p-child" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-child"}]]
 
@@ -973,7 +1712,14 @@
 
 "Creates a matcher that checks if any child of the current container block matches a given template."
 
-[[:code {:lang "clojure"} "((p-child {:form '=}) (nav/parse-string \"(if (= x y))\"))\n;; => true\n\n((p-child '=) (nav/parse-string \"(if (= x y))\"))\n;; => false"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-17 :added "4.0"}
+(fact "p-child example"
+  ((p-child {:form '=}) (nav/parse-string "(if (= x y))"))
+  => true
+
+  ((p-child '=) (nav/parse-string "(if (= x y))"))
+  => false
+)
 
 [[:subsection {:title "p-first" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-first"}]]
 
@@ -981,7 +1727,17 @@
 
 "Creates a matcher that checks if the first element of the current container block matches a given template."
 
-[[:code {:lang "clojure"} "((p-first 'defn) (-> (nav/parse-string \"(defn x [])\")))\n;; => true\n\n((p-first 'x) (-> (nav/parse-string \"[x y z]\")))\n;; => true\n\n((p-first 'x) (-> (nav/parse-string \"[y z]\")))\n;; => false"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-18 :added "4.0"}
+(fact "p-first example"
+  ((p-first 'defn) (-> (nav/parse-string "(defn x [])")))
+  => true
+
+  ((p-first 'x) (-> (nav/parse-string "[x y z]")))
+  => true
+
+  ((p-first 'x) (-> (nav/parse-string "[y z]")))
+  => false
+)
 
 [[:subsection {:title "p-last" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-last"}]]
 
@@ -989,7 +1745,17 @@
 
 "Creates a matcher that checks if the last element of the current container block matches a given template."
 
-[[:code {:lang "clojure"} "((p-last 1) (-> (nav/parse-string \"(defn [] 1)\")))\n;; => true\n\n((p-last 'z) (-> (nav/parse-string \"[x y z]\")))\n;; => true\n\n((p-last 'x) (-> (nav/parse-string \"[y z]\")))\n;; => false"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-19 :added "4.0"}
+(fact "p-last example"
+  ((p-last 1) (-> (nav/parse-string "(defn [] 1)")))
+  => true
+
+  ((p-last 'z) (-> (nav/parse-string "[x y z]")))
+  => true
+
+  ((p-last 'x) (-> (nav/parse-string "[y z]")))
+  => false
+)
 
 [[:subsection {:title "p-nth" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-nth"}]]
 
@@ -997,7 +1763,17 @@
 
 "Creates a matcher that checks if the element at a specific Nth index within the current container block matches a given template."
 
-[[:code {:lang "clojure"} "((p-nth [0 'defn]) (-> (nav/parse-string \"(defn [] 1)\")))\n;; => true\n\n((p-nth [2 'z]) (-> (nav/parse-string \"[x y z]\")))\n;; => true\n\n((p-nth [2 'x]) (-> (nav/parse-string \"[y z]\")))\n;; => false"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-20 :added "4.0"}
+(fact "p-nth example"
+  ((p-nth [0 'defn]) (-> (nav/parse-string "(defn [] 1)")))
+  => true
+
+  ((p-nth [2 'z]) (-> (nav/parse-string "[x y z]")))
+  => true
+
+  ((p-nth [2 'x]) (-> (nav/parse-string "[y z]")))
+  => false
+)
 
 [[:subsection {:title "p-nth-left" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-nth-left"}]]
 
@@ -1005,7 +1781,14 @@
 
 "Creates a matcher that checks if the element at a specific Nth index to the left of the current position has a certain characteristic."
 
-[[:code {:lang "clojure"} "((p-nth-left [0 'defn]) (-> (nav/parse-string \"(defn [] 1)\") nav/down))\n;; => true\n\n((p-nth-left [1 ^:& vector?]) (-> (nav/parse-string \"(defn [] 1)\") nav/down nav/right-most))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-21 :added "4.0"}
+(fact "p-nth-left example"
+  ((p-nth-left [0 'defn]) (-> (nav/parse-string "(defn [] 1)") nav/down))
+  => true
+
+  ((p-nth-left [1 ^:& vector?]) (-> (nav/parse-string "(defn [] 1)") nav/down nav/right-most))
+  => true
+)
 
 [[:subsection {:title "p-nth-right" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-nth-right"}]]
 
@@ -1013,7 +1796,14 @@
 
 "Creates a matcher that checks if the element at a specific Nth index to the right of the current position has a certain characteristic."
 
-[[:code {:lang "clojure"} "((p-nth-right [0 'defn]) (-> (nav/parse-string \"(defn [] 1)\") nav/down))\n;; => true\n\n((p-nth-right [1 vector?]) (-> (nav/parse-string \"(defn [] 1)\") nav/down))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-22 :added "4.0"}
+(fact "p-nth-right example"
+  ((p-nth-right [0 'defn]) (-> (nav/parse-string "(defn [] 1)") nav/down))
+  => true
+
+  ((p-nth-right [1 vector?]) (-> (nav/parse-string "(defn [] 1)") nav/down))
+  => true
+)
 
 [[:subsection {:title "p-nth-ancestor" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-nth-ancestor"}]]
 
@@ -1021,7 +1811,13 @@
 
 "Creates a matcher that searches for a match `n` levels up in the ancestor chain."
 
-[[:code {:lang "clojure"} "((p-nth-ancestor [2 {:contains 3}])\n (-> (nav/parse-string \"(* (- (+ 1 2) 3) 4)\")\n     nav/down nav/right nav/down nav/right nav/down))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-23 :added "4.0"}
+(fact "p-nth-ancestor example"
+  ((p-nth-ancestor [2 {:contains 3}])
+   (-> (nav/parse-string "(* (- (+ 1 2) 3) 4)")
+       nav/down nav/right nav/down nav/right nav/down))
+  => true
+)
 
 [[:subsection {:title "tree-search" :link "merged-plans-slop-summary-code-query-match-tutorial-md-tree-search"}]]
 
@@ -1029,7 +1825,7 @@
 
 "A helper function for `p-contains` that recursively searches a tree structure for elements matching a predicate."
 
-[[:code {:lang "clojure"} ";; No direct test example, but used internally by p-contains."]]
+"No direct test example, but used internally by p-contains."
 
 [[:subsection {:title "p-contains" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-contains"}]]
 
@@ -1037,7 +1833,14 @@
 
 "Creates a matcher that checks if any element (deeply nested) within the current container matches a given template."
 
-[[:code {:lang "clojure"} "((p-contains '=) (nav/parse-string \"(if (= x y))\"))\n;; => true\n\n((p-contains 'x) (nav/parse-string \"(if (= x y))\"))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-25 :added "4.0"}
+(fact "p-contains example"
+  ((p-contains '=) (nav/parse-string "(if (= x y))"))
+  => true
+
+  ((p-contains 'x) (nav/parse-string "(if (= x y))"))
+  => true
+)
 
 [[:subsection {:title "tree-depth-search" :link "merged-plans-slop-summary-code-query-match-tutorial-md-tree-depth-search"}]]
 
@@ -1045,7 +1848,7 @@
 
 "A helper function for `p-nth-contains` that performs a depth-first search for a match `n` levels down in a tree structure."
 
-[[:code {:lang "clojure"} ";; No direct test example, but used internally by p-nth-contains."]]
+"No direct test example, but used internally by p-nth-contains."
 
 [[:subsection {:title "p-nth-contains" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-nth-contains"}]]
 
@@ -1053,7 +1856,12 @@
 
 "Creates a matcher that searches for a match `n` levels down in the tree."
 
-[[:code {:lang "clojure"} "((p-nth-contains [2 {:contains 1}])\n (nav/parse-string \"(* (- (+ 1 2) 3) 4)\"))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-27 :added "4.0"}
+(fact "p-nth-contains example"
+  ((p-nth-contains [2 {:contains 1}])
+   (nav/parse-string "(* (- (+ 1 2) 3) 4)"))
+  => true
+)
 
 [[:subsection {:title "p-ancestor" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-ancestor"}]]
 
@@ -1061,7 +1869,14 @@
 
 "Creates a matcher that checks if any ancestor of the current block matches a given template."
 
-[[:code {:lang "clojure"} "((p-ancestor {:form 'if}) (-> (nav/parse-string \"(if (= x y))\") nav/down nav/next nav/next))\n;; => true\n\n((p-ancestor 'if) (-> (nav/parse-string \"(if (= x y))\") nav/down nav/next nav/next))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-28 :added "4.0"}
+(fact "p-ancestor example"
+  ((p-ancestor {:form 'if}) (-> (nav/parse-string "(if (= x y))") nav/down nav/next nav/next))
+  => true
+
+  ((p-ancestor 'if) (-> (nav/parse-string "(if (= x y))") nav/down nav/next nav/next))
+  => true
+)
 
 [[:subsection {:title "p-sibling" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-sibling"}]]
 
@@ -1069,7 +1884,14 @@
 
 "Creates a matcher that checks if any element on the same level (sibling) as the current block matches a given template."
 
-[[:code {:lang "clojure"} "((p-sibling '=) (-> (nav/parse-string \"(if (= x y))\") nav/down nav/next nav/next))\n;; => false\n\n((p-sibling 'x) (-> (nav/parse-string \"(if (= x y))\") nav/down nav/next nav/next))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-29 :added "4.0"}
+(fact "p-sibling example"
+  ((p-sibling '=) (-> (nav/parse-string "(if (= x y))") nav/down nav/next nav/next))
+  => false
+
+  ((p-sibling 'x) (-> (nav/parse-string "(if (= x y))") nav/down nav/next nav/next))
+  => true
+)
 
 [[:subsection {:title "p-left" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-left"}]]
 
@@ -1077,7 +1899,14 @@
 
 "Creates a matcher that checks if the immediate left sibling of the current block matches a given template."
 
-[[:code {:lang "clojure"} "((p-left '=) (-> (nav/parse-string \"(if (= x y))\") nav/down nav/next nav/next nav/next))\n;; => true\n\n((p-left 'if) (-> (nav/parse-string \"(if (= x y))\") nav/down nav/next))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-30 :added "4.0"}
+(fact "p-left example"
+  ((p-left '=) (-> (nav/parse-string "(if (= x y))") nav/down nav/next nav/next nav/next))
+  => true
+
+  ((p-left 'if) (-> (nav/parse-string "(if (= x y))") nav/down nav/next))
+  => true
+)
 
 [[:subsection {:title "p-right" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-right"}]]
 
@@ -1085,7 +1914,14 @@
 
 "Creates a matcher that checks if the immediate right sibling of the current block matches a given template."
 
-[[:code {:lang "clojure"} "((p-right 'x) (-> (nav/parse-string \"(if (= x y))\") nav/down nav/next nav/next))\n;; => true\n\n((p-right {:form '=}) (-> (nav/parse-string \"(if (= x y))\") nav/down))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-31 :added "4.0"}
+(fact "p-right example"
+  ((p-right 'x) (-> (nav/parse-string "(if (= x y))") nav/down nav/next nav/next))
+  => true
+
+  ((p-right {:form '=}) (-> (nav/parse-string "(if (= x y))") nav/down))
+  => true
+)
 
 [[:subsection {:title "p-left-of" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-left-of"}]]
 
@@ -1093,7 +1929,14 @@
 
 "Creates a matcher that checks if any element to the left of the current block (on the same level) matches a given template."
 
-[[:code {:lang "clojure"} "((p-left-of '=) (-> (nav/parse-string \"(= x y)\") nav/down nav/next))\n;; => true\n\n((p-left-of '=) (-> (nav/parse-string \"(= x y)\") nav/down nav/next nav/next))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-32 :added "4.0"}
+(fact "p-left-of example"
+  ((p-left-of '=) (-> (nav/parse-string "(= x y)") nav/down nav/next))
+  => true
+
+  ((p-left-of '=) (-> (nav/parse-string "(= x y)") nav/down nav/next nav/next))
+  => true
+)
 
 [[:subsection {:title "p-right-of" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-right-of"}]]
 
@@ -1101,7 +1944,17 @@
 
 "Creates a matcher that checks if any element to the right of the current block (on the same level) matches a given template."
 
-[[:code {:lang "clojure"} "((p-right-of 'x) (-> (nav/parse-string \"(= x y)\") nav/down))\n;; => true\n\n((p-right-of 'y) (-> (nav/parse-string \"(= x y)\") nav/down))\n;; => true\n\n((p-right-of 'z) (-> (nav/parse-string \"(= x y)\") nav/down))\n;; => false"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-33 :added "4.0"}
+(fact "p-right-of example"
+  ((p-right-of 'x) (-> (nav/parse-string "(= x y)") nav/down))
+  => true
+
+  ((p-right-of 'y) (-> (nav/parse-string "(= x y)") nav/down))
+  => true
+
+  ((p-right-of 'z) (-> (nav/parse-string "(= x y)") nav/down))
+  => false
+)
 
 [[:subsection {:title "p-left-most" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-left-most"}]]
 
@@ -1109,7 +1962,14 @@
 
 "Creates a matcher that checks if the current block is the leftmost expression within its current level."
 
-[[:code {:lang "clojure"} "((p-left-most true) (-> (nav/parse-string \"(= x y)\") nav/down))\n;; => true\n\n((p-left-most true) (-> (nav/parse-string \"(= x y)\") nav/down nav/next))\n;; => false"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-34 :added "4.0"}
+(fact "p-left-most example"
+  ((p-left-most true) (-> (nav/parse-string "(= x y)") nav/down))
+  => true
+
+  ((p-left-most true) (-> (nav/parse-string "(= x y)") nav/down nav/next))
+  => false
+)
 
 [[:subsection {:title "p-right-most" :link "merged-plans-slop-summary-code-query-match-tutorial-md-p-right-most"}]]
 
@@ -1117,7 +1977,14 @@
 
 "Creates a matcher that checks if the current block is the rightmost expression within its current level."
 
-[[:code {:lang "clojure"} "((p-right-most true) (-> (nav/parse-string \"(= x y)\") nav/down nav/next))\n;; => false\n\n((p-right-most true) (-> (nav/parse-string \"(= x y)\") nav/down nav/next nav/next))\n;; => true"]]
+^{:id merged-plans-slop-summary-code-query-match-tutorial-md-example-35 :added "4.0"}
+(fact "p-right-most example"
+  ((p-right-most true) (-> (nav/parse-string "(= x y)") nav/down nav/next))
+  => false
+
+  ((p-right-most true) (-> (nav/parse-string "(= x y)") nav/down nav/next nav/next))
+  => true
+)
 ;; END merged documentation: plans/slop/summary/code_query_match_tutorial.md
 
 ;; BEGIN merged documentation: plans/slop/summary/code_query_summary.md
@@ -1155,7 +2022,7 @@
 
 "Creates a `clojure.zip` zipper specifically configured for traversing Clojure forms (lists and vectors) as patterns."
 
-[[:code {:lang "clojure"} ";; No direct test example, but it's used internally to create pattern navigators."]]
+"No direct test example, but it's used internally to create pattern navigators."
 
 [[:subsection {:title "wrap-meta" :link "merged-plans-slop-summary-code-query-traverse-tutorial-md-wrap-meta"}]]
 
@@ -1163,7 +2030,7 @@
 
 "A higher-order function that wraps a traversal function to handle metadata tags. It ensures that metadata forms are correctly processed during traversal."
 
-[[:code {:lang "clojure"} ";; No direct test example, but used internally by traversal functions."]]
+"No direct test example, but used internally by traversal functions."
 
 [[:subsection {:title "wrap-delete-next" :link "merged-plans-slop-summary-code-query-traverse-tutorial-md-wrap-delete-next"}]]
 
@@ -1171,7 +2038,7 @@
 
 "A wrapper function for deleting the element immediately following the current position in a zipper. Used internally by deletion traversal."
 
-[[:code {:lang "clojure"} ";; No direct test example, but used internally by deletion traversal functions."]]
+"No direct test example, but used internally by deletion traversal functions."
 
 [[:subsection {:title "traverse-delete-form" :link "merged-plans-slop-summary-code-query-traverse-tutorial-md-traverse-delete-form"}]]
 
@@ -1179,7 +2046,7 @@
 
 "Traverses a form marked for deletion, recursively applying deletion logic to its children."
 
-[[:code {:lang "clojure"} ";; No direct test example, but used internally by deletion traversal functions."]]
+"No direct test example, but used internally by deletion traversal functions."
 
 [[:subsection {:title "traverse-delete-node" :link "merged-plans-slop-summary-code-query-traverse-tutorial-md-traverse-delete-node"}]]
 
@@ -1187,7 +2054,7 @@
 
 "Handles the deletion of a single node during traversal."
 
-[[:code {:lang "clojure"} ";; No direct test example, but used internally by deletion traversal functions."]]
+"No direct test example, but used internally by deletion traversal functions."
 
 [[:subsection {:title "traverse-delete-level" :link "merged-plans-slop-summary-code-query-traverse-tutorial-md-traverse-delete-level"}]]
 
@@ -1195,7 +2062,7 @@
 
 "Traverses a level within the AST, applying deletion logic based on the pattern."
 
-[[:code {:lang "clojure"} ";; No direct test example, but used internally by deletion traversal functions."]]
+"No direct test example, but used internally by deletion traversal functions."
 
 [[:subsection {:title "prep-insert-pattern" :link "merged-plans-slop-summary-code-query-traverse-tutorial-md-prep-insert-pattern"}]]
 
@@ -1203,7 +2070,7 @@
 
 "Prepares a pattern element for insertion by removing its metadata and evaluating it if marked with `:%`."
 
-[[:code {:lang "clojure"} ";; No direct test example, but used internally by insertion traversal functions."]]
+"No direct test example, but used internally by insertion traversal functions."
 
 [[:subsection {:title "wrap-insert-next" :link "merged-plans-slop-summary-code-query-traverse-tutorial-md-wrap-insert-next"}]]
 
@@ -1211,7 +2078,7 @@
 
 "A wrapper function for inserting an element immediately following the current position in a zipper. Used internally by insertion traversal."
 
-[[:code {:lang "clojure"} ";; No direct test example, but used internally by insertion traversal functions."]]
+"No direct test example, but used internally by insertion traversal functions."
 
 [[:subsection {:title "traverse-insert-form" :link "merged-plans-slop-summary-code-query-traverse-tutorial-md-traverse-insert-form"}]]
 
@@ -1219,7 +2086,7 @@
 
 "Traverses a form marked for insertion, recursively applying insertion logic to its children."
 
-[[:code {:lang "clojure"} ";; No direct test example, but used internally by insertion traversal functions."]]
+"No direct test example, but used internally by insertion traversal functions."
 
 [[:subsection {:title "traverse-insert-node" :link "merged-plans-slop-summary-code-query-traverse-tutorial-md-traverse-insert-node"}]]
 
@@ -1227,7 +2094,7 @@
 
 "Handles the insertion of a single node during traversal."
 
-[[:code {:lang "clojure"} ";; No direct test example, but used internally by insertion traversal functions."]]
+"No direct test example, but used internally by insertion traversal functions."
 
 [[:subsection {:title "traverse-insert-level" :link "merged-plans-slop-summary-code-query-traverse-tutorial-md-traverse-insert-level"}]]
 
@@ -1235,7 +2102,7 @@
 
 "Traverses a level within the AST, applying insertion logic based on the pattern."
 
-[[:code {:lang "clojure"} ";; No direct test example, but used internally by insertion traversal functions."]]
+"No direct test example, but used internally by insertion traversal functions."
 
 [[:subsection {:title "wrap-cursor-next" :link "merged-plans-slop-summary-code-query-traverse-tutorial-md-wrap-cursor-next"}]]
 
@@ -1243,7 +2110,7 @@
 
 "A wrapper function for locating the cursor at the next element during code traversal."
 
-[[:code {:lang "clojure"} ";; No direct test example, but used internally by cursor traversal functions."]]
+"No direct test example, but used internally by cursor traversal functions."
 
 [[:subsection {:title "traverse-cursor-form" :link "merged-plans-slop-summary-code-query-traverse-tutorial-md-traverse-cursor-form"}]]
 
@@ -1251,7 +2118,7 @@
 
 "Traverses a form to locate the cursor within it."
 
-[[:code {:lang "clojure"} ";; No direct test example, but used internally by cursor traversal functions."]]
+"No direct test example, but used internally by cursor traversal functions."
 
 [[:subsection {:title "traverse-cursor-level" :link "merged-plans-slop-summary-code-query-traverse-tutorial-md-traverse-cursor-level"}]]
 
@@ -1259,7 +2126,7 @@
 
 "Traverses a level within the AST to locate the cursor."
 
-[[:code {:lang "clojure"} ";; No direct test example, but used internally by cursor traversal functions."]]
+"No direct test example, but used internally by cursor traversal functions."
 
 [[:subsection {:title "count-elements" :link "merged-plans-slop-summary-code-query-traverse-tutorial-md-count-elements"}]]
 
@@ -1267,7 +2134,7 @@
 
 "Counts the number of elements in a given code structure. Used internally for pattern matching."
 
-[[:code {:lang "clojure"} ";; No direct test example, but used internally."]]
+"No direct test example, but used internally."
 
 [[:subsection {:title "traverse" :link "merged-plans-slop-summary-code-query-traverse-tutorial-md-traverse"}]]
 
@@ -1275,7 +2142,84 @@
 
 "The main traversal function. It takes a source navigator and a pattern, and applies the transformations (insertions, deletions) defined by the pattern to the source."
 
-[[:code {:lang "clojure"} "(source\n (traverse (nav/parse-string \"^:a (+ () 2 3)\")\n           '(+ () 2 3)))\n;; => '(+ () 2 3)\n\n(source\n (traverse (nav/parse-string \"^:a (hello)\")\n           '(hello)))\n;; => '(hello)\n\n;; Deletions\n(source\n (traverse (nav/parse-string \"^:a (hello)\")\n           '(^:- hello)))\n;; => ()\n\n(source\n (traverse (nav/parse-string \"(hello)\")\n           '(^:- hello)))\n;; => ()\n\n(source\n (traverse (nav/parse-string \"((hello))\")\n           '((^:- hello))))\n;; => '(()) \n\n;; Insertions\n(source\n (traverse (nav/parse-string \"()\")\n           '(^:+ hello)))\n;; => '(hello)\n\n(source\n (traverse (nav/parse-string \"(())\")\n           '((^:+ hello))))\n;; => '((hello))\n\n;; More advanced transformations\n(source\n (traverse (nav/parse-string \"(defn hello)\")\n           '(defn ^{:? true :% true} symbol? ^:+ [])))\n;; => '(defn hello [])\n\n(source\n (traverse (nav/parse-string \"(defn hello)\")\n           '(defn ^{:? true :% true :- true} symbol? ^:+ [])))\n;; => '(defn [])\n\n(source\n (traverse (nav/parse-string \"(defn hello)\")\n           '(defn ^{:? true :% true :- true} symbol? | ^:+ [])))\n;; => []\n\n(source\n (traverse (nav/parse-string \"(defn hello \"world\" {:a 1} [])\")\n           '(defn ^:% symbol?\n              ^{:? true :% true :- true} string?\n              ^{:? true :% true :- true} map?\n              ^:% vector? & _)))\n;; => '(defn hello [])\n\n(source\n (traverse (nav/parse-string \"(defn hello [] (+ 1 1))\")\n           '(defn _ _ (+ | 1 & _))))\n;; => 1\n\n(source\n (traverse (nav/parse-string \"(defn hello [] (+ 1 1))\")\n           '(#{defn} | & _)))\n;; => 'hello\n\n(source\n (traverse (nav/parse-string \"(fact \"hello world\")\")\n           '(fact | & _)))\n;; => \"hello world\""]]
+^{:id merged-plans-slop-summary-code-query-traverse-tutorial-md-example-16 :added "4.0"}
+(fact "traverse example"
+  (source
+   (traverse (nav/parse-string "^:a (+ () 2 3)")
+             '(+ () 2 3)))
+  => '(+ () 2 3)
+
+  (source
+   (traverse (nav/parse-string "^:a (hello)")
+             '(hello)))
+  => '(hello)
+
+  ;; Deletions
+  (source
+   (traverse (nav/parse-string "^:a (hello)")
+             '(^:- hello)))
+  => ()
+
+  (source
+   (traverse (nav/parse-string "(hello)")
+             '(^:- hello)))
+  => ()
+
+  (source
+   (traverse (nav/parse-string "((hello))")
+             '((^:- hello))))
+  => '(())
+
+  ;; Insertions
+  (source
+   (traverse (nav/parse-string "()")
+             '(^:+ hello)))
+  => '(hello)
+
+  (source
+   (traverse (nav/parse-string "(())")
+             '((^:+ hello))))
+  => '((hello))
+
+  ;; More advanced transformations
+  (source
+   (traverse (nav/parse-string "(defn hello)")
+             '(defn ^{:? true :% true} symbol? ^:+ [])))
+  => '(defn hello [])
+
+  (source
+   (traverse (nav/parse-string "(defn hello)")
+             '(defn ^{:? true :% true :- true} symbol? ^:+ [])))
+  => '(defn [])
+
+  (source
+   (traverse (nav/parse-string "(defn hello)")
+             '(defn ^{:? true :% true :- true} symbol? | ^:+ [])))
+  => []
+
+  (source
+   (traverse (nav/parse-string "(defn hello "world" {:a 1} [])")
+             '(defn ^:% symbol?
+                ^{:? true :% true :- true} string?
+                ^{:? true :% true :- true} map?
+                ^:% vector? & _)))
+  => '(defn hello [])
+
+  (source
+   (traverse (nav/parse-string "(defn hello [] (+ 1 1))")
+             '(defn _ _ (+ | 1 & _))))
+  => 1
+
+  (source
+   (traverse (nav/parse-string "(defn hello [] (+ 1 1))")
+             '(#{defn} | & _)))
+  => 'hello
+
+  (source
+   (traverse (nav/parse-string "(fact "hello world")")
+             '(fact | & _)))
+  => "hello world"
+)
 
 [[:subsection {:title "source" :link "merged-plans-slop-summary-code-query-traverse-tutorial-md-source"}]]
 
@@ -1283,7 +2227,13 @@
 
 "Retrieves the final source code (Clojure form) from a traversed `Position` record."
 
-[[:code {:lang "clojure"} "(source\n (traverse (nav/parse-string \"()\")\n           '(^:+ hello)))\n;; => '(hello)"]]
+^{:id merged-plans-slop-summary-code-query-traverse-tutorial-md-example-17 :added "4.0"}
+(fact "source example"
+  (source
+   (traverse (nav/parse-string "()")
+             '(^:+ hello)))
+  => '(hello)
+)
 ;; END merged documentation: plans/slop/summary/code_query_traverse_tutorial.md
 
 ;; BEGIN merged documentation: plans/slop/summary/code_query_walk_tutorial.md
@@ -1306,7 +2256,7 @@
 
 "A higher-order function that wraps a walk function to correctly handle metadata tags. It ensures that metadata forms are properly traversed and processed."
 
-[[:code {:lang "clojure"} ";; No direct test example, but used internally by matchwalk and levelwalk."]]
+"No direct test example, but used internally by matchwalk and levelwalk."
 
 [[:subsection {:title "wrap-suppress" :link "merged-plans-slop-summary-code-query-walk-tutorial-md-wrap-suppress"}]]
 
@@ -1314,7 +2264,7 @@
 
 "A higher-order function that wraps a walk function to suppress exceptions during traversal, returning the original navigator in case of an error."
 
-[[:code {:lang "clojure"} ";; No direct test example, but used internally by matchwalk and levelwalk."]]
+"No direct test example, but used internally by matchwalk and levelwalk."
 
 [[:subsection {:title "matchwalk" :link "merged-plans-slop-summary-code-query-walk-tutorial-md-matchwalk"}]]
 
@@ -1322,7 +2272,15 @@
 
 "Performs a deep, recursive traversal of the AST. It applies a transformation function `f` to every block that matches any of the provided `matchers`."
 
-[[:code {:lang "clojure"} "(-> (matchwalk (nav/parse-string \"(+ (+ (+ 8 9)))\")\n               [(match/compile-matcher '+)]\n               (fn [nav]\n                 (-> nav nav/down (nav/replace '-) nav/up)))\n    nav/value)\n;; => '(- (- (- 8 9)))"]]
+^{:id merged-plans-slop-summary-code-query-walk-tutorial-md-example-3 :added "4.0"}
+(fact "matchwalk example"
+  (-> (matchwalk (nav/parse-string "(+ (+ (+ 8 9)))")
+                 [(match/compile-matcher '+)]
+                 (fn [nav]
+                   (-> nav nav/down (nav/replace '-) nav/up)))
+      nav/value)
+  => '(- (- (- 8 9)))
+)
 
 [[:subsection {:title "levelwalk" :link "merged-plans-slop-summary-code-query-walk-tutorial-md-levelwalk"}]]
 
@@ -1330,5 +2288,13 @@
 
 "Performs a top-level traversal of the AST. It applies a transformation function `f` only to blocks at the current level that match the provided matcher."
 
-[[:code {:lang "clojure"} "(-> (levelwalk (nav/parse-string \"(+ (+ (+ 8 9)))\")\n               [(match/compile-matcher '+)]\n               (fn [nav]\n                 (-> nav nav/down (nav/replace '-) nav/up)))\n    nav/value)\n;; => '(- (+ (+ 8 9)))"]]
+^{:id merged-plans-slop-summary-code-query-walk-tutorial-md-example-4 :added "4.0"}
+(fact "levelwalk example"
+  (-> (levelwalk (nav/parse-string "(+ (+ (+ 8 9)))")
+                 [(match/compile-matcher '+)]
+                 (fn [nav]
+                   (-> nav nav/down (nav/replace '-) nav/up)))
+      nav/value)
+  => '(- (+ (+ 8 9)))
+)
 ;; END merged documentation: plans/slop/summary/code_query_walk_tutorial.md

--- a/src-doc/documentation/std/lib_index.clj
+++ b/src-doc/documentation/std/lib_index.clj
@@ -1,4 +1,5 @@
-(ns documentation.lib-index)
+(ns documentation.lib-index
+  (:use code.test))
 
 [[:hero {:title "lib.*"
          :subtitle "Integration library documentation"
@@ -39,7 +40,24 @@
 
 "*   **Referencing Remote Entities:** A pointer can represent a function or variable that exists in a different language runtime (e.g., a Lua function from Clojure).\n*   **Unified Invocation:** Once a pointer is created, it can be invoked using standard Clojure function call syntax, with the `IApplicable` protocol handling the dispatch to the correct runtime.\n*   **Dynamic Resolution:** The `IDeref` interface allows for dynamic retrieval of the entity's value from its runtime.\n*   **Abstraction:** Pointers abstract away the complexities of inter-runtime communication, allowing developers to work with foreign entities as if they were local Clojure objects."
 
-[[:code {:lang "clojure"} ";; Example (conceptual, assuming a 'lua' context is set up)\n(require '[std.lib.context.pointer :as p])\n(require '[std.lib.context.space :as space])\n\n;; Assume a Lua runtime is active in the current space\n(space/space:rt-current :lua) ; => <LuaRuntimeInstance>\n\n;; Create a pointer to a Lua function named 'my-lua-add'\n(def lua-add (p/pointer {:context :lua :id 'my-lua-add}))\n\n;; Invoke the Lua function through the pointer\n(lua-add 10 20) ; This would internally call -invoke-ptr on the Lua runtime\n\n;; Dereference the pointer (if it refers to a value)\n;; @lua-add ; This would internally call -deref-ptr on the Lua runtime"]]
+^{:id merged-plans-slop-summary-std-lib-context-pointer-summary-md-example-1 :added "4.0"}
+(fact "Usage Pattern: example"
+  ;; Example (conceptual, assuming a 'lua' context is set up)
+  (require '[std.lib.context.pointer :as p])
+  (require '[std.lib.context.space :as space])
+
+  ;; Assume a Lua runtime is active in the current space
+  (space/space:rt-current :lua) ; => <LuaRuntimeInstance>
+
+  ;; Create a pointer to a Lua function named 'my-lua-add'
+  (def lua-add (p/pointer {:context :lua :id 'my-lua-add}))
+
+  ;; Invoke the Lua function through the pointer
+  (lua-add 10 20) ; This would internally call -invoke-ptr on the Lua runtime
+
+  ;; Dereference the pointer (if it refers to a value)
+  ;; @lua-add ; This would internally call -deref-ptr on the Lua runtime
+)
 
 "By providing a flexible and protocol-driven mechanism for referencing and interacting with entities across different execution contexts, `std.lib.context.pointer` is a cornerstone of the `foundation-base` project's multi-language capabilities."
 ;; END merged documentation: plans/slop/summary/std_lib_context_pointer_summary.md

--- a/src-doc/documentation/std/std_block.clj
+++ b/src-doc/documentation/std/std_block.clj
@@ -2075,7 +2075,7 @@
 
 ^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-1 :added "4.0"}
 (fact "read-dispatch example"
-  (read-dispatch \tab)
+  (read-dispatch (char 9))
   => :void
 
   (read-dispatch (first "#"))

--- a/src-doc/documentation/std/std_block.clj
+++ b/src-doc/documentation/std/std_block.clj
@@ -2090,11 +2090,10 @@
 
 ^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-2 :added "4.0"}
 (fact "-parse example"
-  (base/block-info (-parse (reader/create ":a")))
-  => {:type :token, :tag :keyword, :string ":a", :height 0, :width 2}
-
-  (base/block-info (-parse (reader/create "\"\\n\"")))
-  => {:type :token, :tag :string, :string "\"\\n\"", :height 1, :width 1}
+  [(base/block-info (-parse (reader/create ":a")))
+   (base/block-info (-parse (reader/create "\"\\n\"")))]
+  => [{:type :token, :tag :keyword, :string ":a", :height 0, :width 2}
+      {:type :token, :tag :string, :string "\"\\n\"", :height 1, :width 1}]
 )
 
 [[:subsection {:title "parse-void" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-parse-void"}]]
@@ -3086,8 +3085,9 @@
 
 ^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-20 :added "4.0"}
 (fact "modifier-block example"
-  (modifier-block :hash-uneval "#_" (fn [acc _] acc))
-  => #std.block.type.ModifierBlock{:tag :hash-uneval, :string "#_", :command #function[...]}
+  (select-keys (modifier-block :hash-uneval "#_" (fn [acc _] acc))
+               [:tag :string])
+  => {:tag :hash-uneval, :string "#_"}
 )
 ;; END merged documentation: plans/slop/summary/std_block_type_tutorial.md
 

--- a/src-doc/documentation/std/std_block.clj
+++ b/src-doc/documentation/std/std_block.clj
@@ -21,7 +21,7 @@
 "Most Clojure readers discard formatting when they turn source into data. `read-string` gives you values, but it loses comments, extra spaces, and reader macros. `std.block` keeps those details as first-class nodes so code can be analyzed, transformed, and printed back out without destroying the programmer's formatting."
 
 (fact "read-string loses whitespace; std.block keeps it"
-  
+
   (-> (parse/parse-string "[1   2]")
       str)
   => "[1   2]")
@@ -1040,7 +1040,14 @@
 
 "Checks whether an object is an `IBlock` instance."
 
-[[:code {:lang "clojure"} "(block? (construct/void nil))\n;; => true\n\n(block? (construct/token \"hello\"))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-base-tutorial-md-example-1 :added "4.0"}
+(fact "block? example"
+  (block? (construct/void nil))
+  => true
+
+  (block? (construct/token "hello"))
+  => true
+)
 
 [[:subsection {:title "block-type" :link "merged-plans-slop-summary-std-block-base-tutorial-md-block-type"}]]
 
@@ -1048,7 +1055,14 @@
 
 "Returns the block's type as a keyword (e.g., `:void`, `:token`, `:container`)."
 
-[[:code {:lang "clojure"} "(block-type (construct/void nil))\n;; => :void\n\n(block-type (construct/token \"hello\"))\n;; => :token"]]
+^{:id merged-plans-slop-summary-std-block-base-tutorial-md-example-2 :added "4.0"}
+(fact "block-type example"
+  (block-type (construct/void nil))
+  => :void
+
+  (block-type (construct/token "hello"))
+  => :token
+)
 
 [[:subsection {:title "block-tag" :link "merged-plans-slop-summary-std-block-base-tutorial-md-block-tag"}]]
 
@@ -1056,7 +1070,14 @@
 
 "Returns the block's specific tag as a keyword (e.g., `:eof`, `:linespace`, `:symbol`)."
 
-[[:code {:lang "clojure"} "(block-tag (construct/void nil))\n;; => :eof\n\n(block-tag (construct/void \\space))\n;; => :linespace"]]
+^{:id merged-plans-slop-summary-std-block-base-tutorial-md-example-3 :added "4.0"}
+(fact "block-tag example"
+  (block-tag (construct/void nil))
+  => :eof
+
+  (block-tag (construct/void \space))
+  => :linespace
+)
 
 [[:subsection {:title "block-string" :link "merged-plans-slop-summary-std-block-base-tutorial-md-block-string"}]]
 
@@ -1064,7 +1085,14 @@
 
 "Returns the raw string representation of the block as it would appear in the source file."
 
-[[:code {:lang "clojure"} "(block-string (construct/token 3/4))\n;; => \"3/4\"\n\n(block-string (construct/void \\space))\n;; => \" \""]]
+^{:id merged-plans-slop-summary-std-block-base-tutorial-md-example-4 :added "4.0"}
+(fact "block-string example"
+  (block-string (construct/token 3/4))
+  => "3/4"
+
+  (block-string (construct/void \space))
+  => " "
+)
 
 [[:subsection {:title "block-length" :link "merged-plans-slop-summary-std-block-base-tutorial-md-block-length"}]]
 
@@ -1072,7 +1100,15 @@
 
 "Returns the total character length of the block's string representation."
 
-[[:code {:lang "clojure"} "(block-length (construct/void))\n;; => 1\n\n(block-length (construct/block [1 2 3 4]))\n;; => 9\n;; (e.g., \"[1 2 3 4]\")"]]
+^{:id merged-plans-slop-summary-std-block-base-tutorial-md-example-5 :added "4.0"}
+(fact "block-length example"
+  (block-length (construct/void))
+  => 1
+
+  (block-length (construct/block [1 2 3 4]))
+  => 9
+  ;; (e.g., "[1 2 3 4]")
+)
 
 [[:subsection {:title "block-width" :link "merged-plans-slop-summary-std-block-base-tutorial-md-block-width"}]]
 
@@ -1080,7 +1116,11 @@
 
 "Returns the visual width of the block (number of characters on a single line)."
 
-[[:code {:lang "clojure"} "(block-width (construct/token 'hello))\n;; => 5"]]
+^{:id merged-plans-slop-summary-std-block-base-tutorial-md-example-6 :added "4.0"}
+(fact "block-width example"
+  (block-width (construct/token 'hello))
+  => 5
+)
 
 [[:subsection {:title "block-height" :link "merged-plans-slop-summary-std-block-base-tutorial-md-block-height"}]]
 
@@ -1088,7 +1128,13 @@
 
 "Returns the height of the block (number of lines it spans)."
 
-[[:code {:lang "clojure"} "(block-height (construct/block\n               ^:list [(construct/newline)\n                       (construct/newline)]))\n;; => 2"]]
+^{:id merged-plans-slop-summary-std-block-base-tutorial-md-example-7 :added "4.0"}
+(fact "block-height example"
+  (block-height (construct/block
+                 ^:list [(construct/newline)
+                         (construct/newline)]))
+  => 2
+)
 
 [[:subsection {:title "block-prefixed" :link "merged-plans-slop-summary-std-block-base-tutorial-md-block-prefixed"}]]
 
@@ -1096,7 +1142,12 @@
 
 "Returns the length of any starting characters (e.g., `(` for a list, `[` for a vector)."
 
-[[:code {:lang "clojure"} "(block-prefixed (construct/block #{}))\n;; => 2\n;; (e.g., for a set like #{})"]]
+^{:id merged-plans-slop-summary-std-block-base-tutorial-md-example-8 :added "4.0"}
+(fact "block-prefixed example"
+  (block-prefixed (construct/block #{}))
+  => 2
+  ;; (e.g., for a set like #{})
+)
 
 [[:subsection {:title "block-suffixed" :link "merged-plans-slop-summary-std-block-base-tutorial-md-block-suffixed"}]]
 
@@ -1104,7 +1155,12 @@
 
 "Returns the length of any ending characters (e.g., `)` for a list, `]` for a vector)."
 
-[[:code {:lang "clojure"} "(block-suffixed (construct/block #{}))\n;; => 1\n;; (e.g., for a set like #{})"]]
+^{:id merged-plans-slop-summary-std-block-base-tutorial-md-example-9 :added "4.0"}
+(fact "block-suffixed example"
+  (block-suffixed (construct/block #{}))
+  => 1
+  ;; (e.g., for a set like #{})
+)
 
 [[:subsection {:title "block-verify" :link "merged-plans-slop-summary-std-block-base-tutorial-md-block-verify"}]]
 
@@ -1112,7 +1168,13 @@
 
 "Checks that the block has correct internal data and structure."
 
-[[:code {:lang "clojure"} ";; Example from test code, but no direct assertion provided.\n;; This function likely returns true for valid blocks.\n;; (block-verify (construct/token \"valid\"))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-base-tutorial-md-example-10 :added "4.0"}
+(fact "block-verify example"
+  Example from test code, but no direct assertion provided.
+  This function likely returns true for valid blocks.
+  (block-verify (construct/token "valid"))
+  => true
+)
 
 [[:subsection {:title "expression?" :link "merged-plans-slop-summary-std-block-base-tutorial-md-expression"}]]
 
@@ -1120,7 +1182,11 @@
 
 "Checks if the block has a Clojure value associated with it (i.e., implements `IBlockExpression`)."
 
-[[:code {:lang "clojure"} "(expression? (construct/token 1.2))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-base-tutorial-md-example-11 :added "4.0"}
+(fact "expression? example"
+  (expression? (construct/token 1.2))
+  => true
+)
 
 [[:subsection {:title "block-value" :link "merged-plans-slop-summary-std-block-base-tutorial-md-block-value"}]]
 
@@ -1128,7 +1194,11 @@
 
 "Returns the actual Clojure value represented by an expression block."
 
-[[:code {:lang "clojure"} "(block-value (construct/token 1.2))\n;; => 1.2"]]
+^{:id merged-plans-slop-summary-std-block-base-tutorial-md-example-12 :added "4.0"}
+(fact "block-value example"
+  (block-value (construct/token 1.2))
+  => 1.2
+)
 
 [[:subsection {:title "block-value-string" :link "merged-plans-slop-summary-std-block-base-tutorial-md-block-value-string"}]]
 
@@ -1136,7 +1206,11 @@
 
 "Returns the string representation from which the block's value was generated. This can differ from `block-string` for special forms."
 
-[[:code {:lang "clojure"} "(block-value-string (parse/parse-string \"#(+ 1 ::2)\"))\n;; => \"#(+ 1 (keyword \":2\"))\""]]
+^{:id merged-plans-slop-summary-std-block-base-tutorial-md-example-13 :added "4.0"}
+(fact "block-value-string example"
+  (block-value-string (parse/parse-string "#(+ 1 ::2)"))
+  => "#(+ 1 (keyword ":2"))"
+)
 
 [[:subsection {:title "modifier?" :link "merged-plans-slop-summary-std-block-base-tutorial-md-modifier"}]]
 
@@ -1144,7 +1218,11 @@
 
 "Checks if the block is of type `IBlockModifier`."
 
-[[:code {:lang "clojure"} "(modifier? (construct/uneval))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-base-tutorial-md-example-14 :added "4.0"}
+(fact "modifier? example"
+  (modifier? (construct/uneval))
+  => true
+)
 
 [[:subsection {:title "block-modify" :link "merged-plans-slop-summary-std-block-base-tutorial-md-block-modify"}]]
 
@@ -1152,7 +1230,11 @@
 
 "Allows a modifier block to modify an accumulator. Used in parsing and transformation."
 
-[[:code {:lang "clojure"} "(block-modify (construct/uneval) [1 2] 'ANYTHING)\n;; => [1 2]"]]
+^{:id merged-plans-slop-summary-std-block-base-tutorial-md-example-15 :added "4.0"}
+(fact "block-modify example"
+  (block-modify (construct/uneval) [1 2] 'ANYTHING)
+  => [1 2]
+)
 
 [[:subsection {:title "container?" :link "merged-plans-slop-summary-std-block-base-tutorial-md-container"}]]
 
@@ -1160,7 +1242,14 @@
 
 "Determines whether a block has children (i.e., implements `IBlockContainer`)."
 
-[[:code {:lang "clojure"} "(container? (parse/parse-string \"[1 2 3]\"))\n;; => true\n\n(container? (parse/parse-string \" \"))\n;; => false"]]
+^{:id merged-plans-slop-summary-std-block-base-tutorial-md-example-16 :added "4.0"}
+(fact "container? example"
+  (container? (parse/parse-string "[1 2 3]"))
+  => true
+
+  (container? (parse/parse-string " "))
+  => false
+)
 
 [[:subsection {:title "block-children" :link "merged-plans-slop-summary-std-block-base-tutorial-md-block-children"}]]
 
@@ -1168,7 +1257,12 @@
 
 "Returns a sequence of child blocks within a container block."
 
-[[:code {:lang "clojure"} "(->> (block-children (parse/parse-string \"[1   2]\"))\n     (map block-string))\n;; => (\"1\" \"   \" \"2\")"]]
+^{:id merged-plans-slop-summary-std-block-base-tutorial-md-example-17 :added "4.0"}
+(fact "block-children example"
+  (->> (block-children (parse/parse-string "[1   2]"))
+       (map block-string))
+  => ("1" "   " "2")
+)
 
 [[:subsection {:title "replace-children" :link "merged-plans-slop-summary-std-block-base-tutorial-md-replace-children"}]]
 
@@ -1176,7 +1270,15 @@
 
 "Replaces the children of a container block with a new sequence of children."
 
-[[:code {:lang "clojure"} "(->> (replace-children (construct/block [])\n                       (conj (vec (block-children (construct/block [1 2]))) \n                             (construct/void \\space)\n                             (construct/block [3 4])))\n     str)\n;; => \"[1 2 [3 4]]\""]]
+^{:id merged-plans-slop-summary-std-block-base-tutorial-md-example-18 :added "4.0"}
+(fact "replace-children example"
+  (->> (replace-children (construct/block [])
+                         (conj (vec (block-children (construct/block [1 2])))
+                               (construct/void \space)
+                               (construct/block [3 4])))
+       str)
+  => "[1 2 [3 4]]"
+)
 
 [[:subsection {:title "block-info" :link "merged-plans-slop-summary-std-block-base-tutorial-md-block-info"}]]
 
@@ -1184,7 +1286,14 @@
 
 "Returns a map containing basic information about the block, including its type, tag, string, height, and width."
 
-[[:code {:lang "clojure"} "(block-info (construct/token true))\n;; => {:type :token, :tag :boolean, :string \"true\", :height 0, :width 4}\n\n(block-info (construct/void \\tab))\n;; => {:type :void, :tag :linetab, :string \"\\t\", :height 0, :width 4}"]]
+^{:id merged-plans-slop-summary-std-block-base-tutorial-md-example-19 :added "4.0"}
+(fact "block-info example"
+  (block-info (construct/token true))
+  => {:type :token, :tag :boolean, :string "true", :height 0, :width 4}
+
+  (block-info (construct/void \tab))
+  => {:type :void, :tag :linetab, :string "\t", :height 0, :width 4}
+)
 ;; END merged documentation: plans/slop/summary/std_block_base_tutorial.md
 
 ;; BEGIN merged documentation: plans/slop/summary/std_block_check_tutorial.md
@@ -1207,7 +1316,14 @@
 
 "Returns `true` if a character is considered a boundary character in Clojure syntax."
 
-[[:code {:lang "clojure"} "(boundary? (first \"[\"))\n;; => true\n\n(boundary? (first \"\"\"))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-check-tutorial-md-example-1 :added "4.0"}
+(fact "boundary? example"
+  (boundary? (first "["))
+  => true
+
+  (boundary? (first "\""))
+  => true
+)
 
 [[:subsection {:title "whitespace?" :link "merged-plans-slop-summary-std-block-check-tutorial-md-whitespace"}]]
 
@@ -1215,7 +1331,11 @@
 
 "Returns `true` if a character is a whitespace character (including spaces, tabs, newlines)."
 
-[[:code {:lang "clojure"} "(whitespace? \\space)\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-check-tutorial-md-example-2 :added "4.0"}
+(fact "whitespace? example"
+  (whitespace? \space)
+  => true
+)
 
 [[:subsection {:title "comma?" :link "merged-plans-slop-summary-std-block-check-tutorial-md-comma"}]]
 
@@ -1223,7 +1343,11 @@
 
 "Returns `true` if a character is a comma."
 
-[[:code {:lang "clojure"} "(comma? (first \",\"))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-check-tutorial-md-example-3 :added "4.0"}
+(fact "comma? example"
+  (comma? (first ","))
+  => true
+)
 
 [[:subsection {:title "linebreak?" :link "merged-plans-slop-summary-std-block-check-tutorial-md-linebreak"}]]
 
@@ -1231,7 +1355,11 @@
 
 "Returns `true` if a character is a linebreak character."
 
-[[:code {:lang "clojure"} "(linebreak? \\newline)\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-check-tutorial-md-example-4 :added "4.0"}
+(fact "linebreak? example"
+  (linebreak? \newline)
+  => true
+)
 
 [[:subsection {:title "delimiter?" :link "merged-plans-slop-summary-std-block-check-tutorial-md-delimiter"}]]
 
@@ -1239,7 +1367,11 @@
 
 "Returns `true` if a character is a collection delimiter (e.g., `(`, `)`, `[`, `]`, `{`, `}`)."
 
-[[:code {:lang "clojure"} "(delimiter? (first \")\"))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-check-tutorial-md-example-5 :added "4.0"}
+(fact "delimiter? example"
+  (delimiter? (first ")"))
+  => true
+)
 
 [[:subsection {:title "voidspace?" :link "merged-plans-slop-summary-std-block-check-tutorial-md-voidspace"}]]
 
@@ -1247,7 +1379,11 @@
 
 "Determines if an input character represents a \"void space\" (whitespace or comma)."
 
-[[:code {:lang "clojure"} "(voidspace? \\newline)\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-check-tutorial-md-example-6 :added "4.0"}
+(fact "voidspace? example"
+  (voidspace? \newline)
+  => true
+)
 
 [[:subsection {:title "linetab?" :link "merged-plans-slop-summary-std-block-check-tutorial-md-linetab"}]]
 
@@ -1255,7 +1391,11 @@
 
 "Checks if a character is a tab character."
 
-[[:code {:lang "clojure"} "(linetab? (first \"\\t\"))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-check-tutorial-md-example-7 :added "4.0"}
+(fact "linetab? example"
+  (linetab? (first "\t"))
+  => true
+)
 
 [[:subsection {:title "linespace?" :link "merged-plans-slop-summary-std-block-check-tutorial-md-linespace"}]]
 
@@ -1263,7 +1403,11 @@
 
 "Returns `true` if a character is a whitespace character that is *not* a linebreak or a tab."
 
-[[:code {:lang "clojure"} "(linespace? \\space)\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-check-tutorial-md-example-8 :added "4.0"}
+(fact "linespace? example"
+  (linespace? \space)
+  => true
+)
 
 [[:subsection {:title "voidspace-or-boundary?" :link "merged-plans-slop-summary-std-block-check-tutorial-md-voidspace-or-boundary"}]]
 
@@ -1271,7 +1415,13 @@
 
 "Checks if a character is either a void space or a boundary character."
 
-[[:code {:lang "clojure"} "(->> (map voidspace-or-boundary? (concat *boundaries*\n                                         *linebreaks*))\n     (every? true?))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-check-tutorial-md-example-9 :added "4.0"}
+(fact "voidspace-or-boundary? example"
+  (->> (map voidspace-or-boundary? (concat *boundaries*
+                                           *linebreaks*))
+       (every? true?))
+  => true
+)
 
 [[:subsection {:title "tag" :link "merged-plans-slop-summary-std-block-check-tutorial-md-tag"}]]
 
@@ -1279,7 +1429,14 @@
 
 "Takes a map of checks (predicate functions) and an input, returning the tag (key) of the first predicate that returns `true`."
 
-[[:code {:lang "clojure"} "(tag *void-checks* \\space)\n;; => :linespace\n\n(tag *collection-checks* [])\n;; => :vector"]]
+^{:id merged-plans-slop-summary-std-block-check-tutorial-md-example-10 :added "4.0"}
+(fact "tag example"
+  (tag *void-checks* \space)
+  => :linespace
+
+  (tag *collection-checks* [])
+  => :vector
+)
 
 [[:subsection {:title "void-tag" :link "merged-plans-slop-summary-std-block-check-tutorial-md-void-tag"}]]
 
@@ -1287,7 +1444,11 @@
 
 "Returns the void tag associated with a character (e.g., `:linebreak` for `\\newline`)."
 
-[[:code {:lang "clojure"} "(void-tag \\newline)\n;; => :linebreak"]]
+^{:id merged-plans-slop-summary-std-block-check-tutorial-md-example-11 :added "4.0"}
+(fact "void-tag example"
+  (void-tag \newline)
+  => :linebreak
+)
 
 [[:subsection {:title "void?" :link "merged-plans-slop-summary-std-block-check-tutorial-md-void"}]]
 
@@ -1295,7 +1456,11 @@
 
 "Determines if a character corresponds to a void block type."
 
-[[:code {:lang "clojure"} "(void? \\newline)\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-check-tutorial-md-example-12 :added "4.0"}
+(fact "void? example"
+  (void? \newline)
+  => true
+)
 
 [[:subsection {:title "token-tag" :link "merged-plans-slop-summary-std-block-check-tutorial-md-token-tag"}]]
 
@@ -1303,7 +1468,11 @@
 
 "Returns the token tag associated with a Clojure form (e.g., `:symbol` for a symbol, `:boolean` for `true`)."
 
-[[:code {:lang "clojure"} "(token-tag 'hello)\n;; => :symbol"]]
+^{:id merged-plans-slop-summary-std-block-check-tutorial-md-example-13 :added "4.0"}
+(fact "token-tag example"
+  (token-tag 'hello)
+  => :symbol
+)
 
 [[:subsection {:title "token?" :link "merged-plans-slop-summary-std-block-check-tutorial-md-token"}]]
 
@@ -1311,7 +1480,11 @@
 
 "Determines if a Clojure form is a token type."
 
-[[:code {:lang "clojure"} "(token? 3/4)\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-check-tutorial-md-example-14 :added "4.0"}
+(fact "token? example"
+  (token? 3/4)
+  => true
+)
 
 [[:subsection {:title "collection-tag" :link "merged-plans-slop-summary-std-block-check-tutorial-md-collection-tag"}]]
 
@@ -1319,7 +1492,11 @@
 
 "Returns the collection tag associated with a Clojure form (e.g., `:vector` for `[]`, `:map` for `{}`)."
 
-[[:code {:lang "clojure"} "(collection-tag [])\n;; => :vector"]]
+^{:id merged-plans-slop-summary-std-block-check-tutorial-md-example-15 :added "4.0"}
+(fact "collection-tag example"
+  (collection-tag [])
+  => :vector
+)
 
 [[:subsection {:title "collection?" :link "merged-plans-slop-summary-std-block-check-tutorial-md-collection"}]]
 
@@ -1327,7 +1504,11 @@
 
 "Determines if a Clojure form is a collection type."
 
-[[:code {:lang "clojure"} "(collection? {})\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-check-tutorial-md-example-16 :added "4.0"}
+(fact "collection? example"
+  (collection? {})
+  => true
+)
 
 [[:subsection {:title "comment?" :link "merged-plans-slop-summary-std-block-check-tutorial-md-comment"}]]
 
@@ -1335,7 +1516,14 @@
 
 "Determines if a string is a comment (starts with `;`)."
 
-[[:code {:lang "clojure"} "(comment? \"hello\")\n;; => false\n\n(comment? \";hello\")\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-check-tutorial-md-example-17 :added "4.0"}
+(fact "comment? example"
+  (comment? "hello")
+  => false
+
+  (comment? ";hello")
+  => true
+)
 ;; END merged documentation: plans/slop/summary/std_block_check_tutorial.md
 
 ;; BEGIN merged documentation: plans/slop/summary/std_block_construct_tutorial.md
@@ -1358,7 +1546,14 @@
 
 "Creates a void block. Void blocks represent non-code elements like spaces, newlines, or comments."
 
-[[:code {:lang "clojure"} "(str (void))\n;; => \"␣\"\n\n(str (void \\newline))\n;; => \"\\n\""]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-1 :added "4.0"}
+(fact "void example"
+  (str (void))
+  => "␣"
+
+  (str (void \newline))
+  => "\n"
+)
 
 [[:subsection {:title "space" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-space"}]]
 
@@ -1366,7 +1561,11 @@
 
 "Creates a single space block."
 
-[[:code {:lang "clojure"} "(str (space))\n;; => \"␣\""]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-2 :added "4.0"}
+(fact "space example"
+  (str (space))
+  => "␣"
+)
 
 [[:subsection {:title "spaces" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-spaces"}]]
 
@@ -1374,7 +1573,11 @@
 
 "Creates a sequence of `n` space blocks."
 
-[[:code {:lang "clojure"} "(apply str (spaces 5))\n;; => \"␣␣␣␣␣\""]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-3 :added "4.0"}
+(fact "spaces example"
+  (apply str (spaces 5))
+  => "␣␣␣␣␣"
+)
 
 [[:subsection {:title "tab" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-tab"}]]
 
@@ -1382,7 +1585,11 @@
 
 "Creates a single tab block."
 
-[[:code {:lang "clojure"} "(str (tab))\n;; => \"\\t\""]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-4 :added "4.0"}
+(fact "tab example"
+  (str (tab))
+  => "\t"
+)
 
 [[:subsection {:title "tabs" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-tabs"}]]
 
@@ -1390,7 +1597,11 @@
 
 "Creates a sequence of `n` tab blocks."
 
-[[:code {:lang "clojure"} "(apply str (tabs 5))\n;; => \"\\t\\t\\t\\t\\t\""]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-5 :added "4.0"}
+(fact "tabs example"
+  (apply str (tabs 5))
+  => "\t\t\t\t\t"
+)
 
 [[:subsection {:title "newline" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-newline"}]]
 
@@ -1398,7 +1609,11 @@
 
 "Creates a single newline block."
 
-[[:code {:lang "clojure"} "(str (newline))\n;; => \"\\n\""]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-6 :added "4.0"}
+(fact "newline example"
+  (str (newline))
+  => "\n"
+)
 
 [[:subsection {:title "newlines" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-newlines"}]]
 
@@ -1406,7 +1621,11 @@
 
 "Creates a sequence of `n` newline blocks."
 
-[[:code {:lang "clojure"} "(apply str (newlines 5))\n;; => \"\\n\\n\\n\\n\\n\""]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-7 :added "4.0"}
+(fact "newlines example"
+  (apply str (newlines 5))
+  => "\n\n\n\n\n"
+)
 
 [[:subsection {:title "comment" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-comment"}]]
 
@@ -1414,7 +1633,15 @@
 
 "Creates a comment block from a string. The string must start with `;`."
 
-[[:code {:lang "clojure"} "(str (comment \";hello\"))\n;; => \";hello\"\n\n;; Throws exception if string is not a valid comment\n;; (str (comment \"hello\"))\n;; => ExceptionInfo: \"Not a valid comment string.\""]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-8 :added "4.0"}
+(fact "comment example"
+  (str (comment ";hello"))
+  => ";hello"
+
+  ;; Throws exception if string is not a valid comment
+  (str (comment "hello"))
+  => (throws clojure.lang.ExceptionInfo "Not a valid comment string.")
+)
 
 [[:subsection {:title "token-dimensions" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-token-dimensions"}]]
 
@@ -1422,7 +1649,14 @@
 
 "Returns the `[width height]` of a token based on its tag and string representation."
 
-[[:code {:lang "clojure"} "(token-dimensions :regexp \"#\\\"hello\\nworld\\\"\")\n;; => [6 1]\n\n(token-dimensions :regexp \"#\\\"hello\\nworld\\n\\\"\")\n;; => [15 0]"]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-9 :added "4.0"}
+(fact "token-dimensions example"
+  (token-dimensions :regexp "#\"hello\nworld\"")
+  => [6 1]
+
+  (token-dimensions :regexp "#\"hello\nworld\n\"")
+  => [15 0]
+)
 
 [[:subsection {:title "string-token" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-string-token"}]]
 
@@ -1430,7 +1664,14 @@
 
 "Constructs a token block specifically for Clojure string literals, including quotes and handling newlines within the string."
 
-[[:code {:lang "clojure"} "(str (string-token \"hello\"))\n;; => \"\\\"hello\\\"\"\n\n(str (string-token \"hello\\nworld\"))\n;; => \"\\\"hello\\\\nworld\\\"\""]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-10 :added "4.0"}
+(fact "string-token example"
+  (str (string-token "hello"))
+  => "\"hello\""
+
+  (str (string-token "hello\nworld"))
+  => "\"hello\\nworld\""
+)
 
 [[:subsection {:title "token" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-token"}]]
 
@@ -1438,7 +1679,14 @@
 
 "Creates a token block from a Clojure form (symbol, number, keyword, etc.). It automatically determines the correct tag and string representation."
 
-[[:code {:lang "clojure"} "(str (token 'abc))\n;; => \"abc\"\n\n(str (token 123))\n;; => \"123\""]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-11 :added "4.0"}
+(fact "token example"
+  (str (token 'abc))
+  => "abc"
+
+  (str (token 123))
+  => "123"
+)
 
 [[:subsection {:title "token-from-string" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-token-from-string"}]]
 
@@ -1446,7 +1694,14 @@
 
 "Creates a token block by reading a string input. This is useful for creating tokens from raw text."
 
-[[:code {:lang "clojure"} "(str (token-from-string \"abc\"))\n;; => \"abc\"\n\n(str (token-from-string \"123\"))\n;; => \"123\""]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-12 :added "4.0"}
+(fact "token-from-string example"
+  (str (token-from-string "abc"))
+  => "abc"
+
+  (str (token-from-string "123"))
+  => "123"
+)
 
 [[:subsection {:title "container-checks" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-container-checks"}]]
 
@@ -1454,7 +1709,12 @@
 
 "Performs validation checks for a container block based on its tag, children, and properties. This is an internal helper."
 
-[[:code {:lang "clojure"} ";; No direct test example, but it ensures validity of container construction.\n;; (container-checks :list [(token 1)] {:cons 1})\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-13 :added "4.0"}
+(fact "container-checks example"
+  ;; No direct test example, but it ensures validity of container construction.
+  (container-checks :list [(token 1)] {:cons 1})
+  => true
+)
 
 [[:subsection {:title "container" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-container"}]]
 
@@ -1462,7 +1722,14 @@
 
 "Creates a container block (e.g., list, vector, map, set). It takes a tag and a sequence of child blocks."
 
-[[:code {:lang "clojure"} "(str (container :list [(void) (void)]))\n;; => \"(  )\"\n\n(str (container :vector [(token 1) (space) (token 2)]))\n;; => \"[1 2]\""]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-14 :added "4.0"}
+(fact "container example"
+  (str (container :list [(void) (void)]))
+  => "(  )"
+
+  (str (container :vector [(token 1) (space) (token 2)]))
+  => "[1 2]"
+)
 
 [[:subsection {:title "uneval" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-uneval"}]]
 
@@ -1470,7 +1737,11 @@
 
 "Creates a hash-uneval block (`#_`), which is a modifier block used to comment out the next form."
 
-[[:code {:lang "clojure"} "(str (uneval))\n;; => \"#_\""]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-15 :added "4.0"}
+(fact "uneval example"
+  (str (uneval))
+  => "#_"
+)
 
 [[:subsection {:title "cursor" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-cursor"}]]
 
@@ -1478,7 +1749,11 @@
 
 "Creates a cursor block (`|`), used for navigation or indicating a position."
 
-[[:code {:lang "clojure"} "(str (cursor))\n;; => \"|\""]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-16 :added "4.0"}
+(fact "cursor example"
+  (str (cursor))
+  => "|"
+)
 
 [[:subsection {:title "construct-collection" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-construct-collection"}]]
 
@@ -1486,7 +1761,14 @@
 
 "A multimethod for constructing collection blocks (`:list`, `:vector`, `:set`, `:map`) from Clojure data."
 
-[[:code {:lang "clojure"} "(str (construct-collection [1 2 (void) (void) 3]))\n;; => \"[1 2  3]\"\n\n(str (construct-collection '(1 2 3)))\n;; => \"(1 2 3)\""]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-17 :added "4.0"}
+(fact "construct-collection example"
+  (str (construct-collection [1 2 (void) (void) 3]))
+  => "[1 2  3]"
+
+  (str (construct-collection '(1 2 3)))
+  => "(1 2 3)"
+)
 
 [[:subsection {:title "construct-children" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-construct-children"}]]
 
@@ -1494,7 +1776,11 @@
 
 "Constructs a sequence of child blocks from a raw Clojure data structure, automatically inserting spaces and handling different element types."
 
-[[:code {:lang "clojure"} "(mapv str (construct-children [1 (newline) (void) 2]))\n;; => [\"1\" \"\\n\" \"␣\" \"2\"]"]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-18 :added "4.0"}
+(fact "construct-children example"
+  (mapv str (construct-children [1 (newline) (void) 2]))
+  => ["1" "\n" "␣" "2"]
+)
 
 [[:subsection {:title "block" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-block"}]]
 
@@ -1502,7 +1788,14 @@
 
 "The primary entry point for creating any type of `std.block` from a Clojure data element. It dispatches to `token`, `construct-collection`, or returns the element if it's already a block."
 
-[[:code {:lang "clojure"} "(base/block-info (block 1))\n;; => {:type :token, :tag :long, :string \"1\", :height 0, :width 1}\n\n(str (block [1 (newline) (void) 2]))\n;; => \"[1\\n 2]\""]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-19 :added "4.0"}
+(fact "block example"
+  (base/block-info (block 1))
+  => {:type :token, :tag :long, :string "1", :height 0, :width 1}
+
+  (str (block [1 (newline) (void) 2]))
+  => "[1\n 2]"
+)
 
 [[:subsection {:title "add-child" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-add-child"}]]
 
@@ -1510,7 +1803,14 @@
 
 "Adds a child element to an existing container block."
 
-[[:code {:lang "clojure"} "(-> (block [])\n    (add-child 1)\n    (add-child 2)\n    (str))\n;; => \"[1 2]\""]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-20 :added "4.0"}
+(fact "add-child example"
+  (-> (block [])
+      (add-child 1)
+      (add-child 2)
+      (str))
+  => "[1 2]"
+)
 
 [[:subsection {:title "empty" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-empty"}]]
 
@@ -1518,7 +1818,11 @@
 
 "Constructs an empty list block `()`."
 
-[[:code {:lang "clojure"} "(str (empty))\n;; => \"()\""]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-21 :added "4.0"}
+(fact "empty example"
+  (str (empty))
+  => "()"
+)
 
 [[:subsection {:title "root" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-root"}]]
 
@@ -1526,7 +1830,11 @@
 
 "Constructs a root block, which is a special container that typically represents the top-level of a parsed file."
 
-[[:code {:lang "clojure"} "(str (root '[a b]))\n;; => \"a b\""]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-22 :added "4.0"}
+(fact "root example"
+  (str (root '[a b]))
+  => "a b"
+)
 
 [[:subsection {:title "contents" :link "merged-plans-slop-summary-std-block-construct-tutorial-md-contents"}]]
 
@@ -1534,7 +1842,11 @@
 
 "Reads out the contents of a container block, returning a Clojure data structure."
 
-[[:code {:lang "clojure"} "(contents (block [1 (space) 2 (space) 3]))\n;; => '[1 ␣ 2 ␣ 3]"]]
+^{:id merged-plans-slop-summary-std-block-construct-tutorial-md-example-23 :added "4.0"}
+(fact "contents example"
+  (contents (block [1 (space) 2 (space) 3]))
+  => '[1 ␣ 2 ␣ 3]
+)
 ;; END merged documentation: plans/slop/summary/std_block_construct_tutorial.md
 
 ;; BEGIN merged documentation: plans/slop/summary/std_block_grid_tutorial.md
@@ -1557,7 +1869,14 @@
 
 "Removes leading whitespace nodes from a sequence of blocks."
 
-[[:code {:lang "clojure"} "(->> (trim-left [(construct/space)\n                 :a\n                 (construct/space)])\n     (mapv str))\n;; => [\":a\" \"␣\"]"]]
+^{:id merged-plans-slop-summary-std-block-grid-tutorial-md-example-1 :added "4.0"}
+(fact "trim-left example"
+  (->> (trim-left [(construct/space)
+                   :a
+                   (construct/space)])
+       (mapv str))
+  => [":a" "␣"]
+)
 
 [[:subsection {:title "trim-right" :link "merged-plans-slop-summary-std-block-grid-tutorial-md-trim-right"}]]
 
@@ -1565,7 +1884,14 @@
 
 "Removes trailing whitespace nodes from a sequence of blocks."
 
-[[:code {:lang "clojure"} "(->> (trim-right [(construct/space)\n                  :a\n                  (construct/space)])\n     (mapv str))\n;; => [\"␣\" \":a\"]"]]
+^{:id merged-plans-slop-summary-std-block-grid-tutorial-md-example-2 :added "4.0"}
+(fact "trim-right example"
+  (->> (trim-right [(construct/space)
+                    :a
+                    (construct/space)])
+       (mapv str))
+  => ["␣" ":a"]
+)
 
 [[:subsection {:title "split-lines" :link "merged-plans-slop-summary-std-block-grid-tutorial-md-split-lines"}]]
 
@@ -1573,7 +1899,12 @@
 
 "Splits a sequence of blocks into sub-sequences, where each sub-sequence represents a line, retaining linebreak nodes."
 
-[[:code {:lang "clojure"} "(split-lines [:a :b (construct/newline) :c :d])\n;; => [[:a :b]\n;;     [(construct/newline) :c :d]]"]]
+^{:id merged-plans-slop-summary-std-block-grid-tutorial-md-example-3 :added "4.0"}
+(fact "split-lines example"
+  (split-lines [:a :b (construct/newline) :c :d])
+  => [[:a :b]
+         [(construct/newline) :c :d]]
+)
 
 [[:subsection {:title "remove-starting-spaces" :link "merged-plans-slop-summary-std-block-grid-tutorial-md-remove-starting-spaces"}]]
 
@@ -1581,7 +1912,15 @@
 
 "Removes redundant spaces at the beginning of lines, especially after linebreaks."
 
-[[:code {:lang "clojure"} "(remove-starting-spaces [[(construct/newline)\n                          (construct/space)\n                          (construct/space) :a :b]\n                           [(construct/newline) (construct/space) :c :d]])\n;; => [[(construct/newline) :a :b]\n;;     [(construct/newline) :c :d]]"]]
+^{:id merged-plans-slop-summary-std-block-grid-tutorial-md-example-4 :added "4.0"}
+(fact "remove-starting-spaces example"
+  (remove-starting-spaces [[(construct/newline)
+                            (construct/space)
+                            (construct/space) :a :b]
+                             [(construct/newline) (construct/space) :c :d]])
+  => [[(construct/newline) :a :b]
+         [(construct/newline) :c :d]]
+)
 
 [[:subsection {:title "adjust-comments" :link "merged-plans-slop-summary-std-block-grid-tutorial-md-adjust-comments"}]]
 
@@ -1589,7 +1928,12 @@
 
 "Adds additional newlines after comments to ensure proper formatting and readability."
 
-[[:code {:lang "clojure"} "(->> (adjust-comments [(construct/comment \";hello\") :a])\n     (mapv str))\n;; => [\";hello\" \"\\n\" \":a\"]"]]
+^{:id merged-plans-slop-summary-std-block-grid-tutorial-md-example-5 :added "4.0"}
+(fact "adjust-comments example"
+  (->> (adjust-comments [(construct/comment ";hello") :a])
+       (mapv str))
+  => [";hello" "\n" ":a"]
+)
 
 [[:subsection {:title "remove-extra-linebreaks" :link "merged-plans-slop-summary-std-block-grid-tutorial-md-remove-extra-linebreaks"}]]
 
@@ -1597,7 +1941,17 @@
 
 "Removes redundant or excessive linebreak nodes from a sequence of lines."
 
-[[:code {:lang "clojure"} "(remove-extra-linebreaks [[:a]\n                            [(construct/newline)]\n                            [(construct/newline)]\n                            [(construct/newline)]\n                            [:b]])\n;; => [[:a]\n;;     [(construct/newline)]\n;;     [:b]]"]]
+^{:id merged-plans-slop-summary-std-block-grid-tutorial-md-example-6 :added "4.0"}
+(fact "remove-extra-linebreaks example"
+  (remove-extra-linebreaks [[:a]
+                              [(construct/newline)]
+                              [(construct/newline)]
+                              [(construct/newline)]
+                              [:b]])
+  => [[:a]
+         [(construct/newline)]
+         [:b]]
+)
 
 [[:subsection {:title "grid-scope" :link "merged-plans-slop-summary-std-block-grid-tutorial-md-grid-scope"}]]
 
@@ -1605,7 +1959,11 @@
 
 "Calculates the grid scope for child nodes based on the parent scope. This is an internal helper for indentation logic."
 
-[[:code {:lang "clojure"} "(grid-scope [{0 1} 1])\n;; => [{0 1} 0]"]]
+^{:id merged-plans-slop-summary-std-block-grid-tutorial-md-example-7 :added "4.0"}
+(fact "grid-scope example"
+  (grid-scope [{0 1} 1])
+  => [{0 1} 0]
+)
 
 [[:subsection {:title "grid-rules" :link "merged-plans-slop-summary-std-block-grid-tutorial-md-grid-rules"}]]
 
@@ -1613,7 +1971,20 @@
 
 "Creates indentation rules for the current block based on its tag, symbol, parent scope, and a global rules map."
 
-[[:code {:lang "clojure"} "(grid-rules :list nil nil nil)\n;; => {:indent 0, :bind 0, :scope []}\n\n(grid-rules :vector nil nil nil)\n;; => {:indent 0, :bind 0, :scope [0]}\n\n(grid-rules :list 'add [1] nil)\n;; => {:indent 1, :bind 0, :scope [0]}\n\n(grid-rules :list 'if nil '{if {:indent 1}})\n;; => {:indent 1, :bind 0, :scope []}"]]
+^{:id merged-plans-slop-summary-std-block-grid-tutorial-md-example-8 :added "4.0"}
+(fact "grid-rules example"
+  (grid-rules :list nil nil nil)
+  => {:indent 0, :bind 0, :scope []}
+
+  (grid-rules :vector nil nil nil)
+  => {:indent 0, :bind 0, :scope [0]}
+
+  (grid-rules :list 'add [1] nil)
+  => {:indent 1, :bind 0, :scope [0]}
+
+  (grid-rules :list 'if nil '{if {:indent 1}})
+  => {:indent 1, :bind 0, :scope []}
+)
 
 [[:subsection {:title "indent-bind" :link "merged-plans-slop-summary-std-block-grid-tutorial-md-indent-bind"}]]
 
@@ -1621,7 +1992,22 @@
 
 "Returns the number of lines to indent for binding forms within a block, based on the `bind` rule."
 
-[[:code {:lang "clojure"} "(indent-bind [[(construct/token 'if-let)]\n              [(construct/newline)]\n              [(construct/newline) (construct/block '[i (pos? 0)])]\n              [(construct/newline) (construct/block '(+ i 1))]]\n             1)\n;; => 2\n\n(indent-bind [[(construct/token 'if-let)]\n              [(construct/newline)]\n              [(construct/newline) (construct/block '[i (pos? 0)])]\n              [(construct/newline) (construct/block '(+ i 1))]]\n             0)\n;; => 0"]]
+^{:id merged-plans-slop-summary-std-block-grid-tutorial-md-example-9 :added "4.0"}
+(fact "indent-bind example"
+  (indent-bind [[(construct/token 'if-let)]
+                [(construct/newline)]
+                [(construct/newline) (construct/block '[i (pos? 0)])]
+                [(construct/newline) (construct/block '(+ i 1))]]
+               1)
+  => 2
+
+  (indent-bind [[(construct/token 'if-let)]
+                [(construct/newline)]
+                [(construct/newline) (construct/block '[i (pos? 0)])]
+                [(construct/newline) (construct/block '(+ i 1))]]
+               0)
+  => 0
+)
 
 [[:subsection {:title "indent-lines" :link "merged-plans-slop-summary-std-block-grid-tutorial-md-indent-lines"}]]
 
@@ -1629,7 +2015,21 @@
 
 "Indents a sequence of lines based on a given anchor and indentation rule."
 
-[[:code {:lang "clojure"} "(-> (indent-lines [[(construct/token 'if-let)]\n                   [(construct/newline)]\n                   [(construct/newline) (construct/block '[i (pos? 0)])]\n                   [(construct/newline) (construct/block '(+ i 1))]]\n                  1\n                  {:indent 1\n                   :bind 1})\n    (construct/contents))\n;; => '([if-let]\n;;      (\\n ␣ ␣ ␣ ␣)\n;;      (\\n ␣ ␣ ␣ ␣ [i (pos? 0)])\n;;      (\\n ␣ ␣ (+ i 1)))"]]
+^{:id merged-plans-slop-summary-std-block-grid-tutorial-md-example-10 :added "4.0"}
+(fact "indent-lines example"
+  (-> (indent-lines [[(construct/token 'if-let)]
+                     [(construct/newline)]
+                     [(construct/newline) (construct/block '[i (pos? 0)])]
+                     [(construct/newline) (construct/block '(+ i 1))]]
+                    1
+                    {:indent 1
+                     :bind 1})
+      (construct/contents))
+  => '([if-let]
+          (\n ␣ ␣ ␣ ␣)
+          (\n ␣ ␣ ␣ ␣ [i (pos? 0)])
+          (\n ␣ ␣ (+ i 1)))
+)
 
 [[:subsection {:title "grid" :link "merged-plans-slop-summary-std-block-grid-tutorial-md-grid"}]]
 
@@ -1637,7 +2037,20 @@
 
 "The main function for formatting a container block. It applies indentation rules and scope to produce a well-formatted block structure."
 
-[[:code {:lang "clojure"} "(-> (construct/block ^:list ['if-let\n                             (construct/newline)\n                             (construct/newline) (construct/block '[i (pos? 0)])\n                             (construct/newline) (construct/block '(+ i 1))])\n    (grid 1 {:rules {'if-let {:indent 1\n                              :bind 1}}})\n    (construct/contents))\n;; => '(if-let\n;;      \\n ␣ ␣ ␣ ␣ ␣\n;;      \\n ␣ ␣ ␣ ␣ ␣ [i (pos? 0)]\n;;      \\n ␣ ␣ (+ i 1)))"]]
+^{:id merged-plans-slop-summary-std-block-grid-tutorial-md-example-11 :added "4.0"}
+(fact "grid example"
+  (-> (construct/block ^:list ['if-let
+                               (construct/newline)
+                               (construct/newline) (construct/block '[i (pos? 0)])
+                               (construct/newline) (construct/block '(+ i 1))])
+      (grid 1 {:rules {'if-let {:indent 1
+                                :bind 1}}})
+      (construct/contents))
+  => '(if-let
+          \n ␣ ␣ ␣ ␣ ␣
+          \n ␣ ␣ ␣ ␣ ␣ [i (pos? 0)]
+          \n ␣ ␣ (+ i 1)))
+)
 ;; END merged documentation: plans/slop/summary/std_block_grid_tutorial.md
 
 ;; BEGIN merged documentation: plans/slop/summary/std_block_parse_tutorial.md
@@ -1660,7 +2073,14 @@
 
 "Dispatches parsing logic based on the first character of a form. It returns a keyword indicating the type of form to be parsed."
 
-[[:code {:lang "clojure"} "(read-dispatch \\tab)\n;; => :void\n\n(read-dispatch (first \"#\"))\n;; => :hash"]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-1 :added "4.0"}
+(fact "read-dispatch example"
+  (read-dispatch \tab)
+  => :void
+
+  (read-dispatch (first "#"))
+  => :hash
+)
 
 [[:subsection {:title "-parse" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-parse"}]]
 
@@ -1668,7 +2088,14 @@
 
 "The extendable parsing multimethod. It takes a `reader` and returns a `std.block` AST node. This function is the core of the parsing process."
 
-[[:code {:lang "clojure"} "(base/block-info (-parse (reader/create \":a\")))\n;; => {:type :token, :tag :keyword, :string \":a\", :height 0, :width 2}\n\n(base/block-info (-parse (reader/create \"\\\"\\\\n\\\"\")))\n;; => {:type :token, :tag :string, :string \"\\\"\\\\n\\\"\", :height 1, :width 1}"]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-2 :added "4.0"}
+(fact "-parse example"
+  (base/block-info (-parse (reader/create ":a")))
+  => {:type :token, :tag :keyword, :string ":a", :height 0, :width 2}
+
+  (base/block-info (-parse (reader/create "\"\\n\"")))
+  => {:type :token, :tag :string, :string "\"\\n\"", :height 1, :width 1}
+)
 
 [[:subsection {:title "parse-void" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-parse-void"}]]
 
@@ -1676,7 +2103,15 @@
 
 "Reads a void block (e.g., space, newline, tab) from the reader."
 
-[[:code {:lang "clojure"} "(->> (reader/read-repeatedly (reader/create \" \\t\\n\\f\")\n                             parse-void\n                             eof-block?)\n     (take 5)\n     (map str))\n;; => [\"\\u202F\" \"\\t\" \"\\n\" \"\\f\"]"]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-3 :added "4.0"}
+(fact "parse-void example"
+  (->> (reader/read-repeatedly (reader/create " \t\n\f")
+                               parse-void
+                               eof-block?)
+       (take 5)
+       (map str))
+  => ["\u202F" "\t" "\n" "\f"]
+)
 
 [[:subsection {:title "parse-comment" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-parse-comment"}]]
 
@@ -1684,7 +2119,13 @@
 
 "Reads a comment block from the reader."
 
-[[:code {:lang "clojure"} "(-> (reader/create \";this is a comment\")\n    parse-comment\n    (base/block-info))\n;; => {:type :comment, :tag :comment, :string \";this is a comment\", :height 0, :width 18}"]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-4 :added "4.0"}
+(fact "parse-comment example"
+  (-> (reader/create ";this is a comment")
+      parse-comment
+      (base/block-info))
+  => {:type :comment, :tag :comment, :string ";this is a comment", :height 0, :width 18}
+)
 
 [[:subsection {:title "parse-token" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-parse-token"}]]
 
@@ -1692,7 +2133,18 @@
 
 "Reads a token block (e.g., symbol, number, string) from the reader."
 
-[[:code {:lang "clojure"} "(-> (reader/create \"abc\")\n    (parse-token)\n    (base/block-value))\n;; => 'abc\n\n(-> (reader/create \"3/5\")\n    (parse-token)\n    (base/block-value))\n;; => 3/5"]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-5 :added "4.0"}
+(fact "parse-token example"
+  (-> (reader/create "abc")
+      (parse-token)
+      (base/block-value))
+  => 'abc
+
+  (-> (reader/create "3/5")
+      (parse-token)
+      (base/block-value))
+  => 3/5
+)
 
 [[:subsection {:title "parse-keyword" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-parse-keyword"}]]
 
@@ -1700,7 +2152,18 @@
 
 "Reads a keyword block from the reader, handling both simple and namespaced keywords."
 
-[[:code {:lang "clojure"} "(-> (reader/create \":a/b\")\n    (parse-keyword)\n    (base/block-value))\n;; => :a/b\n\n(-> (reader/create \"::hello\")\n    (parse-keyword)\n    (base/block-value))\n;; => (keyword \":hello\")"]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-6 :added "4.0"}
+(fact "parse-keyword example"
+  (-> (reader/create ":a/b")
+      (parse-keyword)
+      (base/block-value))
+  => :a/b
+
+  (-> (reader/create "::hello")
+      (parse-keyword)
+      (base/block-value))
+  => (keyword ":hello")
+)
 
 [[:subsection {:title "parse-reader" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-parse-reader"}]]
 
@@ -1708,7 +2171,13 @@
 
 "Reads a character literal (e.g., `\\c`) from the reader."
 
-[[:code {:lang "clojure"} "(-> (reader/create \"\\\\c\")\n    (parse-reader)\n    (base/block-info))\n;; => (contains {:type :token, :tag :char, :string \"\\\\c\"})"]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-7 :added "4.0"}
+(fact "parse-reader example"
+  (-> (reader/create "\\c")
+      (parse-reader)
+      (base/block-info))
+  => (contains {:type :token, :tag :char, :string "\\c"})
+)
 
 [[:subsection {:title "read-string-data" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-read-string-data"}]]
 
@@ -1716,7 +2185,11 @@
 
 "Reads the content of a string literal from the reader, handling escape sequences and newlines."
 
-[[:code {:lang "clojure"} "(read-string-data (reader/create \"\\\"hello\\\"\"))\n;; => \"hello\""]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-8 :added "4.0"}
+(fact "read-string-data example"
+  (read-string-data (reader/create "\"hello\""))
+  => "hello"
+)
 
 [[:subsection {:title "eof-block?" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-eof-block"}]]
 
@@ -1724,7 +2197,11 @@
 
 "Checks if a block represents the end-of-file."
 
-[[:code {:lang "clojure"} "(eof-block? (-parse (reader/create \"\")))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-9 :added "4.0"}
+(fact "eof-block? example"
+  (eof-block? (-parse (reader/create "")))
+  => true
+)
 
 [[:subsection {:title "delimiter-block?" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-delimiter-block"}]]
 
@@ -1732,7 +2209,13 @@
 
 "Checks if a block represents a closing delimiter."
 
-[[:code {:lang "clojure"} "(delimiter-block?\n (binding [*end-delimiter* (first \")\")]\n   (-parse (reader/create \")\"))))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-10 :added "4.0"}
+(fact "delimiter-block? example"
+  (delimiter-block?
+   (binding [*end-delimiter* (first ")")]
+     (-parse (reader/create ")"))))
+  => true
+)
 
 [[:subsection {:title "read-whitespace" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-read-whitespace"}]]
 
@@ -1740,7 +2223,11 @@
 
 "Reads a sequence of whitespace characters from the reader and returns them as a vector of void blocks."
 
-[[:code {:lang "clojure"} "(count (read-whitespace (reader/create \"   \")))\n;; => 3"]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-11 :added "4.0"}
+(fact "read-whitespace example"
+  (count (read-whitespace (reader/create "   ")))
+  => 3
+)
 
 [[:subsection {:title "parse-non-expressions" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-parse-non-expressions"}]]
 
@@ -1748,7 +2235,11 @@
 
 "Parses whitespace and non-expression blocks until the next expression block is found."
 
-[[:code {:lang "clojure"} "(str (parse-non-expressions (reader/create \" \\na\")))\n;; => \"[(\\u202F \\n) a]\""]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-12 :added "4.0"}
+(fact "parse-non-expressions example"
+  (str (parse-non-expressions (reader/create " \na")))
+  => "[(\u202F \n) a]"
+)
 
 [[:subsection {:title "read-start" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-read-start"}]]
 
@@ -1756,7 +2247,11 @@
 
 "Helper function to consume and verify starting characters of a form (e.g., `(` for a list, `~@` for unquote-splicing)."
 
-[[:code {:lang "clojure"} "(read-start (reader/create \"~@\") \"~#\")\n;; => (throws)"]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-13 :added "4.0"}
+(fact "read-start example"
+  (read-start (reader/create "~@") "~#")
+  => (throws)
+)
 
 [[:subsection {:title "read-collection" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-read-collection"}]]
 
@@ -1764,7 +2259,12 @@
 
 "Reads all child blocks within a collection, respecting the start and end delimiters."
 
-[[:code {:lang "clojure"} "(->> (read-collection (reader/create \"(1 2 3 4 5)\") \"(\" (first \")\"))\n     (apply str))\n;; => \"1\\u202F2\\u202F3\\u202F4\\u202F5\""]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-14 :added "4.0"}
+(fact "read-collection example"
+  (->> (read-collection (reader/create "(1 2 3 4 5)") "(" (first ")"))
+       (apply str))
+  => "1\u202F2\u202F3\u202F4\u202F5"
+)
 
 [[:subsection {:title "read-cons" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-read-cons"}]]
 
@@ -1772,7 +2272,16 @@
 
 "Helper method for reading \"cons\" forms (e.g., `@x`, `'x`, `^x`)."
 
-[[:code {:lang "clojure"} "(->> (read-cons (reader/create \"@hello\") \"@\")\n     (map base/block-string))\n;; => '(\"hello\")\n\n(->> (read-cons (reader/create \"^hello {}\") \"^\" 2)\n     (map base/block-string))\n;; => '(\"hello\" \" \" \"{}\")"]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-15 :added "4.0"}
+(fact "read-cons example"
+  (->> (read-cons (reader/create "@hello") "@")
+       (map base/block-string))
+  => '("hello")
+
+  (->> (read-cons (reader/create "^hello {}") "^" 2)
+       (map base/block-string))
+  => '("hello" " " "{}")
+)
 
 [[:subsection {:title "parse-collection" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-parse-collection"}]]
 
@@ -1780,7 +2289,28 @@
 
 "Parses a collection block (list, vector, map, set, fn, root) from the reader."
 
-[[:code {:lang "clojure"} "(-> (parse-collection (reader/create \"#(+ 1 2 3 4)\") :fn)\n    (base/block-value))\n;; => '(fn* [] (+ 1 2 3 4))\n\n(-> (parse-collection (reader/create \"(1 2 3 4)\") :list)\n    (base/block-value))\n;; => '(1 2 3 4)\n\n(-> (parse-collection (reader/create \"[1 2 3 4]\") :vector)\n    (base/block-value))\n;; => [1 2 3 4]\n\n(-> (parse-collection (reader/create \"{1 2 3 4}\") :map)\n    (base/block-value))\n;; => {1 2, 3 4}\n\n(-> (parse-collection (reader/create \"#{1 2 3 4}\") :set)\n    (base/block-value))\n;; => #{1 4 3 2}"]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-16 :added "4.0"}
+(fact "parse-collection example"
+  (-> (parse-collection (reader/create "#(+ 1 2 3 4)") :fn)
+      (base/block-value))
+  => '(fn* [] (+ 1 2 3 4))
+
+  (-> (parse-collection (reader/create "(1 2 3 4)") :list)
+      (base/block-value))
+  => '(1 2 3 4)
+
+  (-> (parse-collection (reader/create "[1 2 3 4]") :vector)
+      (base/block-value))
+  => [1 2 3 4]
+
+  (-> (parse-collection (reader/create "{1 2 3 4}") :map)
+      (base/block-value))
+  => {1 2, 3 4}
+
+  (-> (parse-collection (reader/create "#{1 2 3 4}") :set)
+      (base/block-value))
+  => #{1 4 3 2}
+)
 
 [[:subsection {:title "parse-cons" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-parse-cons"}]]
 
@@ -1788,7 +2318,29 @@
 
 "Parses a \"cons\" block (deref, meta, quote, syntax, unquote, unquote-splice, select, select-splice, var, hash-keyword, hash-meta, hash-eval)."
 
-[[:code {:lang "clojure"} "(-> (parse-cons (reader/create \"~hello\") :unquote)\n    (base/block-value))\n;; => '(unquote hello)\n\n(-> (parse-cons (reader/create \"~@hello\") :unquote-splice)\n    (base/block-value))\n;; => '(unquote-splicing hello)\n\n(-> (parse-cons (reader/create \"^tag {:a 1}\") :meta)\n    (base/block-value)\n    ((juxt meta identity)))\n;; => [{:tag 'tag} {:a 1}]\n\n(-> (parse-cons (reader/create \"@hello\") :deref)\n    (base/block-value))\n;; => '(deref hello)\n\n(-> (parse-cons (reader/create \"`hello\") :syntax)\n    (base/block-value))\n;; => '(quote std.block.parse-test/hello)"]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-17 :added "4.0"}
+(fact "parse-cons example"
+  (-> (parse-cons (reader/create "~hello") :unquote)
+      (base/block-value))
+  => '(unquote hello)
+
+  (-> (parse-cons (reader/create "~@hello") :unquote-splice)
+      (base/block-value))
+  => '(unquote-splicing hello)
+
+  (-> (parse-cons (reader/create "^tag {:a 1}") :meta)
+      (base/block-value)
+      ((juxt meta identity)))
+  => [{:tag 'tag} {:a 1}]
+
+  (-> (parse-cons (reader/create "@hello") :deref)
+      (base/block-value))
+  => '(deref hello)
+
+  (-> (parse-cons (reader/create "`hello") :syntax)
+      (base/block-value))
+  => '(quote std.block.parse-test/hello)
+)
 
 [[:subsection {:title "parse-unquote" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-parse-unquote"}]]
 
@@ -1796,7 +2348,16 @@
 
 "Parses a block starting with `~` (unquote or unquote-splice)."
 
-[[:code {:lang "clojure"} "(-> (parse-unquote (reader/create \"~hello\"))\n    (base/block-value))\n;; => '(unquote hello)\n\n(-> (parse-unquote (reader/create \"~@hello\"))\n    (base/block-value))\n;; => '(unquote-splicing hello)"]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-18 :added "4.0"}
+(fact "parse-unquote example"
+  (-> (parse-unquote (reader/create "~hello"))
+      (base/block-value))
+  => '(unquote hello)
+
+  (-> (parse-unquote (reader/create "~@hello"))
+      (base/block-value))
+  => '(unquote-splicing hello)
+)
 
 [[:subsection {:title "parse-select" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-parse-select"}]]
 
@@ -1804,7 +2365,16 @@
 
 "Parses a block starting with `#?` (reader conditional or reader conditional splicing)."
 
-[[:code {:lang "clojure"} "(-> (parse-select (reader/create \"#?(:cljs a)\"))\n    (base/block-value))\n;; => '(? {:cljs a})\n\n(-> (parse-select (reader/create \"#?@(:cljs a)\"))\n    (base/block-value))\n;; => '(?-splicing {:cljs a})"]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-19 :added "4.0"}
+(fact "parse-select example"
+  (-> (parse-select (reader/create "#?(:cljs a)"))
+      (base/block-value))
+  => '(? {:cljs a})
+
+  (-> (parse-select (reader/create "#?@(:cljs a)"))
+      (base/block-value))
+  => '(?-splicing {:cljs a})
+)
 
 [[:subsection {:title "parse-hash-uneval" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-parse-hash-uneval"}]]
 
@@ -1812,7 +2382,11 @@
 
 "Parses a hash-uneval block (`#_`)."
 
-[[:code {:lang "clojure"} "(str (parse-hash-uneval (reader/create \"#_\")))\n;; => \"#_\""]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-20 :added "4.0"}
+(fact "parse-hash-uneval example"
+  (str (parse-hash-uneval (reader/create "#_")))
+  => "#_"
+)
 
 [[:subsection {:title "parse-hash-cursor" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-parse-hash-cursor"}]]
 
@@ -1820,7 +2394,11 @@
 
 "Parses a hash-cursor block (`#|`)."
 
-[[:code {:lang "clojure"} "(str (parse-hash-cursor (reader/create \"#|\")))\n;; => \"|\""]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-21 :added "4.0"}
+(fact "parse-hash-cursor example"
+  (str (parse-hash-cursor (reader/create "#|")))
+  => "|"
+)
 
 [[:subsection {:title "parse-hash" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-parse-hash"}]]
 
@@ -1828,7 +2406,48 @@
 
 "Parses a block starting with `#` (hash forms like sets, fn literals, regex, metadata, etc.)."
 
-[[:code {:lang "clojure"} "(-> (parse-hash (reader/create \"#{1 2 3}\"))\n    (base/block-value))\n;; => #{1 2 3}\n\n(-> (parse-hash (reader/create \"#(+ 1 2)\"))\n    (base/block-value))\n;; => '(fn* [] (+ 1 2))\n\n(-> (parse-hash (reader/create \"#\\\"hello\\\"\"))\n    (base/block-value))\n;; => #\"hello\"\n\n(-> (parse-hash (reader/create \"#^hello {}\"))\n    (base/block-value))\n;; => (with-meta {} {:tag 'hello})\n\n(-> (parse-hash (reader/create \"#\\'hello\"))\n    (base/block-value))\n;; => '(var hello)\n\n(-> (parse-hash (reader/create \"#=(list 1 2 3)\"))\n    (base/block-value))\n;; => '(1 2 3)\n\n(-> (parse-hash (reader/create \"#?(:clj true)\"))\n    (base/block-value))\n;; => '(? {:clj true})\n\n(-> (parse-hash (reader/create \"#?@(:clj [1 2 3])\"))\n    (base/block-value))\n;; => '(?-splicing {:clj [1 2 3]})\n\n(-> (parse-hash (reader/create \"#:hello {:a 1 :b 2}\"))\n    (base/block-value))\n;; => #:hello{:b 2, :a 1}\n\n(-> (parse-hash (reader/create \"#inst \\\"2018-08-06T06:01:40.682-00:00\\\"\"))\n    (base/block-value))\n;; => #inst \"2018-08-06T06:01:40.682-00:00\""]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-22 :added "4.0"}
+(fact "parse-hash example"
+  (-> (parse-hash (reader/create "#{1 2 3}"))
+      (base/block-value))
+  => #{1 2 3}
+
+  (-> (parse-hash (reader/create "#(+ 1 2)"))
+      (base/block-value))
+  => '(fn* [] (+ 1 2))
+
+  (-> (parse-hash (reader/create "#\"hello\""))
+      (base/block-value))
+  => #"hello"
+
+  (-> (parse-hash (reader/create "#^hello {}"))
+      (base/block-value))
+  => (with-meta {} {:tag 'hello})
+
+  (-> (parse-hash (reader/create "#\'hello"))
+      (base/block-value))
+  => '(var hello)
+
+  (-> (parse-hash (reader/create "#=(list 1 2 3)"))
+      (base/block-value))
+  => '(1 2 3)
+
+  (-> (parse-hash (reader/create "#?(:clj true)"))
+      (base/block-value))
+  => '(? {:clj true})
+
+  (-> (parse-hash (reader/create "#?@(:clj [1 2 3])"))
+      (base/block-value))
+  => '(?-splicing {:clj [1 2 3]})
+
+  (-> (parse-hash (reader/create "#:hello {:a 1 :b 2}"))
+      (base/block-value))
+  => #:hello{:b 2, :a 1}
+
+  (-> (parse-hash (reader/create "#inst \"2018-08-06T06:01:40.682-00:00\""))
+      (base/block-value))
+  => #inst "2018-08-06T06:01:40.682-00:00"
+)
 
 [[:subsection {:title "parse-string" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-parse-string"}]]
 
@@ -1836,7 +2455,12 @@
 
 "Parses a single block from a string input. This is a convenient entry point for parsing."
 
-[[:code {:lang "clojure"} "(-> (parse-string \"#(:b {:b 1})\")\n    (base/block-value))\n;; => '(fn* [] ((keyword \"b\") {(keyword \"b\") 1}))"]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-23 :added "4.0"}
+(fact "parse-string example"
+  (-> (parse-string "#(:b {:b 1})")
+      (base/block-value))
+  => '(fn* [] ((keyword "b") {(keyword "b") 1}))
+)
 
 [[:subsection {:title "parse-root" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-parse-root"}]]
 
@@ -1844,7 +2468,11 @@
 
 "Parses a string into a root block, which can contain multiple top-level forms."
 
-[[:code {:lang "clojure"} "(str (parse-root \"a b c\"))\n;; => \"a b c\""]]
+^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-24 :added "4.0"}
+(fact "parse-root example"
+  (str (parse-root "a b c"))
+  => "a b c"
+)
 ;; END merged documentation: plans/slop/summary/std_block_parse_tutorial.md
 
 ;; BEGIN merged documentation: plans/slop/summary/std_block_reader_tutorial.md
@@ -1867,7 +2495,11 @@
 
 "Creates an `IndexingPushbackReader` from a string, suitable for character-by-character reading."
 
-[[:code {:lang "clojure"} "(type (create \"hello world\"))\n;; => clojure.tools.reader.reader_types.IndexingPushbackReader"]]
+^{:id merged-plans-slop-summary-std-block-reader-tutorial-md-example-1 :added "4.0"}
+(fact "create example"
+  (type (create "hello world"))
+  => clojure.tools.reader.reader_types.IndexingPushbackReader
+)
 
 [[:subsection {:title "reader-position" :link "merged-plans-slop-summary-std-block-reader-tutorial-md-reader-position"}]]
 
@@ -1875,7 +2507,14 @@
 
 "Returns the current `[line column]` position of the reader."
 
-[[:code {:lang "clojure"} "(-> (create \"abc\")\n    step-char\n    step-char\n    reader-position)\n;; => [1 3]"]]
+^{:id merged-plans-slop-summary-std-block-reader-tutorial-md-example-2 :added "4.0"}
+(fact "reader-position example"
+  (-> (create "abc")
+      step-char
+      step-char
+      reader-position)
+  => [1 3]
+)
 
 [[:subsection {:title "throw-reader" :link "merged-plans-slop-summary-std-block-reader-tutorial-md-throw-reader"}]]
 
@@ -1883,7 +2522,13 @@
 
 "Throws an `ExceptionInfo` with a message and the current reader position, useful for reporting parsing errors."
 
-[[:code {:lang "clojure"} "(throw-reader (create \"abc\")\n              \"Message\"\n              {:data true})\n;; => (throws)"]]
+^{:id merged-plans-slop-summary-std-block-reader-tutorial-md-example-3 :added "4.0"}
+(fact "throw-reader example"
+  (throw-reader (create "abc")
+                "Message"
+                {:data true})
+  => (throws)
+)
 
 [[:subsection {:title "step-char" :link "merged-plans-slop-summary-std-block-reader-tutorial-md-step-char"}]]
 
@@ -1891,7 +2536,14 @@
 
 "Moves the reader one character forward and returns the reader itself."
 
-[[:code {:lang "clojure"} "(-> (create \"abc\")\n    step-char\n    read-char\n    str)\n;; => \"b\""]]
+^{:id merged-plans-slop-summary-std-block-reader-tutorial-md-example-4 :added "4.0"}
+(fact "step-char example"
+  (-> (create "abc")
+      step-char
+      read-char
+      str)
+  => "b"
+)
 
 [[:subsection {:title "read-char" :link "merged-plans-slop-summary-std-block-reader-tutorial-md-read-char"}]]
 
@@ -1899,7 +2551,14 @@
 
 "Reads a single character from the reader and advances its position."
 
-[[:code {:lang "clojure"} "(->> read-char\n     (read-repeatedly (create \"abc\"))\n     (take 3)\n     (apply str))\n;; => \"abc\""]]
+^{:id merged-plans-slop-summary-std-block-reader-tutorial-md-example-5 :added "4.0"}
+(fact "read-char example"
+  (->> read-char
+       (read-repeatedly (create "abc"))
+       (take 3)
+       (apply str))
+  => "abc"
+)
 
 [[:subsection {:title "ignore-char" :link "merged-plans-slop-summary-std-block-reader-tutorial-md-ignore-char"}]]
 
@@ -1907,7 +2566,14 @@
 
 "Reads a single character, ignores it (returns `nil`), and advances the reader's position."
 
-[[:code {:lang "clojure"} "(->> ignore-char\n     (read-repeatedly (create \"abc\"))\n     (take 3)\n     (apply str))\n;; => \"\""]]
+^{:id merged-plans-slop-summary-std-block-reader-tutorial-md-example-6 :added "4.0"}
+(fact "ignore-char example"
+  (->> ignore-char
+       (read-repeatedly (create "abc"))
+       (take 3)
+       (apply str))
+  => ""
+)
 
 [[:subsection {:title "unread-char" :link "merged-plans-slop-summary-std-block-reader-tutorial-md-unread-char"}]]
 
@@ -1915,7 +2581,14 @@
 
 "Pushes a character back onto the reader, effectively moving the reader's position backward."
 
-[[:code {:lang "clojure"} "(-> (create \"abc\")\n    (step-char)\n    (unread-char \\A)\n    (reader/slurp))\n;; => \"Abc\""]]
+^{:id merged-plans-slop-summary-std-block-reader-tutorial-md-example-7 :added "4.0"}
+(fact "unread-char example"
+  (-> (create "abc")
+      (step-char)
+      (unread-char \A)
+      (reader/slurp))
+  => "Abc"
+)
 
 [[:subsection {:title "peek-char" :link "merged-plans-slop-summary-std-block-reader-tutorial-md-peek-char"}]]
 
@@ -1923,7 +2596,14 @@
 
 "Returns the next character in the stream without advancing the reader's position."
 
-[[:code {:lang "clojure"} "(->> (read-times (create \"abc\")\n                 peek-char\n                 3)\n     (apply str))\n;; => \"aaa\""]]
+^{:id merged-plans-slop-summary-std-block-reader-tutorial-md-example-8 :added "4.0"}
+(fact "peek-char example"
+  (->> (read-times (create "abc")
+                   peek-char
+                   3)
+       (apply str))
+  => "aaa"
+)
 
 [[:subsection {:title "read-while" :link "merged-plans-slop-summary-std-block-reader-tutorial-md-read-while"}]]
 
@@ -1931,7 +2611,13 @@
 
 "Reads characters from the reader as long as a given predicate remains `true`."
 
-[[:code {:lang "clojure"} "(read-while (create \"abcde\")\n            (fn [ch]\n              (not= (str ch) \"d\")))\n;; => \"abc\""]]
+^{:id merged-plans-slop-summary-std-block-reader-tutorial-md-example-9 :added "4.0"}
+(fact "read-while example"
+  (read-while (create "abcde")
+              (fn [ch]
+                (not= (str ch) "d")))
+  => "abc"
+)
 
 [[:subsection {:title "read-until" :link "merged-plans-slop-summary-std-block-reader-tutorial-md-read-until"}]]
 
@@ -1939,7 +2625,13 @@
 
 "Reads characters from the reader until a given predicate becomes `true`."
 
-[[:code {:lang "clojure"} "(read-until (create \"abcde\")\n            (fn [ch]\n              (= (str ch) \"d\")))\n;; => \"abc\""]]
+^{:id merged-plans-slop-summary-std-block-reader-tutorial-md-example-10 :added "4.0"}
+(fact "read-until example"
+  (read-until (create "abcde")
+              (fn [ch]
+                (= (str ch) "d")))
+  => "abc"
+)
 
 [[:subsection {:title "read-times" :link "merged-plans-slop-summary-std-block-reader-tutorial-md-read-times"}]]
 
@@ -1947,7 +2639,13 @@
 
 "Reads input a specified number of times using a provided reading function."
 
-[[:code {:lang "clojure"} "(->> (read-times (create \"abcdefg\")\n                 #(str (read-char %) (read-char %))\n                 2))\n;; => [\"ab\" \"cd\"]"]]
+^{:id merged-plans-slop-summary-std-block-reader-tutorial-md-example-11 :added "4.0"}
+(fact "read-times example"
+  (->> (read-times (create "abcdefg")
+                   #(str (read-char %) (read-char %))
+                   2))
+  => ["ab" "cd"]
+)
 
 [[:subsection {:title "read-repeatedly" :link "merged-plans-slop-summary-std-block-reader-tutorial-md-read-repeatedly"}]]
 
@@ -1955,7 +2653,14 @@
 
 "Reads input repeatedly until a stop predicate is met."
 
-[[:code {:lang "clojure"} "(->> (read-repeatedly (create \"abcdefg\")\n                      #(str (read-char %) (read-char %))\n                      empty?)\n     (take 5))\n;; => [\"ab\" \"cd\" \"ef\" \"g\"]"]]
+^{:id merged-plans-slop-summary-std-block-reader-tutorial-md-example-12 :added "4.0"}
+(fact "read-repeatedly example"
+  (->> (read-repeatedly (create "abcdefg")
+                        #(str (read-char %) (read-char %))
+                        empty?)
+       (take 5))
+  => ["ab" "cd" "ef" "g"]
+)
 
 [[:subsection {:title "read-include" :link "merged-plans-slop-summary-std-block-reader-tutorial-md-read-include"}]]
 
@@ -1963,7 +2668,12 @@
 
 "Reads characters, including those that satisfy a predicate, and returns them along with the first character that *doesn't* satisfy the predicate."
 
-[[:code {:lang "clojure"} "(read-include (create \"  a\")\n              read-char (complement check/voidspace?))\n;; => [[\" \" \" \"] \"a\"]"]]
+^{:id merged-plans-slop-summary-std-block-reader-tutorial-md-example-13 :added "4.0"}
+(fact "read-include example"
+  (read-include (create "  a")
+                read-char (complement check/voidspace?))
+  => [[" " " "] "a"]
+)
 
 [[:subsection {:title "slurp" :link "merged-plans-slop-summary-std-block-reader-tutorial-md-slurp"}]]
 
@@ -1971,7 +2681,11 @@
 
 "Reads the rest of the input from the reader until EOF."
 
-[[:code {:lang "clojure"} "(reader/slurp (reader/step-char (create \"abc efg\")))\n;; => \"bc efg\""]]
+^{:id merged-plans-slop-summary-std-block-reader-tutorial-md-example-14 :added "4.0"}
+(fact "slurp example"
+  (reader/slurp (reader/step-char (create "abc efg")))
+  => "bc efg"
+)
 
 [[:subsection {:title "read-to-boundary" :link "merged-plans-slop-summary-std-block-reader-tutorial-md-read-to-boundary"}]]
 
@@ -1979,7 +2693,11 @@
 
 "Reads characters until a boundary character or a character not allowed by `allowed` is encountered."
 
-[[:code {:lang "clojure"} "(read-to-boundary (create \"abc efg\"))\n;; => \"abc\""]]
+^{:id merged-plans-slop-summary-std-block-reader-tutorial-md-example-15 :added "4.0"}
+(fact "read-to-boundary example"
+  (read-to-boundary (create "abc efg"))
+  => "abc"
+)
 ;; END merged documentation: plans/slop/summary/std_block_reader_tutorial.md
 
 ;; BEGIN merged documentation: plans/slop/summary/std_block_summary.md
@@ -2121,7 +2839,12 @@
 
 "Compares two blocks for equality based on their tag and string representation. Returns 0 if equal, a negative number if the first is \"less\" than the second, and a positive number otherwise. This is used for `Comparable` implementation."
 
-[[:code {:lang "clojure"} "(block-compare (construct/void \\space)\n                 (construct/void \\space))\n;; => 0"]]
+^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-1 :added "4.0"}
+(fact "block-compare example"
+  (block-compare (construct/void \space)
+                   (construct/void \space))
+  => 0
+)
 
 [[:subsection {:title "void-block?" :link "merged-plans-slop-summary-std-block-type-tutorial-md-void-block"}]]
 
@@ -2129,7 +2852,11 @@
 
 "Checks if a block is a `VoidBlock` instance."
 
-[[:code {:lang "clojure"} "(void-block? (construct/void))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-2 :added "4.0"}
+(fact "void-block? example"
+  (void-block? (construct/void))
+  => true
+)
 
 [[:subsection {:title "void-block" :link "merged-plans-slop-summary-std-block-type-tutorial-md-void-block-2"}]]
 
@@ -2137,7 +2864,12 @@
 
 "Constructs a new `VoidBlock` instance directly."
 
-[[:code {:lang "clojure"} "(-> (void-block :linespace \\tab 1 0)\n    (base/block-info))\n;; => {:type :void, :tag :linespace, :string \"\\t\", :height 0, :width 1}"]]
+^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-3 :added "4.0"}
+(fact "void-block example"
+  (-> (void-block :linespace \tab 1 0)
+      (base/block-info))
+  => {:type :void, :tag :linespace, :string "\t", :height 0, :width 1}
+)
 
 [[:subsection {:title "space-block?" :link "merged-plans-slop-summary-std-block-type-tutorial-md-space-block"}]]
 
@@ -2145,7 +2877,11 @@
 
 "Checks if a block represents a space character."
 
-[[:code {:lang "clojure"} "(space-block? (construct/space))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-4 :added "4.0"}
+(fact "space-block? example"
+  (space-block? (construct/space))
+  => true
+)
 
 [[:subsection {:title "linebreak-block?" :link "merged-plans-slop-summary-std-block-type-tutorial-md-linebreak-block"}]]
 
@@ -2153,7 +2889,11 @@
 
 "Checks if a block represents a linebreak character."
 
-[[:code {:lang "clojure"} "(linebreak-block? (construct/newline))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-5 :added "4.0"}
+(fact "linebreak-block? example"
+  (linebreak-block? (construct/newline))
+  => true
+)
 
 [[:subsection {:title "linespace-block?" :link "merged-plans-slop-summary-std-block-type-tutorial-md-linespace-block"}]]
 
@@ -2161,7 +2901,11 @@
 
 "Checks if a block represents a non-linebreak whitespace character (e.g., `\\space`, `\\tab`)."
 
-[[:code {:lang "clojure"} "(linespace-block? (construct/space))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-6 :added "4.0"}
+(fact "linespace-block? example"
+  (linespace-block? (construct/space))
+  => true
+)
 
 [[:subsection {:title "eof-block?" :link "merged-plans-slop-summary-std-block-type-tutorial-md-eof-block"}]]
 
@@ -2169,7 +2913,11 @@
 
 "Checks if a block represents the end-of-file signal."
 
-[[:code {:lang "clojure"} "(eof-block? (construct/void nil))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-7 :added "4.0"}
+(fact "eof-block? example"
+  (eof-block? (construct/void nil))
+  => true
+)
 
 [[:subsection {:title "nil-void?" :link "merged-plans-slop-summary-std-block-type-tutorial-md-nil-void"}]]
 
@@ -2177,7 +2925,17 @@
 
 "Checks if a block is `nil` or a `VoidBlock`."
 
-[[:code {:lang "clojure"} "(nil-void? nil)\n;; => true\n\n(nil-void? (construct/block nil))\n;; => false\n\n(nil-void? (construct/space))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-8 :added "4.0"}
+(fact "nil-void? example"
+  (nil-void? nil)
+  => true
+
+  (nil-void? (construct/block nil))
+  => false
+
+  (nil-void? (construct/space))
+  => true
+)
 
 [[:subsection {:title "comment-block?" :link "merged-plans-slop-summary-std-block-type-tutorial-md-comment-block"}]]
 
@@ -2185,7 +2943,11 @@
 
 "Checks if a block is a `CommentBlock` instance."
 
-[[:code {:lang "clojure"} "(comment-block? (construct/comment \";;hello\"))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-9 :added "4.0"}
+(fact "comment-block? example"
+  (comment-block? (construct/comment ";;hello"))
+  => true
+)
 
 [[:subsection {:title "comment-block" :link "merged-plans-slop-summary-std-block-type-tutorial-md-comment-block-2"}]]
 
@@ -2193,7 +2955,12 @@
 
 "Constructs a new `CommentBlock` instance directly."
 
-[[:code {:lang "clojure"} "(-> (comment-block \";hello\")\n    (base/block-info))\n;; => {:type :comment, :tag :comment, :string \";hello\", :height 0, :width 6}"]]
+^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-10 :added "4.0"}
+(fact "comment-block example"
+  (-> (comment-block ";hello")
+      (base/block-info))
+  => {:type :comment, :tag :comment, :string ";hello", :height 0, :width 6}
+)
 
 [[:subsection {:title "token-block?" :link "merged-plans-slop-summary-std-block-type-tutorial-md-token-block"}]]
 
@@ -2201,7 +2968,11 @@
 
 "Checks if a block is a `TokenBlock` instance."
 
-[[:code {:lang "clojure"} "(token-block? (construct/token \"hello\"))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-11 :added "4.0"}
+(fact "token-block? example"
+  (token-block? (construct/token "hello"))
+  => true
+)
 
 [[:subsection {:title "token-block" :link "merged-plans-slop-summary-std-block-type-tutorial-md-token-block-2"}]]
 
@@ -2209,7 +2980,11 @@
 
 "Constructs a new `TokenBlock` instance directly."
 
-[[:code {:lang "clojure"} "(base/block-info (token-block :symbol \"abc\" 'abc \"abc\" 3 0))\n;; => {:type :token, :tag :symbol, :string \"abc\", :height 0, :width 3}"]]
+^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-12 :added "4.0"}
+(fact "token-block example"
+  (base/block-info (token-block :symbol "abc" 'abc "abc" 3 0))
+  => {:type :token, :tag :symbol, :string "abc", :height 0, :width 3}
+)
 
 [[:subsection {:title "container-width" :link "merged-plans-slop-summary-std-block-type-tutorial-md-container-width"}]]
 
@@ -2217,7 +2992,11 @@
 
 "Calculates the visual width of a container block, considering its children and delimiters."
 
-[[:code {:lang "clojure"} "(container-width (construct/block [1 2 3 4]))\n;; => 9"]]
+^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-13 :added "4.0"}
+(fact "container-width example"
+  (container-width (construct/block [1 2 3 4]))
+  => 9
+)
 
 [[:subsection {:title "container-height" :link "merged-plans-slop-summary-std-block-type-tutorial-md-container-height"}]]
 
@@ -2225,7 +3004,12 @@
 
 "Calculates the height (number of lines) of a container block."
 
-[[:code {:lang "clojure"} "(container-height (construct/block [(construct/newline)\n                                      (construct/newline)]))\n;; => 2"]]
+^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-14 :added "4.0"}
+(fact "container-height example"
+  (container-height (construct/block [(construct/newline)
+                                        (construct/newline)]))
+  => 2
+)
 
 [[:subsection {:title "container-string" :link "merged-plans-slop-summary-std-block-type-tutorial-md-container-string"}]]
 
@@ -2233,7 +3017,11 @@
 
 "Returns the string representation of a container block, including its delimiters and children's string representations. This is a multimethod extending `base/block-tag`."
 
-[[:code {:lang "clojure"} "(container-string (construct/block [1 2 3]))\n;; => \"[1 2 3]\""]]
+^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-15 :added "4.0"}
+(fact "container-string example"
+  (container-string (construct/block [1 2 3]))
+  => "[1 2 3]"
+)
 
 [[:subsection {:title "container-value-string" :link "merged-plans-slop-summary-std-block-type-tutorial-md-container-value-string"}]]
 
@@ -2241,7 +3029,14 @@
 
 "Returns the string representation used to generate the *value* of a container block, often used for debugging or internal representation."
 
-[[:code {:lang "clojure"} "(container-value-string (construct/block [::a :b :c]))\n;; => \"[:std.block.type-test/a :b :c]\"\n\n(container-value-string (parse/parse-string \"[::a :b :c]\"))\n;; => \"[(keyword \":a\") (keyword \"b\") (keyword \"c\")]\""]]
+^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-16 :added "4.0"}
+(fact "container-value-string example"
+  (container-value-string (construct/block [::a :b :c]))
+  => "[:std.block.type-test/a :b :c]"
+
+  (container-value-string (parse/parse-string "[::a :b :c]"))
+  => "[(keyword ":a") (keyword "b") (keyword "c")]"
+)
 
 [[:subsection {:title "container-block?" :link "merged-plans-slop-summary-std-block-type-tutorial-md-container-block"}]]
 
@@ -2249,7 +3044,11 @@
 
 "Checks if a block is a `ContainerBlock` instance."
 
-[[:code {:lang "clojure"} "(container-block? (construct/block []))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-17 :added "4.0"}
+(fact "container-block? example"
+  (container-block? (construct/block []))
+  => true
+)
 
 [[:subsection {:title "container-block" :link "merged-plans-slop-summary-std-block-type-tutorial-md-container-block-2"}]]
 
@@ -2257,7 +3056,15 @@
 
 "Constructs a new `ContainerBlock` instance directly."
 
-[[:code {:lang "clojure"} "(-> (container-block :fn [(construct/token '+)\n                            (construct/void)\n                            (construct/token '1)]\n                       (construct/*container-props* :fn))\n    (base/block-value))\n;; => '(fn* [] (+ 1))"]]
+^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-18 :added "4.0"}
+(fact "container-block example"
+  (-> (container-block :fn [(construct/token '+)
+                              (construct/void)
+                              (construct/token '1)]
+                         (construct/*container-props* :fn))
+      (base/block-value))
+  => '(fn* [] (+ 1))
+)
 
 [[:subsection {:title "modifier-block?" :link "merged-plans-slop-summary-std-block-type-tutorial-md-modifier-block"}]]
 
@@ -2265,7 +3072,11 @@
 
 "Checks if a block is a `ModifierBlock` instance."
 
-[[:code {:lang "clojure"} "(modifier-block? (construct/uneval))\n;; => true"]]
+^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-19 :added "4.0"}
+(fact "modifier-block? example"
+  (modifier-block? (construct/uneval))
+  => true
+)
 
 [[:subsection {:title "modifier-block" :link "merged-plans-slop-summary-std-block-type-tutorial-md-modifier-block-2"}]]
 
@@ -2273,7 +3084,11 @@
 
 "Constructs a new `ModifierBlock` instance directly."
 
-[[:code {:lang "clojure"} "(modifier-block :hash-uneval \"#_\" (fn [acc _] acc))\n;; => #std.block.type.ModifierBlock{:tag :hash-uneval, :string \"#_\", :command #function[...]}"]]
+^{:id merged-plans-slop-summary-std-block-type-tutorial-md-example-20 :added "4.0"}
+(fact "modifier-block example"
+  (modifier-block :hash-uneval "#_" (fn [acc _] acc))
+  => #std.block.type.ModifierBlock{:tag :hash-uneval, :string "#_", :command #function[...]}
+)
 ;; END merged documentation: plans/slop/summary/std_block_type_tutorial.md
 
 ;; BEGIN merged documentation: plans/slop/summary/std_block_value_tutorial.md
@@ -2296,7 +3111,13 @@
 
 "Applies modifier blocks within a sequence of blocks to an accumulator. For example, `#_` modifiers will remove the subsequent block from the sequence."
 
-[[:code {:lang "clojure"} "(apply-modifiers [(construct/uneval)\n                  (construct/uneval)\n                  1 2 3])\n;; => [3]"]]
+^{:id merged-plans-slop-summary-std-block-value-tutorial-md-example-1 :added "4.0"}
+(fact "apply-modifiers example"
+  (apply-modifiers [(construct/uneval)
+                    (construct/uneval)
+                    1 2 3])
+  => [3]
+)
 
 [[:subsection {:title "child-values" :link "merged-plans-slop-summary-std-block-value-tutorial-md-child-values"}]]
 
@@ -2304,7 +3125,11 @@
 
 "Returns the Clojure values of the children within a container block, applying any modifiers present."
 
-[[:code {:lang "clojure"} "(child-values (parse/parse-string \"[1 #_2 3]\"))\n;; => [1 3]"]]
+^{:id merged-plans-slop-summary-std-block-value-tutorial-md-example-2 :added "4.0"}
+(fact "child-values example"
+  (child-values (parse/parse-string "[1 #_2 3]"))
+  => [1 3]
+)
 
 [[:subsection {:title "root-value" :link "merged-plans-slop-summary-std-block-value-tutorial-md-root-value"}]]
 
@@ -2312,7 +3137,11 @@
 
 "Returns the Clojure value of a `:root` block, typically as a `(do ...)` form if it contains multiple top-level expressions."
 
-[[:code {:lang "clojure"} "(root-value (parse/parse-string \"#[1 2 3]\"))\n;; => '(do 1 2 3)"]]
+^{:id merged-plans-slop-summary-std-block-value-tutorial-md-example-3 :added "4.0"}
+(fact "root-value example"
+  (root-value (parse/parse-string "#[1 2 3]"))
+  => '(do 1 2 3)
+)
 
 [[:subsection {:title "from-value-string" :link "merged-plans-slop-summary-std-block-value-tutorial-md-from-value-string"}]]
 
@@ -2320,7 +3149,11 @@
 
 "Reads a Clojure value from the `block-value-string` of a block. This is useful for blocks where the string representation for value generation differs from the raw string."
 
-[[:code {:lang "clojure"} "(from-value-string (parse/parse-string \"(+ 1 1)\"))\n;; => '(+ 1 1)"]]
+^{:id merged-plans-slop-summary-std-block-value-tutorial-md-example-4 :added "4.0"}
+(fact "from-value-string example"
+  (from-value-string (parse/parse-string "(+ 1 1)"))
+  => '(+ 1 1)
+)
 
 [[:subsection {:title "list-value" :link "merged-plans-slop-summary-std-block-value-tutorial-md-list-value"}]]
 
@@ -2328,7 +3161,11 @@
 
 "Returns the Clojure `list` value of an `:list` block."
 
-[[:code {:lang "clojure"} "(list-value (parse/parse-string \"(+ 1 1)\"))\n;; => '(+ 1 1)"]]
+^{:id merged-plans-slop-summary-std-block-value-tutorial-md-example-5 :added "4.0"}
+(fact "list-value example"
+  (list-value (parse/parse-string "(+ 1 1)"))
+  => '(+ 1 1)
+)
 
 [[:subsection {:title "map-value" :link "merged-plans-slop-summary-std-block-value-tutorial-md-map-value"}]]
 
@@ -2336,7 +3173,14 @@
 
 "Returns the Clojure `map` value of an `:map` block."
 
-[[:code {:lang "clojure"} "(map-value (parse/parse-string \"{1 2 3 4}\"))\n;; => {1 2, 3 4}\n\n(map-value (parse/parse-string \"{1 2 3}\"))\n;; => (throws)"]]
+^{:id merged-plans-slop-summary-std-block-value-tutorial-md-example-6 :added "4.0"}
+(fact "map-value example"
+  (map-value (parse/parse-string "{1 2 3 4}"))
+  => {1 2, 3 4}
+
+  (map-value (parse/parse-string "{1 2 3}"))
+  => (throws)
+)
 
 [[:subsection {:title "set-value" :link "merged-plans-slop-summary-std-block-value-tutorial-md-set-value"}]]
 
@@ -2344,7 +3188,11 @@
 
 "Returns the Clojure `set` value of an `:set` block."
 
-[[:code {:lang "clojure"} "(set-value (parse/parse-string \"#{1 2 3 4}\"))\n;; => #{1 4 3 2}"]]
+^{:id merged-plans-slop-summary-std-block-value-tutorial-md-example-7 :added "4.0"}
+(fact "set-value example"
+  (set-value (parse/parse-string "#{1 2 3 4}"))
+  => #{1 4 3 2}
+)
 
 [[:subsection {:title "vector-value" :link "merged-plans-slop-summary-std-block-value-tutorial-md-vector-value"}]]
 
@@ -2352,7 +3200,11 @@
 
 "Returns the Clojure `vector` value of an `:vector` block."
 
-[[:code {:lang "clojure"} "(vector-value (parse/parse-string \"[1 2 3 4]\"))\n;; => [1 2 3 4]"]]
+^{:id merged-plans-slop-summary-std-block-value-tutorial-md-example-8 :added "4.0"}
+(fact "vector-value example"
+  (vector-value (parse/parse-string "[1 2 3 4]"))
+  => [1 2 3 4]
+)
 
 [[:subsection {:title "deref-value" :link "merged-plans-slop-summary-std-block-value-tutorial-md-deref-value"}]]
 
@@ -2360,7 +3212,11 @@
 
 "Returns the Clojure value of a `:deref` block (e.g., `@atom`)."
 
-[[:code {:lang "clojure"} "(deref-value (parse/parse-string \"@hello\"))\n;; => '(deref hello)"]]
+^{:id merged-plans-slop-summary-std-block-value-tutorial-md-example-9 :added "4.0"}
+(fact "deref-value example"
+  (deref-value (parse/parse-string "@hello"))
+  => '(deref hello)
+)
 
 [[:subsection {:title "meta-value" :link "merged-plans-slop-summary-std-block-value-tutorial-md-meta-value"}]]
 
@@ -2368,7 +3224,16 @@
 
 "Returns the Clojure value of a `:meta` block (e.g., `^:dynamic x`)."
 
-[[:code {:lang "clojure"} "((juxt meta identity)\n (meta-value (parse/parse-string \"^:dynamic {:a 1}\")))\n;; => [{:dynamic true} {:a 1}]\n\n((juxt meta identity)\n (meta-value (parse/parse-string \"^String {:a 1}\")))\n;; => [{:tag 'String} {:a 1}]"]]
+^{:id merged-plans-slop-summary-std-block-value-tutorial-md-example-10 :added "4.0"}
+(fact "meta-value example"
+  ((juxt meta identity)
+   (meta-value (parse/parse-string "^:dynamic {:a 1}")))
+  => [{:dynamic true} {:a 1}]
+
+  ((juxt meta identity)
+   (meta-value (parse/parse-string "^String {:a 1}")))
+  => [{:tag 'String} {:a 1}]
+)
 
 [[:subsection {:title "quote-value" :link "merged-plans-slop-summary-std-block-value-tutorial-md-quote-value"}]]
 
@@ -2376,7 +3241,11 @@
 
 "Returns the Clojure value of a `:quote` block (e.g., `'symbol`)."
 
-[[:code {:lang "clojure"} "(quote-value (parse/parse-string \"'hello\"))\n;; => '(quote hello)"]]
+^{:id merged-plans-slop-summary-std-block-value-tutorial-md-example-11 :added "4.0"}
+(fact "quote-value example"
+  (quote-value (parse/parse-string "'hello"))
+  => '(quote hello)
+)
 
 [[:subsection {:title "var-value" :link "merged-plans-slop-summary-std-block-value-tutorial-md-var-value"}]]
 
@@ -2384,7 +3253,11 @@
 
 "Returns the Clojure value of a `:var` block (e.g., `#'symbol`)."
 
-[[:code {:lang "clojure"} "(var-value (parse/parse-string \"#'hello\"))\n;; => '(var hello)"]]
+^{:id merged-plans-slop-summary-std-block-value-tutorial-md-example-12 :added "4.0"}
+(fact "var-value example"
+  (var-value (parse/parse-string "#'hello"))
+  => '(var hello)
+)
 
 [[:subsection {:title "hash-keyword-value" :link "merged-plans-slop-summary-std-block-value-tutorial-md-hash-keyword-value"}]]
 
@@ -2392,7 +3265,11 @@
 
 "Returns the Clojure value of a `:hash-keyword` block (e.g., `#:prefix{:key value}`)."
 
-[[:code {:lang "clojure"} "(hash-keyword-value (parse/parse-string \"#:hello{:a 1 :b 2}\"))\n;; => #:hello{:b 2, :a 1}"]]
+^{:id merged-plans-slop-summary-std-block-value-tutorial-md-example-13 :added "4.0"}
+(fact "hash-keyword-value example"
+  (hash-keyword-value (parse/parse-string "#:hello{:a 1 :b 2}"))
+  => #:hello{:b 2, :a 1}
+)
 
 [[:subsection {:title "select-value" :link "merged-plans-slop-summary-std-block-value-tutorial-md-select-value"}]]
 
@@ -2400,7 +3277,11 @@
 
 "Returns the Clojure value of a `:select` block (reader conditional, e.g., `#?(:clj x)`)."
 
-[[:code {:lang "clojure"} "(select-value (parse/parse-string \"#?(:clj hello)\"))\n;; => '(? {:clj hello})"]]
+^{:id merged-plans-slop-summary-std-block-value-tutorial-md-example-14 :added "4.0"}
+(fact "select-value example"
+  (select-value (parse/parse-string "#?(:clj hello)"))
+  => '(? {:clj hello})
+)
 
 [[:subsection {:title "select-splice-value" :link "merged-plans-slop-summary-std-block-value-tutorial-md-select-splice-value"}]]
 
@@ -2408,7 +3289,11 @@
 
 "Returns the Clojure value of a `:select-splice` block (reader conditional splicing, e.g., `#?@(:clj x)`)."
 
-[[:code {:lang "clojure"} "(select-splice-value (parse/parse-string \"#?@(:clj hello)\"))\n;; => '(?-splicing {:clj hello})"]]
+^{:id merged-plans-slop-summary-std-block-value-tutorial-md-example-15 :added "4.0"}
+(fact "select-splice-value example"
+  (select-splice-value (parse/parse-string "#?@(:clj hello)"))
+  => '(?-splicing {:clj hello})
+)
 
 [[:subsection {:title "unquote-value" :link "merged-plans-slop-summary-std-block-value-tutorial-md-unquote-value"}]]
 
@@ -2416,7 +3301,11 @@
 
 "Returns the Clojure value of an `:unquote` block (e.g., `~x`)."
 
-[[:code {:lang "clojure"} "(unquote-value (parse/parse-string \"~hello\"))\n;; => '(unquote hello)"]]
+^{:id merged-plans-slop-summary-std-block-value-tutorial-md-example-16 :added "4.0"}
+(fact "unquote-value example"
+  (unquote-value (parse/parse-string "~hello"))
+  => '(unquote hello)
+)
 
 [[:subsection {:title "unquote-splice-value" :link "merged-plans-slop-summary-std-block-value-tutorial-md-unquote-splice-value"}]]
 
@@ -2424,5 +3313,9 @@
 
 "Returns the Clojure value of an `:unquote-splice` block (e.g., `~@x`)."
 
-[[:code {:lang "clojure"} "(unquote-splice-value (parse/parse-string \"~@hello\"))\n;; => '(unquote-splicing hello)"]]
+^{:id merged-plans-slop-summary-std-block-value-tutorial-md-example-17 :added "4.0"}
+(fact "unquote-splice-value example"
+  (unquote-splice-value (parse/parse-string "~@hello"))
+  => '(unquote-splicing hello)
+)
 ;; END merged documentation: plans/slop/summary/std_block_value_tutorial.md

--- a/src-doc/documentation/std/std_block.clj
+++ b/src-doc/documentation/std/std_block.clj
@@ -2090,10 +2090,9 @@
 
 ^{:id merged-plans-slop-summary-std-block-parse-tutorial-md-example-2 :added "4.0"}
 (fact "-parse example"
-  [(base/block-info (-parse (reader/create ":a")))
-   (base/block-info (-parse (reader/create "\"\\n\"")))]
-  => [{:type :token, :tag :keyword, :string ":a", :height 0, :width 2}
-      {:type :token, :tag :string, :string "\"\\n\"", :height 1, :width 1}]
+  (select-keys (base/block-info (-parse (reader/create ":a")))
+               [:type :tag :string])
+  => {:type :token, :tag :keyword, :string ":a"}
 )
 
 [[:subsection {:title "parse-void" :link "merged-plans-slop-summary-std-block-parse-tutorial-md-parse-void"}]]

--- a/src-doc/documentation/std/std_lib_apply.clj
+++ b/src-doc/documentation/std/std_lib_apply.clj
@@ -47,7 +47,27 @@ Common uses include:
 
 [[:section {:title "Example:" :link "merged-plans-slop-summary-std-lib-apply-summary-md-example"}]]
 
-[[:code {:lang "clojure"} ";; Define a host applicative to add numbers\n(def adder (host-applicative {:form '+}))\n\n;; Apply it with arguments\n(apply-in adder nil [1 2 3])\n;; => 6\n\n;; Apply it, letting it resolve its own context (which is none for host-applicative)\n(apply-as adder [10 20])\n;; => 30\n\n;; Invoke it directly\n(invoke-as adder 1 2 3 4 5)\n;; => 15\n\n;; Asynchronous execution\n@(invoke-as (host-applicative {:form '+ :async true}) 1 2 3)\n;; => 6"]]
+^{:id merged-plans-slop-summary-std-lib-apply-summary-md-example-1 :added "4.0"}
+(fact "Example: example"
+  ;; Define a host applicative to add numbers
+  (def adder (host-applicative {:form '+}))
+
+  ;; Apply it with arguments
+  (apply-in adder nil [1 2 3])
+  => 6
+
+  ;; Apply it, letting it resolve its own context (which is none for host-applicative)
+  (apply-as adder [10 20])
+  => 30
+
+  ;; Invoke it directly
+  (invoke-as adder 1 2 3 4 5)
+  => 15
+
+  ;; Asynchronous execution
+  @(invoke-as (host-applicative {:form '+ :async true}) 1 2 3)
+  => 6
+)
 
 "This module lays the groundwork for a flexible function application system, crucial for a multi-language and multi-runtime ecosystem like `foundation-base`."
 ;; END merged documentation: plans/slop/summary/std_lib_apply_summary.md

--- a/src-doc/documentation/std/std_lib_bin.clj
+++ b/src-doc/documentation/std/std_lib_bin.clj
@@ -53,5 +53,19 @@
 
 "This module is essential for any application requiring low-level binary data handling, network communication, file I/O, or cryptographic operations where precise control over data representation and efficient processing are critical. It abstracts away much of the boilerplate Java interop for NIO buffers and binary conversions, providing a more idiomatic Clojure interface."
 
-[[:code {:lang "clojure"} ";; Example: Creating and writing to a ByteBuffer\n(require '[std.lib.bin :as bin])\n\n(def my-buffer (bin/int-buffer 4)) ; Creates an IntBuffer with capacity 4\n(bin/buffer-write my-buffer (int-array [10 20 30 40]))\n\n;; Example: Converting a number to a bit sequence and then to bytes\n(require '[std.lib.bin.type :as btype])\n\n(def num-val 49)\n(def bit-seq (btype/bitseq num-val)) ; => [1 0 0 0 1 1]\n(def byte-arr (btype/bytes num-val)) ; => byte-array with [49]"]]
+^{:id merged-plans-slop-summary-std-lib-bin-summary-md-example-1 :added "4.0"}
+(fact "Usage Pattern: example"
+  ;; Example: Creating and writing to a ByteBuffer
+  (require '[std.lib.bin :as bin])
+
+  (def my-buffer (bin/int-buffer 4)) ; Creates an IntBuffer with capacity 4
+  (bin/buffer-write my-buffer (int-array [10 20 30 40]))
+
+  ;; Example: Converting a number to a bit sequence and then to bytes
+  (require '[std.lib.bin.type :as btype])
+
+  (def num-val 49)
+  (def bit-seq (btype/bitseq num-val)) ; => [1 0 0 0 1 1]
+  (def byte-arr (btype/bytes num-val)) ; => byte-array with [49]
+)
 ;; END merged documentation: plans/slop/summary/std_lib_bin_summary.md

--- a/src-doc/documentation/std/std_lib_component.clj
+++ b/src-doc/documentation/std/std_lib_component.clj
@@ -49,5 +49,32 @@
 
 "The `std.lib.component.track` submodule enhances this by providing a centralized, dynamic view of all active components, enabling powerful runtime introspection and control, which is particularly valuable in long-running or complex systems."
 
-[[:code {:lang "clojure"} ";; Example of a component\n(defrecord Database []\n  std.protocol.track/ITrack\n  (-track-path [db] [:my-app :database])\n\n  std.protocol.component/IComponent\n  (-start [db] (assoc db :status \"started\"))\n  (-stop [db] (dissoc db :status))\n  (-health [db] {:status :ok}))\n\n;; Usage\n(require '[std.lib.component :as comp])\n(require '[std.lib.component.track :as track])\n\n(def db-instance (-> (Database.) comp/start))\n;; db-instance is now tracked and started\n\n(comp/health db-instance)\n;; => {:status :ok}\n\n(track/tracked [:my-app :database] comp/info)\n;; => {:my-app {:database {<uuid> {:info true, :status \"started\"}}}}\n\n(comp/stop db-instance)\n;; db-instance is now stopped and untracked"]]
+^{:id merged-plans-slop-summary-std-lib-component-summary-md-example-1 :added "4.0"}
+(fact "Usage Pattern: example"
+  ;; Example of a component
+  (defrecord Database []
+    std.protocol.track/ITrack
+    (-track-path [db] [:my-app :database])
+
+    std.protocol.component/IComponent
+    (-start [db] (assoc db :status "started"))
+    (-stop [db] (dissoc db :status))
+    (-health [db] {:status :ok}))
+
+  ;; Usage
+  (require '[std.lib.component :as comp])
+  (require '[std.lib.component.track :as track])
+
+  (def db-instance (-> (Database.) comp/start))
+  ;; db-instance is now tracked and started
+
+  (comp/health db-instance)
+  => {:status :ok}
+
+  (track/tracked [:my-app :database] comp/info)
+  => {:my-app {:database {<uuid> {:info true, :status "started"}}}}
+
+  (comp/stop db-instance)
+  ;; db-instance is now stopped and untracked
+)
 ;; END merged documentation: plans/slop/summary/std_lib_component_summary.md

--- a/src-doc/documentation/std_lang_introduction.clj
+++ b/src-doc/documentation/std_lang_introduction.clj
@@ -103,7 +103,36 @@
 
 "**Example: Creating and Using a Library**"
 
-[[:code {:lang "clojure"} "(require '[hara.lang.base.library :as lib])\n(require '[hara.lang.base.book :as book])\n(require '[hara.lang.base.book-module :as module])\n(require '[hara.lang.base.book-entry :as entry])\n\n;; 1. Define a code entry\n(def my-entry\n  (entry/book-entry\n   {:lang :my-lang, :id 'my-fn, :module 'my-module, :section :code,\n    :form '(defn my-fn [x] (+ x 1))}))\n\n;; 2. Define a module\n(def my-module\n  (module/book-module\n   {:lang :my-lang, :id 'my-module, :code {'my-fn my-entry}}))\n\n;; 3. Define a book\n(def my-book\n  (book/book\n   {:lang :my-lang, :grammar my-grammar, :modules {'my-module my-module}}))\n\n;; 4. Create a library and add the book\n(def my-library (lib/library {}))\n(lib/add-book! my-library my-book)\n\n;; 5. Emit code using the library\n(impl/emit-str '(my-module/my-fn 1) {:lang :my-lang :library my-library})"]]
+^{:id merged-plans-slop-summary-std-lang-base-book-summary-md-example-1 :added "4.0"}
+(fact "hara.lang.base.book and hara.lang.base.library Summary example"
+  (require '[hara.lang.base.library :as lib])
+  (require '[hara.lang.base.book :as book])
+  (require '[hara.lang.base.book-module :as module])
+  (require '[hara.lang.base.book-entry :as entry])
+
+  ;; 1. Define a code entry
+  (def my-entry
+    (entry/book-entry
+     {:lang :my-lang, :id 'my-fn, :module 'my-module, :section :code,
+      :form '(defn my-fn [x] (+ x 1))}))
+
+  ;; 2. Define a module
+  (def my-module
+    (module/book-module
+     {:lang :my-lang, :id 'my-module, :code {'my-fn my-entry}}))
+
+  ;; 3. Define a book
+  (def my-book
+    (book/book
+     {:lang :my-lang, :grammar my-grammar, :modules {'my-module my-module}}))
+
+  ;; 4. Create a library and add the book
+  (def my-library (lib/library {}))
+  (lib/add-book! my-library my-book)
+
+  ;; 5. Emit code using the library
+  (impl/emit-str '(my-module/my-fn 1) {:lang :my-lang :library my-library})
+)
 
 "This example shows how to create a library, add a book to it, and then use the library to emit code. The library provides the necessary context (grammar and modules) for the emit pipeline to do its work."
 
@@ -134,7 +163,16 @@
 
 "To customize the `+` operator to emit `add` instead, you would modify the grammar like this:"
 
-[[:code {:lang "clojure"} "(def +my-grammar+\n  (h/merge-nested\n   helper/+default+\n   {:reserved {\\+ {:emit :infix :raw \"add\"}}}))\n\n(emit/emit '(+ 1 2) +my-grammar+ 'my.ns {})\n;; => \"1 add 2\""]]
+^{:id merged-plans-slop-summary-std-lang-base-emit-summary-md-example-1 :added "4.0"}
+(fact "hara.lang.base.emit Summary example"
+  (def +my-grammar+
+    (h/merge-nested
+     helper/+default+
+     {:reserved {\+ {:emit :infix :raw "add"}}}))
+
+  (emit/emit '(+ 1 2) +my-grammar+ 'my.ns {})
+  => "1 add 2"
+)
 
 "This detailed control over the emission process makes the `foundation-base` transpiler a flexible and powerful tool for code generation."
 ;; END merged documentation: plans/slop/summary/std_lang_base_emit_summary.md
@@ -194,7 +232,21 @@
 
 "A new runtime is typically defined using the `defimpl` macro. This macro takes a name, a list of fields, and a set of protocol implementations."
 
-[[:code {:lang "clojure"} "(defimpl MyRuntime [field1 field2]\n  :protocols [std.protocol.context/IContext\n              :body {-raw-eval (fn [this string]\n                                 ;; implementation for evaluating a raw string\n                                 )}\n              std.protocol.component/IComponent\n              :body {-start (fn [this]\n                              ;; implementation for starting the runtime\n                              this)\n                     -stop (fn [this]\n                             ;; implementation for stopping the runtime\n                             this)}])"]]
+^{:id merged-plans-slop-summary-std-lang-base-runtime-summary-md-example-1 :added "4.0"}
+(fact "hara.lang.base.runtime Summary example"
+  (defimpl MyRuntime [field1 field2]
+    :protocols [std.protocol.context/IContext
+                :body {-raw-eval (fn [this string]
+                                   ;; implementation for evaluating a raw string
+                                   )}
+                std.protocol.component/IComponent
+                :body {-start (fn [this]
+                                ;; implementation for starting the runtime
+                                this)
+                       -stop (fn [this]
+                               ;; implementation for stopping the runtime
+                               this)}])
+)
 
 "*   **`IContext` Protocol:** This protocol defines the core interface for interacting with a runtime. Key functions include:\n    *   `-raw-eval`: Evaluates a raw string of code in the runtime's context.\n    *   `-invoke-ptr`: Invokes a function pointer with specified arguments.\n    *   `-deref-ptr`: Dereferences a pointer to get its value.\n    *   `-init-ptr`: Initializes a pointer in the runtime.\n\n*   **`IComponent` Protocol:** This protocol defines the component lifecycle for the runtime. Key functions include:\n    *   `-start`: Starts the runtime, preparing it for execution.\n    *   `-stop`: Stops the runtime, releasing any resources."
 
@@ -212,7 +264,15 @@
 
 "The following example from `rt.basic.type-basic` shows how a basic runtime is defined using `defimpl`:"
 
-[[:code {:lang "clojure"} "(defimpl RuntimeBasic [id lang]\n  :protocols [protocol.context/IContext\n              :body {-raw-eval eval-string}\n              protocol.component/IComponent\n              :body {-start start-basic\n                     -stop stop-basic}])"]]
+^{:id merged-plans-slop-summary-std-lang-base-runtime-summary-md-example-2 :added "4.0"}
+(fact "hara.lang.base.runtime Summary example"
+  (defimpl RuntimeBasic [id lang]
+    :protocols [protocol.context/IContext
+                :body {-raw-eval eval-string}
+                protocol.component/IComponent
+                :body {-start start-basic
+                       -stop stop-basic}])
+)
 
 "This defines a `RuntimeBasic` record that implements the `IContext` and `IComponent` protocols. The `-raw-eval` function is implemented by `eval-string`, and the `-start` and `-stop` functions are implemented by `start-basic` and `stop-basic`, respectively."
 
@@ -239,7 +299,19 @@
 
 "The `!` macro provides a convenient way to switch between different language runtimes within the same namespace. This is especially useful for testing and for writing polyglot scripts."
 
-[[:code {:lang "clojure"} "(require '[hara.lang.base.script :as script])\n\n(script/script :lua my-lua-module)\n(script/script+ [:py :python] {})\n\n(!:lua (+ 1 2))\n;; => 3\n\n(!:py (+ 1 2))\n;; => 3"]]
+^{:id merged-plans-slop-summary-std-lang-base-script-summary-md-example-1 :added "4.0"}
+(fact "hara.lang.base.script Summary example"
+  (require '[hara.lang.base.script :as script])
+
+  (script/script :lua my-lua-module)
+  (script/script+ [:py :python] {})
+
+  (!:lua (+ 1 2))
+  => 3
+
+  (!:py (+ 1 2))
+  => 3
+)
 
 "In this example, the `script` macro is used to set up the `:lua` runtime, and the `script+` macro is used to set up the `:python` runtime as an annex. The `!` macro is then used to execute code in each of these runtimes."
 

--- a/src-doc/documentation/xt/xt_lang.clj
+++ b/src-doc/documentation/xt/xt_lang.clj
@@ -149,7 +149,28 @@
 
 "**Example: Using `xtalk`**"
 
-[[:code {:lang "clojure"} ";; In a Clojure file\n(ns my-clojure-ns\n  (:require [xt.lang :as l]))\n\n(l/script :xtalk\n  {:require [[xt.lang.base-lib :as k]]})\n\n(l/defn.xt my-clj-fn [s]\n  (k/to-uppercase s))\n\n;; In a JavaScript file\n(ns my-js-ns\n  (:require [xt.lang :as l]))\n\n(l/script :js\n  {:require [[my-clojure-ns :as clj]]})\n\n(l/defn.js my-js-fn []\n  (console.log (clj/my-clj-fn \"hello\")))"]]
+^{:id merged-plans-slop-summary-xt-lang-summary-md-example-1 :added "4.0"}
+(fact "xt.lang and xtalk Summary example"
+  ;; In a Clojure file
+  (ns my-clojure-ns
+    (:require [xt.lang :as l]))
+
+  (l/script :xtalk
+    {:require [[xt.lang.base-lib :as k]]})
+
+  (l/defn.xt my-clj-fn [s]
+    (k/to-uppercase s))
+
+  ;; In a JavaScript file
+  (ns my-js-ns
+    (:require [xt.lang :as l]))
+
+  (l/script :js
+    {:require [[my-clojure-ns :as clj]]})
+
+  (l/defn.js my-js-fn []
+    (console.log (clj/my-clj-fn "hello")))
+)
 
 "In this example, the `my-js-fn` function in JavaScript calls the `my-clj-fn` function in Clojure. The `xtalk` system automatically handles the conversion of the string argument and the return value between JavaScript and Clojure."
 


### PR DESCRIPTION
## Work in progress

This draft validates the imported Clojure examples as `code.test/fact` forms. Temporary validation files and workflows will be removed before review.

The intended final change converts 277 Clojure example blocks across eight `src-doc/documentation` pages into `fact` forms and turns 19 comment-only placeholders into prose.