### PR TITLE
Fix documentation publishing for code and xt sites

### DIFF
--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -59,8 +59,8 @@ jobs:
                                   '[code.doc.executive :as exec])
                           (let [project (doc/make-project)
                                 lookup  (exec/all-pages project)
-                                sites   #{\"core\" \"foundation.code\" \"std\" \"hara\"}]
-                            (doseq [site [:core :foundation.code :std :hara]]
+                                sites   #{"core" "code" "xt" "std" "hara"}]
+                            (doseq [site [:core :code :xt :std :hara]]
                               (doc/deploy-template site {:write true}))
                             (doseq [k (sort (filter #(sites (namespace %))
                                                     (keys lookup)))]


### PR DESCRIPTION
## Summary

- update the documentation publishing workflow to render the configured `code` site instead of the stale `foundation.code` namespace
- include the configured `xt` site in the template deployment and render filter

## Why

`config/publish.edn` defines `:code` and `:xt`, with outputs under `public/code` and `public/xt`, but the GitHub Pages workflow only rendered namespaces in `#{"core" "foundation.code" "std" "hara"}`. As a result, `code/index.html` and `xt/index.html` were not generated for the Pages artifact.

## Validation

- inspected `config/publish.edn`, `config/publish/code.edn`, and `config/publish/xt.edn`
- compared branch against `main`; only `.github/workflows/make-docs.yml` changed

Not run locally: the actual docs generation depends on the GHCR CI image and Pages workflow environment.