### PR TITLE
docs: publish application backbone LaTeX papers

### DIFF
--- a/.github/workflows/application-backbone-docs.yml
+++ b/.github/workflows/application-backbone-docs.yml
@@ -1,0 +1,61 @@
+name: Application backbone documents
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/application-backbone/**'
+      - '.github/workflows/application-backbone-docs.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/application-backbone/**'
+      - '.github/workflows/application-backbone-docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and stage PDFs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Install TeX Live and fonts
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            texlive-xetex \
+            texlive-latex-extra \
+            texlive-fonts-recommended \
+            texlive-pictures \
+            latexmk \
+            fonts-inter \
+            fonts-roboto
+          sudo fc-cache -fv
+
+      - name: Build both papers
+        run: make -C docs/application-backbone all
+
+      - name: Stage publication directory
+        run: make -C docs/application-backbone publish
+
+      - name: Verify staged publication
+        run: |
+          set -euo pipefail
+          test -s target/documents/application-backbone/business-analyst.pdf
+          test -s target/documents/application-backbone/senior-developer.pdf
+          test -s target/documents/application-backbone/INDEX.md
+          find target/documents/application-backbone -maxdepth 1 -type f -print -exec ls -lh {} \;
+
+      - name: Upload publication artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: foundation-application-backbone-pdfs
+          path: target/documents/application-backbone/
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/application-backbone/Makefile
+++ b/docs/application-backbone/Makefile
@@ -1,0 +1,32 @@
+.PHONY: all business-analyst senior-developer publish clean distclean
+
+PDFS := business-analyst.pdf senior-developer.pdf
+DIST_DIR := ../../target/documents/application-backbone
+
+all: $(PDFS)
+
+business-analyst: business-analyst.pdf
+
+senior-developer: senior-developer.pdf
+
+%.pdf: %.tex foundation-backbone.sty
+	latexmk -xelatex -interaction=nonstopmode -halt-on-error $<
+
+publish: all
+	mkdir -p $(DIST_DIR)
+	cp $(PDFS) README.md $(DIST_DIR)/
+	printf '%s\n' \
+	  '# Foundation application backbone documents' \
+	  '' \
+	  '- `business-analyst.pdf` — delivery and business-value overview.' \
+	  '- `senior-developer.pdf` — architecture, testing and ecosystem comparison.' \
+	  > $(DIST_DIR)/INDEX.md
+
+clean:
+	latexmk -c business-analyst.tex
+	latexmk -c senior-developer.tex
+
+distclean:
+	latexmk -C business-analyst.tex
+	latexmk -C senior-developer.tex
+	rm -rf $(DIST_DIR)

--- a/docs/application-backbone/README.md
+++ b/docs/application-backbone/README.md
@@ -1,0 +1,74 @@
+# Foundation application backbone papers
+
+This directory contains two LaTeX papers describing how `xt.substrate`, `xt.db.node` and `postgres.core` can be used as a tested data and RPC backbone for AI-assisted web, mobile and edge applications.
+
+- `business-analyst.tex` explains the delivery model, programme controls and business value.
+- `senior-developer.tex` explains the architecture for developers familiar with PostgreSQL, TypeScript, mobile, edge and native ecosystems but not necessarily Clojure or Lisp.
+
+Both papers include diagrams and comparisons with REST/OpenAPI, GraphQL, gRPC, ORMs, backend-as-a-service platforms, CQRS/event sourcing, local-first frameworks and a direct Bun/Rust rewrite. The Bun/Rust section is an architectural comparison rather than a claim about an identified Foundation rewrite branch.
+
+## Install dependencies
+
+On macOS, the installer uses TinyTeX. On Debian or Ubuntu, it installs TeX Live and the Inter/Roboto fonts:
+
+```bash
+docs/application-backbone/install-deps.sh
+```
+
+## Build
+
+From the repository root:
+
+```bash
+make -C docs/application-backbone
+```
+
+Build one paper:
+
+```bash
+make -C docs/application-backbone business-analyst
+make -C docs/application-backbone senior-developer
+```
+
+## Publish locally
+
+Build the PDFs and stage a clean distribution directory under `target/documents/application-backbone/`:
+
+```bash
+make -C docs/application-backbone publish
+```
+
+The staged files are:
+
+```text
+target/documents/application-backbone/
+├── INDEX.md
+├── README.md
+├── business-analyst.pdf
+└── senior-developer.pdf
+```
+
+## Continuous integration
+
+`.github/workflows/application-backbone-docs.yml` runs when these sources or the workflow change. It:
+
+1. installs XeLaTeX, `latexmk` and the required fonts;
+2. builds both papers with warnings treated as LaTeX build failures where applicable;
+3. stages the publish directory;
+4. uploads the complete directory as the `foundation-application-backbone-pdfs` workflow artifact.
+
+The workflow also supports manual dispatch.
+
+## Cleanup
+
+Remove intermediate files while retaining PDFs:
+
+```bash
+make -C docs/application-backbone clean
+```
+
+Remove generated PDFs and the staged distribution directory:
+
+```bash
+make -C docs/application-backbone distclean
+```

--- a/docs/application-backbone/business-analyst.tex
+++ b/docs/application-backbone/business-analyst.tex
@@ -1,0 +1,201 @@
+\documentclass[11pt]{article}
+\usepackage{foundation-backbone}
+
+\begin{document}
+\foundationtitle{Building Applications Around a Tested Data Backbone}{A business analyst's guide to \product{xt.substrate}, \product{xt.db.node}, \product{postgres.core} and AI-assisted delivery}{Audience: business analysts, product owners, delivery leads and solution stakeholders}
+
+\tableofcontents
+\newpage
+
+\section{Executive summary}
+
+Most application programmes repeatedly implement the same business behaviour in a database, API, web client, mobile client, integration service and edge worker. The result is familiar: requirements drift between teams, sync defects appear late, security rules are duplicated, and interface work becomes blocked by unstable services.
+
+Foundation Base takes a different approach. It establishes a tested application backbone before the final user interface is built:
+
+\begin{itemize}
+  \item \product{postgres.core} expresses and generates database-facing behaviour and RPC operations close to PostgreSQL;
+  \item \product{xt.substrate} provides the spaces, request transport and runtime context through which application parts communicate;
+  \item \product{xt.db.node} models live views, local projections, refresh, invalidation and remote execution;
+  \item automated tests exercise data movement through the same topology that the application will use;
+  \item AI and conventional UI teams then build web, mobile and edge experiences against a stable, executable contract.
+\end{itemize}
+
+\callout{The central proposition}{Do not ask each interface team to rediscover the application. Build and test the movement of data once, then project it into many user experiences.}
+
+\section{The delivery model}
+
+\begin{center}
+\begin{tikzpicture}[node distance=11mm and 15mm]
+  \node[fbwide] (req) {Business outcomes\\rules and permissions};
+  \node[fbwide,right=of req] (model) {Application model\\views, RPCs, events};
+  \node[fbwide,right=of model] (test) {Backbone tests\\sync and failure cases};
+  \node[fbwide,below=of model] (contract) {Verified application contract};
+  \node[fbbox,below left=of contract] (web) {Web};
+  \node[fbbox,below=of contract] (mobile) {Mobile};
+  \node[fbbox,below right=of contract] (edge) {Edge / automation};
+  \draw[fbedge] (req) -- (model);
+  \draw[fbedge] (model) -- (test);
+  \draw[fbedge] (test) -- (contract);
+  \draw[fbedge] (model) -- (contract);
+  \draw[fbedge] (contract) -- (web);
+  \draw[fbedge] (contract) -- (mobile);
+  \draw[fbedge] (contract) -- (edge);
+\end{tikzpicture}
+\end{center}
+
+This changes the order of delivery. Instead of treating the API as a late integration point, the team first agrees on the observable behaviour of the system: what data is authoritative, what can be cached locally, which operations may be invoked, how permissions apply, and what should happen during refresh, reconnect and failure.
+
+\section{What the three components contribute}
+
+\subsection{\product{xt.substrate}: application spaces and transport}
+
+A space is an application context, such as a local client space or an authoritative server space. The substrate moves requests and responses between those spaces while keeping the application model independent of the particular network or storage mechanism.
+
+For a business analyst, the useful distinction is not ``frontend versus backend''. It is:
+
+\begin{itemize}
+  \item where a decision is made;
+  \item where authoritative data lives;
+  \item which projection the user sees;
+  \item how a result moves from one context to another.
+\end{itemize}
+
+\subsection{\product{xt.db.node}: live views and synchronisation behaviour}
+
+A view is a named live query cell with input, status, value and dependencies. A screen can therefore be described as a set of views rather than a collection of ad hoc HTTP calls. Tests can prove that a list refreshes, a selected record remains coherent, stale data is invalidated, and a local projection is updated after a remote operation.
+
+\subsection{\product{postgres.core}: operations close to the data}
+
+\product{postgres.core} supports PostgreSQL-oriented definitions and generated behaviour, including functions used as RPC operations. Important rules can execute near the source of truth, reducing the number of partial implementations spread across services. Generated SQL remains reviewable and can be validated independently from the UI.
+
+\section{The concrete local--remote topology}
+
+Foundation Base already exercises a topology in which a local application space can use SQLite while a remote space uses PostgreSQL.
+
+\begin{center}
+\begin{tikzpicture}[node distance=12mm and 23mm]
+  \node[fbwide] (ui) {Web or mobile UI};
+  \node[fbwide,below=of ui] (local) {Local space\\live views};
+  \node[fbstorage,left=of local] (sqlite) {SQLite\\projection};
+  \node[fbwide,right=of local] (substrate) {\product{xt.substrate}\\request transport};
+  \node[fbwide,right=of substrate] (server) {Server space\\models and RPC};
+  \node[fbstorage,right=of server] (pg) {Postgres\\authority};
+  \draw[fbedge] (ui) -- node[right,scale=.8]{read state / refresh} (local);
+  \draw[fbedge] (local) -- (substrate);
+  \draw[fbedge] (substrate) -- (server);
+  \draw[fbedge] (server) -- (pg);
+  \draw[fbedge] (local) -- (sqlite);
+  \draw[fbdashed,bend right=25] (server.south) to node[below,scale=.8]{result projected locally} (local.south);
+\end{tikzpicture}
+\end{center}
+
+This is useful beyond offline applications. The same pattern supports fast local reads, explicit caching, deterministic refresh and a clearer separation between authoritative records and user-facing projections.
+
+\section{What gets tested before the UI}
+
+\begin{center}
+\begin{tikzpicture}[node distance=8mm]
+  \node[fbwide] (a) {Create test state};
+  \node[fbwide,below=of a] (b) {Invoke RPC or refresh};
+  \node[fbwide,below=of b] (c) {Observe remote result};
+  \node[fbwide,below=of c] (d) {Observe local projection};
+  \node[fbwide,below=of d] (e) {Assert permission, status and value};
+  \draw[fbedge] (a) -- (b);
+  \draw[fbedge] (b) -- (c);
+  \draw[fbedge] (c) -- (d);
+  \draw[fbedge] (d) -- (e);
+\end{tikzpicture}
+\end{center}
+
+Typical acceptance scenarios include:
+
+\begin{itemize}
+  \item authorised and unauthorised RPC calls;
+  \item remote updates followed by local refresh;
+  \item list/detail coherence after a mutation;
+  \item stale view invalidation;
+  \item reconnect or replay behaviour;
+  \item the same business operation viewed from web, mobile and edge contexts.
+\end{itemize}
+
+These tests become durable evidence for requirements. They reduce reliance on screenshots and manual end-to-end scripts as the only proof that a rule was implemented.
+
+\section{How AI fits into the workflow}
+
+AI is most effective when it receives a constrained, executable contract. Once entities, view inputs, RPCs, validation, permissions and result shapes are known, AI can concentrate on presentation and interaction.
+
+\begin{center}
+\begin{tikzpicture}[node distance=10mm and 18mm]
+  \node[fbwide] (contract) {Verified contract};
+  \node[fbwide,below left=of contract] (prompt) {UI brief and design system};
+  \node[fbwide,below right=of contract] (examples) {Reference flows and test data};
+  \node[fbwide,below=18mm of contract] (ai) {AI-assisted implementation};
+  \node[fbbox,below left=of ai] (react) {React / Next.js};
+  \node[fbbox,below=of ai] (rn) {React Native};
+  \node[fbbox,below right=of ai] (worker) {Bun / edge worker};
+  \draw[fbedge] (contract) -- (ai);
+  \draw[fbedge] (prompt) -- (ai);
+  \draw[fbedge] (examples) -- (ai);
+  \draw[fbedge] (ai) -- (react);
+  \draw[fbedge] (ai) -- (rn);
+  \draw[fbedge] (ai) -- (worker);
+\end{tikzpicture}
+\end{center}
+
+AI does not replace product analysis. It shortens the distance between an agreed workflow and a usable interface, while the backbone limits the scope for invented business logic.
+
+\section{Comparison with common delivery methods}
+
+\begin{tabularx}{\textwidth}{P{30mm}YYYY}
+\toprule
+\textbf{Method} & \textbf{Primary contract} & \textbf{Sync testing} & \textbf{Cross-platform reuse} & \textbf{Typical risk} \\
+\midrule
+UI-first CRUD & Screens and endpoint calls & Usually late, through E2E tests & Low to moderate & Behaviour is inferred separately by each client \\
+REST/OpenAPI & HTTP schema & Good request/response validation; limited local-state semantics & Moderate & Contract describes calls, not complete view lifecycle \\
+GraphQL & Graph and resolver schema & Strong query composition; client cache behaviour remains framework-specific & Moderate to high & Resolver, cache and mutation conventions can diverge \\
+Backend-as-a-Service & Vendor schema, policies and SDK & Fast integration; deeper sync behaviour depends on platform & High within supported clients & Vendor semantics become the architecture \\
+Event sourcing/CQRS & Events, commands and projections & Excellent history and projection testing & High & Operational and conceptual overhead can exceed the problem \\
+Foundation backbone & Spaces, live views, RPC and tested projections & First-class local/remote pipeline tests & High across generated targets & Requires learning the model and maintaining emitter/runtime agreement \\
+\bottomrule
+\end{tabularx}
+
+Foundation is not automatically preferable in every project. A small, connected CRUD site may be delivered faster with a conventional framework. Its advantage grows when the same rules and data flows must work across several runtimes, when local projections matter, or when generated code and AI-assisted clients must remain aligned.
+
+\section{Comparison with a Bun/Rust rewrite}
+
+A Bun/Rust rewrite is a different optimisation strategy. Bun can provide a fast JavaScript/TypeScript server and tooling environment; Rust can provide predictable native performance, memory safety and compact services. That combination is attractive when runtime throughput, startup time, deployment size or low-level control is the dominant concern.
+
+\begin{tabularx}{\textwidth}{P{34mm}YY}
+\toprule
+ & \textbf{Foundation backbone} & \textbf{Bun/Rust rewrite} \\
+\midrule
+Main goal & Preserve one executable application model across target ecosystems & Reimplement services using high-performance target runtimes \\
+Reuse mechanism & Language definitions, emitters, runtimes and portable \product{xt.*} modules & Shared protocols, generated clients, schemas and manually shared domain crates/packages \\
+Testing emphasis & Generated syntax, runtime behaviour, RPC and local/remote data movement & Unit/integration tests per service plus protocol and end-to-end tests \\
+Performance path & Move operations to PostgreSQL or emit to an appropriate target & Optimise hot services directly in Rust; use Bun for JS/TS workloads \\
+Team accessibility & Higher initial Lisp/Foundation learning curve & Familiar TypeScript plus a substantial Rust learning curve \\
+Change propagation & One model can affect several generated targets & Changes often span Rust services, TS services and client SDKs \\
+Best fit & Cross-cutting applications where consistency and generation dominate & Performance-sensitive systems where direct ownership of each runtime dominates \\
+\bottomrule
+\end{tabularx}
+
+The two approaches can be combined. Rust can implement a specialised service behind a stable RPC boundary, while Bun can host an edge or web-facing adapter. Foundation can remain the source for the application contract and sync tests. The decision is therefore not necessarily a repository-wide rewrite; it can be a measured placement of specialised runtimes at proven bottlenecks.
+
+\section{Recommended programme controls}
+
+\begin{enumerate}
+  \item Define a small vertical slice: one entity, one list/detail workflow and one mutation.
+  \item Write acceptance scenarios around authority, permissions and local projection.
+  \item Generate and inspect PostgreSQL output separately from runtime execution.
+  \item Exercise the same flow through \product{xt.db.node} before designing every screen.
+  \item Give AI tools only the verified contract, design system and acceptance examples.
+  \item Measure delivery time, escaped sync defects and cross-client inconsistency against a conventional slice.
+  \item Introduce Bun or Rust only where measurements show that their runtime characteristics solve a material problem.
+\end{enumerate}
+
+\section{Outcome}
+
+The Foundation approach reframes application delivery as the creation of a tested data backbone with multiple presentation surfaces. Business requirements become observable operations and data movements. UI delivery becomes faster and safer because web, mobile and edge applications are projections of behaviour already exercised in tests.
+
+\end{document}

--- a/docs/application-backbone/business-analyst.tex
+++ b/docs/application-backbone/business-analyst.tex
@@ -1,42 +1,27 @@
-\documentclass[11pt]{article}
+\documentclass[10pt]{article}
 \usepackage{foundation-backbone}
 
 \begin{document}
-\foundationtitle{Building Applications Around a Tested Data Backbone}{A business analyst's guide to \product{xt.substrate}, \product{xt.db.node}, \product{postgres.core} and AI-assisted delivery}{Audience: business analysts, product owners, delivery leads and solution stakeholders}
+\foundationtitle{Building Applications Around a Tested Data Backbone}{A five-page business guide to \product{xt.substrate}, \product{xt.db.node}, \product{postgres.core} and AI-assisted delivery}{Audience: business analysts, product owners, delivery leads and solution stakeholders}
 
-\tableofcontents
-\newpage
+\section{1. The proposition}
 
-\section{Executive summary}
+Application programmes commonly implement the same business behaviour several times: in PostgreSQL, service APIs, web clients, mobile clients, integration jobs and edge workers. Each implementation becomes a place where requirements can drift. Synchronisation and permission defects then emerge late, when the interfaces are already expensive to change.
 
-Most application programmes repeatedly implement the same business behaviour in a database, API, web client, mobile client, integration service and edge worker. The result is familiar: requirements drift between teams, sync defects appear late, security rules are duplicated, and interface work becomes blocked by unstable services.
-
-Foundation Base takes a different approach. It establishes a tested application backbone before the final user interface is built:
-
-\begin{itemize}
-  \item \product{postgres.core} expresses and generates database-facing behaviour and RPC operations close to PostgreSQL;
-  \item \product{xt.substrate} provides the spaces, request transport and runtime context through which application parts communicate;
-  \item \product{xt.db.node} models live views, local projections, refresh, invalidation and remote execution;
-  \item automated tests exercise data movement through the same topology that the application will use;
-  \item AI and conventional UI teams then build web, mobile and edge experiences against a stable, executable contract.
-\end{itemize}
-
-\callout{The central proposition}{Do not ask each interface team to rediscover the application. Build and test the movement of data once, then project it into many user experiences.}
-
-\section{The delivery model}
+Foundation Base reverses that order. It creates a tested application backbone before the final interfaces are built.
 
 \begin{center}
-\begin{tikzpicture}[node distance=11mm and 15mm]
-  \node[fbwide] (req) {Business outcomes\\rules and permissions};
-  \node[fbwide,right=of req] (model) {Application model\\views, RPCs, events};
-  \node[fbwide,right=of model] (test) {Backbone tests\\sync and failure cases};
+\begin{tikzpicture}[node distance=9mm and 12mm,scale=.9,transform shape]
+  \node[fbwide] (outcome) {Business outcomes\\rules and permissions};
+  \node[fbwide,right=of outcome] (model) {Application model\\views, RPCs, events};
+  \node[fbwide,right=of model] (tests) {Backbone tests\\sync and failures};
   \node[fbwide,below=of model] (contract) {Verified application contract};
   \node[fbbox,below left=of contract] (web) {Web};
   \node[fbbox,below=of contract] (mobile) {Mobile};
-  \node[fbbox,below right=of contract] (edge) {Edge / automation};
-  \draw[fbedge] (req) -- (model);
-  \draw[fbedge] (model) -- (test);
-  \draw[fbedge] (test) -- (contract);
+  \node[fbbox,below right=of contract] (edge) {Edge};
+  \draw[fbedge] (outcome) -- (model);
+  \draw[fbedge] (model) -- (tests);
+  \draw[fbedge] (tests) -- (contract);
   \draw[fbedge] (model) -- (contract);
   \draw[fbedge] (contract) -- (web);
   \draw[fbedge] (contract) -- (mobile);
@@ -44,61 +29,56 @@ Foundation Base takes a different approach. It establishes a tested application 
 \end{tikzpicture}
 \end{center}
 
-This changes the order of delivery. Instead of treating the API as a late integration point, the team first agrees on the observable behaviour of the system: what data is authoritative, what can be cached locally, which operations may be invoked, how permissions apply, and what should happen during refresh, reconnect and failure.
-
-\section{What the three components contribute}
-
-\subsection{\product{xt.substrate}: application spaces and transport}
-
-A space is an application context, such as a local client space or an authoritative server space. The substrate moves requests and responses between those spaces while keeping the application model independent of the particular network or storage mechanism.
-
-For a business analyst, the useful distinction is not ``frontend versus backend''. It is:
+The three principal components have distinct roles:
 
 \begin{itemize}
-  \item where a decision is made;
-  \item where authoritative data lives;
-  \item which projection the user sees;
-  \item how a result moves from one context to another.
+  \item \product{postgres.core} expresses PostgreSQL-facing structures and RPC operations close to the source of truth;
+  \item \product{xt.substrate} provides application spaces, transport and runtime context;
+  \item \product{xt.db.node} provides named live views, refresh, invalidation and local projections.
 \end{itemize}
 
-\subsection{\product{xt.db.node}: live views and synchronisation behaviour}
+\callout{Core idea}{Build and test the movement of data once, then project that verified behaviour into multiple user experiences.}
 
-A view is a named live query cell with input, status, value and dependencies. A screen can therefore be described as a set of views rather than a collection of ad hoc HTTP calls. Tests can prove that a list refreshes, a selected record remains coherent, stale data is invalidated, and a local projection is updated after a remote operation.
+This is not merely code generation. The backbone is executable. A team can prove which data is authoritative, which data is cached, how a remote operation changes a local view, and how permissions behave before a polished screen exists.
 
-\subsection{\product{postgres.core}: operations close to the data}
+\newpage
+\section{2. The data and RPC backbone}
 
-\product{postgres.core} supports PostgreSQL-oriented definitions and generated behaviour, including functions used as RPC operations. Important rules can execute near the source of truth, reducing the number of partial implementations spread across services. Generated SQL remains reviewable and can be validated independently from the UI.
-
-\section{The concrete local--remote topology}
-
-Foundation Base already exercises a topology in which a local application space can use SQLite while a remote space uses PostgreSQL.
+Foundation models application contexts as \term{spaces}. A local space may represent a web or mobile client. A server space may represent the authoritative application model. Views describe what the application needs to observe. Storage is attached to the space rather than embedded in every screen definition.
 
 \begin{center}
-\begin{tikzpicture}[node distance=12mm and 23mm]
+\begin{tikzpicture}[node distance=10mm and 18mm,scale=.85,transform shape]
   \node[fbwide] (ui) {Web or mobile UI};
   \node[fbwide,below=of ui] (local) {Local space\\live views};
   \node[fbstorage,left=of local] (sqlite) {SQLite\\projection};
-  \node[fbwide,right=of local] (substrate) {\product{xt.substrate}\\request transport};
-  \node[fbwide,right=of substrate] (server) {Server space\\models and RPC};
+  \node[fbwide,right=of local] (transport) {\product{xt.substrate}\\transport};
+  \node[fbwide,right=of transport] (server) {Server space\\model and RPC};
   \node[fbstorage,right=of server] (pg) {Postgres\\authority};
-  \draw[fbedge] (ui) -- node[right,scale=.8]{read state / refresh} (local);
-  \draw[fbedge] (local) -- (substrate);
-  \draw[fbedge] (substrate) -- (server);
+  \draw[fbedge] (ui) -- node[right,scale=.75]{refresh/read} (local);
+  \draw[fbedge] (local) -- (transport);
+  \draw[fbedge] (transport) -- (server);
   \draw[fbedge] (server) -- (pg);
   \draw[fbedge] (local) -- (sqlite);
-  \draw[fbdashed,bend right=25] (server.south) to node[below,scale=.8]{result projected locally} (local.south);
+  \draw[fbdashed,bend right=26] (server.south) to node[below,scale=.75]{project result} (local.south);
 \end{tikzpicture}
 \end{center}
 
-This is useful beyond offline applications. The same pattern supports fast local reads, explicit caching, deterministic refresh and a clearer separation between authoritative records and user-facing projections.
+This topology supports more than offline use. It gives the programme an explicit answer to four important questions:
 
-\section{What gets tested before the UI}
+\begin{enumerate}
+  \item Where is the authoritative record?
+  \item What does the user see locally?
+  \item Which operation changes the authoritative state?
+  \item How does the changed result reach every relevant view?
+\end{enumerate}
+
+The backbone can be tested as a business workflow:
 
 \begin{center}
-\begin{tikzpicture}[node distance=8mm]
-  \node[fbwide] (a) {Create test state};
+\begin{tikzpicture}[node distance=7mm,scale=.88,transform shape]
+  \node[fbwide] (a) {Create controlled test state};
   \node[fbwide,below=of a] (b) {Invoke RPC or refresh};
-  \node[fbwide,below=of b] (c) {Observe remote result};
+  \node[fbwide,below=of b] (c) {Observe authoritative result};
   \node[fbwide,below=of c] (d) {Observe local projection};
   \node[fbwide,below=of d] (e) {Assert permission, status and value};
   \draw[fbedge] (a) -- (b);
@@ -108,94 +88,92 @@ This is useful beyond offline applications. The same pattern supports fast local
 \end{tikzpicture}
 \end{center}
 
-Typical acceptance scenarios include:
+Typical acceptance scenarios cover authorised and unauthorised operations, list/detail coherence, stale view invalidation, remote updates followed by local refresh, reconnect behaviour and the same operation viewed through multiple application channels.
 
-\begin{itemize}
-  \item authorised and unauthorised RPC calls;
-  \item remote updates followed by local refresh;
-  \item list/detail coherence after a mutation;
-  \item stale view invalidation;
-  \item reconnect or replay behaviour;
-  \item the same business operation viewed from web, mobile and edge contexts.
-\end{itemize}
+\newpage
+\section{3. AI-assisted cross-platform delivery}
 
-These tests become durable evidence for requirements. They reduce reliance on screenshots and manual end-to-end scripts as the only proof that a rule was implemented.
-
-\section{How AI fits into the workflow}
-
-AI is most effective when it receives a constrained, executable contract. Once entities, view inputs, RPCs, validation, permissions and result shapes are known, AI can concentrate on presentation and interaction.
+AI is most effective when it is given a constrained, executable contract. Without that contract, an AI tool may invent endpoints, duplicate validation or implement business rules differently in each client. With the backbone in place, AI can focus on composition and experience.
 
 \begin{center}
-\begin{tikzpicture}[node distance=10mm and 18mm]
+\begin{tikzpicture}[node distance=9mm and 16mm,scale=.88,transform shape]
   \node[fbwide] (contract) {Verified contract};
-  \node[fbwide,below left=of contract] (prompt) {UI brief and design system};
-  \node[fbwide,below right=of contract] (examples) {Reference flows and test data};
-  \node[fbwide,below=18mm of contract] (ai) {AI-assisted implementation};
-  \node[fbbox,below left=of ai] (react) {React / Next.js};
-  \node[fbbox,below=of ai] (rn) {React Native};
-  \node[fbbox,below right=of ai] (worker) {Bun / edge worker};
+  \node[fbwide,below left=of contract] (brief) {Design system\\and UI brief};
+  \node[fbwide,below right=of contract] (fixtures) {Fixtures and\\passing flows};
+  \node[fbwide,below=17mm of contract] (ai) {AI-assisted adapter generation};
+  \node[fbbox,below left=of ai] (web) {Next.js};
+  \node[fbbox,below=of ai] (mobile) {Expo / RN};
+  \node[fbbox,below right=of ai] (edge) {Bun / edge};
   \draw[fbedge] (contract) -- (ai);
-  \draw[fbedge] (prompt) -- (ai);
-  \draw[fbedge] (examples) -- (ai);
-  \draw[fbedge] (ai) -- (react);
-  \draw[fbedge] (ai) -- (rn);
-  \draw[fbedge] (ai) -- (worker);
+  \draw[fbedge] (brief) -- (ai);
+  \draw[fbedge] (fixtures) -- (ai);
+  \draw[fbedge] (ai) -- (web);
+  \draw[fbedge] (ai) -- (mobile);
+  \draw[fbedge] (ai) -- (edge);
 \end{tikzpicture}
 \end{center}
 
-AI does not replace product analysis. It shortens the distance between an agreed workflow and a usable interface, while the backbone limits the scope for invented business logic.
+The AI receives known view inputs, statuses, result shapes, RPC arguments, permission outcomes, error conditions and representative test data. It then builds forms, navigation, responsive layouts, optimistic feedback, accessibility and visual polish without becoming the source of domain truth.
 
-\section{Comparison with common delivery methods}
+\subsection{Delivery implications}
 
-\begin{tabularx}{\textwidth}{P{30mm}YYYY}
+\begin{itemize}
+  \item A vertical slice can be proven before a full design system is complete.
+  \item Web, mobile and edge teams consume the same tested operations.
+  \item Requirements are represented by observable behaviours rather than screenshots alone.
+  \item UI redesign does not require rediscovering synchronisation rules.
+  \item AI-generated clients can be regenerated or replaced while the backbone remains stable.
+\end{itemize}
+
+\subsection{Recommended pilot}
+
+Select one entity with a list, detail panel and mutation. Define authority, permissions and local projection. Generate the PostgreSQL operation, test the refresh path through \product{xt.db.node}, then build one web and one mobile adapter. Compare delivery time, sync defects and rule consistency with a conventional feature implemented by the same team.
+
+The pilot should measure whether Foundation reduces semantic duplication. It should not assume success merely because code was generated quickly.
+
+\newpage
+\section{4. Comparison and decision guide}
+
+\begin{tabularx}{\textwidth}{P{28mm}YYY}
 \toprule
-\textbf{Method} & \textbf{Primary contract} & \textbf{Sync testing} & \textbf{Cross-platform reuse} & \textbf{Typical risk} \\
+\textbf{Approach} & \textbf{Primary strength} & \textbf{Sync/local state} & \textbf{Main risk} \\
 \midrule
-UI-first CRUD & Screens and endpoint calls & Usually late, through E2E tests & Low to moderate & Behaviour is inferred separately by each client \\
-REST/OpenAPI & HTTP schema & Good request/response validation; limited local-state semantics & Moderate & Contract describes calls, not complete view lifecycle \\
-GraphQL & Graph and resolver schema & Strong query composition; client cache behaviour remains framework-specific & Moderate to high & Resolver, cache and mutation conventions can diverge \\
-Backend-as-a-Service & Vendor schema, policies and SDK & Fast integration; deeper sync behaviour depends on platform & High within supported clients & Vendor semantics become the architecture \\
-Event sourcing/CQRS & Events, commands and projections & Excellent history and projection testing & High & Operational and conceptual overhead can exceed the problem \\
-Foundation backbone & Spaces, live views, RPC and tested projections & First-class local/remote pipeline tests & High across generated targets & Requires learning the model and maintaining emitter/runtime agreement \\
+UI-first CRUD & Fast initial screens & Usually added later & Rules drift between clients \\
+REST/OpenAPI & Clear HTTP contracts and client generation & Mostly client-managed & Describes calls better than view lifecycle \\
+GraphQL & Flexible query composition & Cache behaviour is framework-specific & Resolver and mutation conventions diverge \\
+Backend-as-a-Service & Rapid schema, auth and realtime delivery & Platform-dependent & Vendor semantics become architecture \\
+CQRS/event sourcing & Explicit history and projections & Strong but operationally complex & Excess complexity for ordinary workflows \\
+Foundation & Tested spaces, views, RPC and projections & First-class local/remote flow & Learning curve and emitter/runtime discipline \\
 \bottomrule
 \end{tabularx}
 
-Foundation is not automatically preferable in every project. A small, connected CRUD site may be delivered faster with a conventional framework. Its advantage grows when the same rules and data flows must work across several runtimes, when local projections matter, or when generated code and AI-assisted clients must remain aligned.
+\subsection{Foundation versus a Bun/Rust rewrite}
 
-\section{Comparison with a Bun/Rust rewrite}
-
-A Bun/Rust rewrite is a different optimisation strategy. Bun can provide a fast JavaScript/TypeScript server and tooling environment; Rust can provide predictable native performance, memory safety and compact services. That combination is attractive when runtime throughput, startup time, deployment size or low-level control is the dominant concern.
-
-\begin{tabularx}{\textwidth}{P{34mm}YY}
+\begin{tabularx}{\textwidth}{P{32mm}YY}
 \toprule
  & \textbf{Foundation backbone} & \textbf{Bun/Rust rewrite} \\
 \midrule
-Main goal & Preserve one executable application model across target ecosystems & Reimplement services using high-performance target runtimes \\
-Reuse mechanism & Language definitions, emitters, runtimes and portable \product{xt.*} modules & Shared protocols, generated clients, schemas and manually shared domain crates/packages \\
-Testing emphasis & Generated syntax, runtime behaviour, RPC and local/remote data movement & Unit/integration tests per service plus protocol and end-to-end tests \\
-Performance path & Move operations to PostgreSQL or emit to an appropriate target & Optimise hot services directly in Rust; use Bun for JS/TS workloads \\
-Team accessibility & Higher initial Lisp/Foundation learning curve & Familiar TypeScript plus a substantial Rust learning curve \\
-Change propagation & One model can affect several generated targets & Changes often span Rust services, TS services and client SDKs \\
-Best fit & Cross-cutting applications where consistency and generation dominate & Performance-sensitive systems where direct ownership of each runtime dominates \\
+Primary goal & Preserve one executable model across ecosystems & Reimplement services in fast target runtimes \\
+Best advantage & Semantic consistency and generation & Native performance and direct runtime control \\
+Testing centre & Emission, runtime, RPC and projection flow & Per-service tests plus protocol conformance \\
+Change propagation & One model can affect several targets & Changes may span Rust, TypeScript and SDKs \\
+Best fit & Cross-cutting applications and sync-heavy products & Measured CPU, memory, latency or startup bottlenecks \\
 \bottomrule
 \end{tabularx}
 
-The two approaches can be combined. Rust can implement a specialised service behind a stable RPC boundary, while Bun can host an edge or web-facing adapter. Foundation can remain the source for the application contract and sync tests. The decision is therefore not necessarily a repository-wide rewrite; it can be a measured placement of specialised runtimes at proven bottlenecks.
+The approaches can be combined. Rust can implement a specialised service behind a stable RPC boundary, while Bun hosts a TypeScript-native web or edge adapter. Foundation can retain the application contract and end-to-end sync tests.
 
-\section{Recommended programme controls}
+\subsection{Programme controls}
 
 \begin{enumerate}
-  \item Define a small vertical slice: one entity, one list/detail workflow and one mutation.
-  \item Write acceptance scenarios around authority, permissions and local projection.
-  \item Generate and inspect PostgreSQL output separately from runtime execution.
-  \item Exercise the same flow through \product{xt.db.node} before designing every screen.
-  \item Give AI tools only the verified contract, design system and acceptance examples.
-  \item Measure delivery time, escaped sync defects and cross-client inconsistency against a conventional slice.
-  \item Introduce Bun or Rust only where measurements show that their runtime characteristics solve a material problem.
+  \item Start with a narrow vertical slice and focused regression facts.
+  \item Inspect generated PostgreSQL separately from runtime behaviour.
+  \item Treat local projection and remote authority as explicit requirements.
+  \item Give AI only verified contracts, fixtures and design constraints.
+  \item Profile before introducing Bun or Rust for performance reasons.
+  \item Keep target-specific services behind tested boundaries.
 \end{enumerate}
 
-\section{Outcome}
-
-The Foundation approach reframes application delivery as the creation of a tested data backbone with multiple presentation surfaces. Business requirements become observable operations and data movements. UI delivery becomes faster and safer because web, mobile and edge applications are projections of behaviour already exercised in tests.
+\callout{Decision rule}{Use Foundation where consistency, projection testing and multi-target generation dominate. Use direct Bun/Rust services where measured runtime constraints dominate. Use a hybrid where both are materially valuable.}
 
 \end{document}

--- a/docs/application-backbone/foundation-backbone.sty
+++ b/docs/application-backbone/foundation-backbone.sty
@@ -1,0 +1,112 @@
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{foundation-backbone}[2026/07/10 Foundation application backbone style]
+
+\RequirePackage{fontspec}
+\RequirePackage[a4paper,margin=22mm]{geometry}
+\RequirePackage{xcolor}
+\RequirePackage{microtype}
+\RequirePackage{graphicx}
+\RequirePackage{booktabs}
+\RequirePackage{tabularx}
+\RequirePackage{array}
+\RequirePackage{enumitem}
+\RequirePackage{titlesec}
+\RequirePackage{fancyhdr}
+\RequirePackage{hyperref}
+\RequirePackage{tikz}
+\RequirePackage{listings}
+\RequirePackage{fontawesome5}
+\usetikzlibrary{arrows.meta,positioning,fit,backgrounds,calc,shapes.geometric,shapes.multipart}
+
+\definecolor{FoundationInk}{HTML}{172033}
+\definecolor{FoundationBlue}{HTML}{2867B2}
+\definecolor{FoundationTeal}{HTML}{168C88}
+\definecolor{FoundationGold}{HTML}{B47A16}
+\definecolor{FoundationRed}{HTML}{A94545}
+\definecolor{FoundationLight}{HTML}{F3F6FA}
+\definecolor{FoundationMid}{HTML}{D9E2EE}
+\definecolor{FoundationGrey}{HTML}{5D6878}
+
+\IfFontExistsTF{Inter}{\setmainfont{Inter}}{\setmainfont{TeX Gyre Heros}}
+\IfFontExistsTF{Roboto Mono}{\setmonofont{Roboto Mono}}{\setmonofont{Latin Modern Mono}}
+
+\hypersetup{
+  colorlinks=true,
+  linkcolor=FoundationBlue,
+  urlcolor=FoundationTeal,
+  citecolor=FoundationBlue,
+  pdftitle={Foundation Application Backbone}
+}
+
+\setlength{\parindent}{0pt}
+\setlength{\parskip}{0.65em}
+\setlist[itemize]{leftmargin=1.5em,itemsep=0.25em,topsep=0.25em}
+\setlist[enumerate]{leftmargin=1.7em,itemsep=0.25em,topsep=0.25em}
+\renewcommand{\arraystretch}{1.25}
+
+\titleformat{\section}{\LARGE\bfseries\color{FoundationInk}}{}{0pt}{}
+\titleformat{\subsection}{\Large\bfseries\color{FoundationBlue}}{}{0pt}{}
+\titleformat{\subsubsection}{\large\bfseries\color{FoundationInk}}{}{0pt}{}
+
+\pagestyle{fancy}
+\fancyhf{}
+\fancyhead[L]{\small\textbf{Foundation Base}}
+\fancyhead[R]{\small Application Backbone}
+\fancyfoot[C]{\small\thepage}
+\renewcommand{\headrulewidth}{0.3pt}
+
+\newcommand{\product}[1]{\texttt{#1}}
+\newcommand{\term}[1]{\textbf{#1}}
+\newcommand{\callout}[2]{%
+  \begin{center}
+  \begin{minipage}{0.94\linewidth}
+  \colorbox{FoundationLight}{\parbox{0.94\linewidth}{\textbf{#1}\par #2}}
+  \end{minipage}
+  \end{center}
+}
+
+\newcommand{\foundationtitle}[3]{%
+  \begin{titlepage}
+  \color{FoundationInk}
+  \vspace*{18mm}
+  {\Huge\bfseries #1\par}
+  \vspace{4mm}
+  {\LARGE #2\par}
+  \vspace{12mm}
+  \begin{tikzpicture}
+    \node[draw=FoundationBlue,fill=FoundationLight,rounded corners=3pt,minimum width=\textwidth,minimum height=22mm,align=left,text width=0.91\textwidth] {
+      \Large\textbf{Model once. Test the movement of data. Generate many application surfaces.}
+    };
+  \end{tikzpicture}
+  \vfill
+  {\large #3\par}
+  \vspace{3mm}
+  {\small Foundation Base --- July 2026\par}
+  \end{titlepage}
+}
+
+\tikzset{
+  fbbox/.style={draw=FoundationBlue,fill=FoundationLight,rounded corners=3pt,minimum height=10mm,align=center,text width=30mm},
+  fbwide/.style={fbbox,text width=43mm},
+  fbstorage/.style={cylinder,shape border rotate=90,aspect=0.25,draw=FoundationTeal,fill=FoundationLight,minimum height=14mm,minimum width=23mm,align=center},
+  fbedge/.style={-{Latex[length=2.5mm]},thick,draw=FoundationGrey},
+  fbdashed/.style={fbedge,dashed},
+  fbgroup/.style={draw=FoundationMid,rounded corners=5pt,inner sep=7pt}
+}
+
+\lstdefinestyle{foundation}{
+  basicstyle=\small\ttfamily,
+  backgroundcolor=\color{FoundationLight},
+  frame=single,
+  rulecolor=\color{FoundationMid},
+  breaklines=true,
+  columns=fullflexible,
+  keepspaces=true,
+  showstringspaces=false,
+  xleftmargin=0.5em,
+  framexleftmargin=0.5em
+}
+\lstset{style=foundation}
+
+\newcolumntype{Y}{>{\raggedright\arraybackslash}X}
+\newcolumntype{P}[1]{>{\raggedright\arraybackslash}p{#1}}

--- a/docs/application-backbone/install-deps.sh
+++ b/docs/application-backbone/install-deps.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$(uname -s)" in
+  Darwin)
+    if ! command -v tlmgr >/dev/null 2>&1; then
+      curl -L https://yihui.org/tinytex/install-unx.sh | sh
+      export PATH="$HOME/Library/TinyTeX/bin/universal-darwin:$PATH"
+    fi
+    tlmgr install latexmk fontspec geometry xcolor microtype graphics booktabs tools enumitem titlesec fancyhdr hyperref pgf listings fontawesome5
+    ;;
+  Linux)
+    sudo apt-get update
+    sudo apt-get install -y --no-install-recommends \
+      texlive-xetex \
+      texlive-latex-extra \
+      texlive-fonts-recommended \
+      texlive-pictures \
+      latexmk \
+      fonts-inter \
+      fonts-roboto
+    sudo fc-cache -fv
+    ;;
+  *)
+    echo "Unsupported operating system: $(uname -s)" >&2
+    exit 1
+    ;;
+esac

--- a/docs/application-backbone/senior-developer.tex
+++ b/docs/application-backbone/senior-developer.tex
@@ -1,0 +1,322 @@
+\documentclass[11pt]{article}
+\usepackage{foundation-backbone}
+
+\begin{document}
+\foundationtitle{Foundation as an Executable Application Backbone}{A technical guide for senior developers working across PostgreSQL, JavaScript, mobile, edge and native ecosystems}{Audience: senior developers and architects who may be new to Clojure, Lisp and Foundation}
+
+\tableofcontents
+\newpage
+
+\section{Architectural intent}
+
+Foundation Base is not primarily a web framework. It is a language and runtime toolkit for describing behaviour, emitting target-language code, running that code in target runtimes, and testing the agreement between those stages.
+
+For application work, three areas form a useful backbone:
+
+\begin{itemize}
+  \item \product{postgres.core}: PostgreSQL definitions and generated database-side operations;
+  \item \product{xt.substrate}: spaces, request/response transport, eventing and runtime context;
+  \item \product{xt.db.node}: models, named views, local caches, SQL attachments, invalidation and remote refresh.
+\end{itemize}
+
+The intended outcome is a stable application contract that is executable before a production UI exists.
+
+\section{Mental model for non-Lisp developers}
+
+Lisp syntax makes code structure explicit with lists. A form such as:
+
+\begin{lstlisting}[language=Lisp]
+(model/view-refresh node "room/local" "orders" "list")
+\end{lstlisting}
+
+is equivalent in intent to a conventional function call. The additional value in Foundation is that forms can be inspected and transformed as data before they are emitted to JavaScript, SQL, Python or another target.
+
+\begin{center}
+\begin{tikzpicture}[node distance=11mm and 16mm]
+  \node[fbwide] (form) {Source form\\data structure};
+  \node[fbwide,right=of form] (prep) {Preprocessing\\macro expansion};
+  \node[fbwide,right=of prep] (grammar) {Target grammar\\validated constructs};
+  \node[fbwide,below=of prep] (emit) {Emitter output};
+  \node[fbwide,left=of emit] (runtime) {Target runtime};
+  \node[fbwide,right=of emit] (tests) {Emission and runtime tests};
+  \draw[fbedge] (form) -- (prep);
+  \draw[fbedge] (prep) -- (grammar);
+  \draw[fbedge] (grammar) -- (emit);
+  \draw[fbedge] (emit) -- (runtime);
+  \draw[fbedge] (emit) -- (tests);
+  \draw[fbedge] (runtime) -- (tests);
+\end{tikzpicture}
+\end{center}
+
+This pipeline is why a portable module is more than a shared package. Its source form, transformations, target grammar, emitted syntax and runtime result are all part of the implementation.
+
+\section{Backbone topology}
+
+\subsection{Spaces and live views}
+
+A substrate node owns application spaces. A space can represent a local client context, a remote server context, a test peer or another logical boundary. \product{xt.db.node} installs models into spaces. A model groups named views; each view has query input, status, value, dependencies and a query key.
+
+\begin{center}
+\begin{tikzpicture}[node distance=10mm and 18mm]
+  \node[fbwide] (node) {substrate node};
+  \node[fbwide,below left=of node] (local) {space: room/local};
+  \node[fbwide,below right=of node] (server) {space: room/server};
+  \node[fbbox,below left=of local] (list) {view: list};
+  \node[fbbox,below right=of local] (detail) {view: detail};
+  \node[fbwide,below=of server] (model) {server model};
+  \draw[fbedge] (node) -- (local);
+  \draw[fbedge] (node) -- (server);
+  \draw[fbedge] (local) -- (list);
+  \draw[fbedge] (local) -- (detail);
+  \draw[fbedge] (server) -- (model);
+\end{tikzpicture}
+\end{center}
+
+The application-facing shape is defined before storage. A view can begin in memory, then be backed by SQLite or delegated to a remote Postgres-backed space without changing the screen-level model.
+
+\subsection{Local SQLite and remote PostgreSQL}
+
+The repository walkthroughs exercise this topology directly:
+
+\begin{center}
+\begin{tikzpicture}[node distance=11mm and 20mm]
+  \node[fbwide] (ui) {UI adapter};
+  \node[fbwide,right=of ui] (lv) {local live view};
+  \node[fbstorage,below=of lv] (sqlite) {SQLite};
+  \node[fbwide,right=of lv] (transport) {substrate transport};
+  \node[fbwide,right=of transport] (sv) {server view / RPC};
+  \node[fbstorage,below=of sv] (pg) {Postgres};
+  \draw[fbedge] (ui) -- node[above,scale=.8]{refresh / read} (lv);
+  \draw[fbedge] (lv) -- (transport);
+  \draw[fbedge] (transport) -- (sv);
+  \draw[fbedge] (sv) -- (pg);
+  \draw[fbedge] (lv) -- (sqlite);
+  \draw[fbdashed,bend right=28] (sv.south) to node[below,scale=.8]{project result} (lv.south);
+\end{tikzpicture}
+\end{center}
+
+This makes the local store an explicit materialised projection rather than an incidental framework cache.
+
+\section{Role of \product{postgres.core}}
+
+\product{postgres.core} is part of the target-language system rather than an ORM abstraction over SQL. PostgreSQL functions, graph operations and supporting definitions can be expressed in Foundation forms, emitted as SQL/PLpgSQL and executed in a PostgreSQL runtime.
+
+A robust workflow treats database generation as a separate validation stage:
+
+\begin{enumerate}
+  \item inspect the source form and nearby grammar definitions;
+  \item emit SQL and review the exact generated text;
+  \item validate syntax and quoting against PostgreSQL;
+  \item execute against a disposable database where the environment permits;
+  \item invoke the operation through the same RPC path used by the application;
+  \item verify the resulting local projection through \product{xt.db.node}.
+\end{enumerate}
+
+\begin{center}
+\begin{tikzpicture}[node distance=9mm]
+  \node[fbwide] (src) {Foundation Postgres form};
+  \node[fbwide,below=of src] (sql) {Emitted SQL / PLpgSQL};
+  \node[fbwide,below=of sql] (db) {Database execution};
+  \node[fbwide,below=of db] (rpc) {RPC invocation};
+  \node[fbwide,below=of rpc] (projection) {Local view projection};
+  \draw[fbedge] (src) -- (sql);
+  \draw[fbedge] (sql) -- (db);
+  \draw[fbedge] (db) -- (rpc);
+  \draw[fbedge] (rpc) -- (projection);
+\end{tikzpicture}
+\end{center}
+
+\section{Testing strategy}
+
+The highest-value tests are not isolated CRUD facts. They prove agreement across layers.
+
+\subsection{Test pyramid for generated applications}
+
+\begin{center}
+\begin{tikzpicture}
+  \filldraw[fill=FoundationLight,draw=FoundationBlue] (0,0) -- (12,0) -- (10.8,1.4) -- (1.2,1.4) -- cycle;
+  \node at (6,.7) {grammar, transformation and emitter facts};
+  \filldraw[fill=FoundationLight,draw=FoundationTeal] (1.2,1.6) -- (10.8,1.6) -- (9.5,3) -- (2.5,3) -- cycle;
+  \node at (6,2.3) {target runtime and database execution};
+  \filldraw[fill=FoundationLight,draw=FoundationGold] (2.5,3.2) -- (9.5,3.2) -- (8.2,4.6) -- (3.8,4.6) -- cycle;
+  \node at (6,3.9) {RPC, sync and projection flows};
+  \filldraw[fill=FoundationLight,draw=FoundationRed] (3.8,4.8) -- (8.2,4.8) -- (7.1,6.2) -- (4.9,6.2) -- cycle;
+  \node[align=center] at (6,5.5) {thin UI\\acceptance};
+\end{tikzpicture}
+\end{center}
+
+This ordering pushes correctness below the UI. UI tests then verify interaction and accessibility rather than re-proving every database rule.
+
+\subsection{Representative flow test}
+
+\begin{center}
+\begin{tikzpicture}[node distance=12mm and 16mm]
+  \node[fbbox] (test) {code.test fact};
+  \node[fbwide,right=of test] (local) {local view refresh};
+  \node[fbwide,right=of local] (remote) {remote dispatch};
+  \node[fbstorage,below=of remote] (pg) {Postgres};
+  \node[fbstorage,below=of local] (sqlite) {SQLite};
+  \node[fbwide,left=of sqlite] (assert) {assert status, value, invalidation};
+  \draw[fbedge] (test) -- (local);
+  \draw[fbedge] (local) -- (remote);
+  \draw[fbedge] (remote) -- (pg);
+  \draw[fbedge] (remote) -- (local);
+  \draw[fbedge] (local) -- (sqlite);
+  \draw[fbedge] (sqlite) -- (assert);
+\end{tikzpicture}
+\end{center}
+
+\section{AI-generated UI as an adapter}
+
+Once the backbone is executable, UI generation can be treated as adapter generation. The AI receives:
+
+\begin{itemize}
+  \item model and view definitions;
+  \item view inputs, statuses and result shapes;
+  \item RPC names, arguments, errors and permissions;
+  \item fixture data and passing flow tests;
+  \item the design system and target framework constraints.
+\end{itemize}
+
+The generated client should not reproduce domain rules. It invokes operations, renders view state and adapts interaction to the target ecosystem.
+
+\begin{center}
+\begin{tikzpicture}[node distance=11mm and 15mm]
+  \node[fbwide] (backbone) {Executable backbone};
+  \node[fbwide,below=of backbone] (adapter) {Generated adapter boundary};
+  \node[fbbox,below left=of adapter] (next) {Next.js};
+  \node[fbbox,below=of adapter] (expo) {Expo / RN};
+  \node[fbbox,below right=of adapter] (edge) {Bun / edge};
+  \draw[fbedge] (backbone) -- (adapter);
+  \draw[fbedge] (adapter) -- (next);
+  \draw[fbedge] (adapter) -- (expo);
+  \draw[fbedge] (adapter) -- (edge);
+\end{tikzpicture}
+\end{center}
+
+\section{Comparison with established approaches}
+
+\begin{tabularx}{\textwidth}{P{27mm}YYYY}
+\toprule
+\textbf{Approach} & \textbf{Contract} & \textbf{Local state} & \textbf{Generation} & \textbf{Main trade-off} \\
+\midrule
+REST + OpenAPI & HTTP operations and schemas & Client-framework responsibility & Excellent clients and server stubs & Weak model of view lifecycle and sync \\
+GraphQL & Type graph and resolver operations & Normalised client cache, framework-specific & Strong schema tooling & Resolver/cache semantics are distributed \\
+gRPC / Protobuf & Binary service contracts & Application responsibility & Excellent multi-language stubs & RPC-centric, not projection-centric \\
+Prisma / ORM & Database model and generated client & Application responsibility & Strong DB client generation & Domain and sync behaviour remain elsewhere \\
+Supabase/Firebase & Hosted schema, auth, realtime and SDK & Platform-managed or client SDK cache & Fast client delivery & Vendor-specific semantics and boundaries \\
+CQRS/event sourcing & Commands, events and projections & Explicit projections & Often custom generators & Operational cost and eventual consistency complexity \\
+Local-first frameworks & Replicated local model & First-class & Varies & Conflict semantics and backend integration can dominate \\
+Foundation & Forms, grammars, spaces, views, RPC and runtime tests & Explicit local projection attached to a space & Multi-target emitters and portable modules & Requires Foundation literacy and cross-stage discipline \\
+\bottomrule
+\end{tabularx}
+
+Foundation's differentiator is not that it alone can generate code or support local state. It is the ability to keep source forms, emitted target code, target runtimes and local/remote projection tests in one repository and one implementation workflow.
+
+\section{Comparison with a Bun/Rust rewrite}
+
+A Bun/Rust rewrite should be evaluated as an alternative decomposition, not as an automatic successor architecture.
+
+\subsection{Typical Bun/Rust topology}
+
+\begin{center}
+\begin{tikzpicture}[node distance=11mm and 18mm]
+  \node[fbwide] (client) {TypeScript clients};
+  \node[fbwide,right=of client] (bun) {Bun API / edge layer};
+  \node[fbwide,right=of bun] (rust) {Rust domain services};
+  \node[fbstorage,right=of rust] (pg) {Postgres};
+  \node[fbwide,below=of bun] (schema) {OpenAPI / Protobuf / shared schemas};
+  \draw[fbedge] (client) -- (bun);
+  \draw[fbedge] (bun) -- (rust);
+  \draw[fbedge] (rust) -- (pg);
+  \draw[fbdashed] (schema) -- (client);
+  \draw[fbdashed] (schema) -- (bun);
+  \draw[fbdashed] (schema) -- (rust);
+\end{tikzpicture}
+\end{center}
+
+This architecture can be excellent when the system needs highly tuned native services, predictable memory use, low startup overhead or a TypeScript-native web/edge layer. It also makes the target implementation direct: Rust developers read Rust and Bun developers read TypeScript.
+
+\subsection{Trade-off matrix}
+
+\begin{tabularx}{\textwidth}{P{34mm}YY}
+\toprule
+\textbf{Dimension} & \textbf{Foundation} & \textbf{Bun/Rust rewrite} \\
+\midrule
+Primary abstraction & Portable source forms and target grammars & Services and packages in their implementation languages \\
+Source of truth & Foundation module plus emitter/runtime tests & Protocol schemas plus Rust/TypeScript implementations \\
+Runtime efficiency & Depends on emitted target and placement of work, especially PostgreSQL & Direct control; Rust is strong for CPU, memory and concurrency hot paths \\
+Developer onboarding & Lisp syntax and Foundation concepts are unfamiliar to many & Bun/TypeScript is accessible; production Rust has a steep ownership/type learning curve \\
+Cross-target consistency & High when portable modules and tests remain supported across targets & Must be enforced through schemas, generated clients and conformance suites \\
+Debugging & Requires tracing source form through emitted code and runtime & Familiar target-native debugging in each service \\
+Change surface & A model change may regenerate several targets & A contract change may require multiple service and client updates \\
+Local/remote sync & Modelled directly through spaces, views and projections & Requires a chosen sync/local-first library or custom protocol \\
+Best optimisation & Reduce semantic duplication and improve generation & Maximise target-native performance and operational isolation \\
+Failure mode & Unsupported grammar constructs or emitter/runtime disagreement & Protocol drift, duplicated domain rules and service integration complexity \\
+\bottomrule
+\end{tabularx}
+
+\subsection{Hybrid placement}
+
+The strongest design may be hybrid:
+
+\begin{center}
+\begin{tikzpicture}[node distance=10mm and 17mm]
+  \node[fbwide] (model) {Foundation contract and sync tests};
+  \node[fbwide,below left=of model] (pg) {Generated Postgres RPC};
+  \node[fbwide,below=of model] (bun) {Bun web / edge adapter};
+  \node[fbwide,below right=of model] (rust) {Rust specialised service};
+  \node[fbwide,below=20mm of model] (clients) {Web and mobile clients};
+  \draw[fbedge] (model) -- (pg);
+  \draw[fbedge] (model) -- (bun);
+  \draw[fbedge] (model) -- (rust);
+  \draw[fbedge] (pg) -- (clients);
+  \draw[fbedge] (bun) -- (clients);
+  \draw[fbedge] (rust) -- (clients);
+\end{tikzpicture}
+\end{center}
+
+Use Rust for a measured hotspot or systems boundary, Bun for a TypeScript-native adapter, and Foundation for contract generation and end-to-end projection tests. This preserves the rewrite's performance benefits without discarding the tested backbone.
+
+\section{Decision framework}
+
+Prefer Foundation when:
+
+\begin{itemize}
+  \item the same domain behaviour must be projected across several target ecosystems;
+  \item generated SQL and portable modules already express substantial business value;
+  \item local SQLite/remote PostgreSQL behaviour is important;
+  \item consistency and testable code generation are more valuable than target-native familiarity.
+\end{itemize}
+
+Prefer a direct Bun/Rust implementation when:
+
+\begin{itemize}
+  \item profiling demonstrates CPU, memory, latency or startup constraints that target-native code materially improves;
+  \item the service boundary is narrow and stable;
+  \item the organisation can sustain Rust and TypeScript implementations plus protocol conformance tests;
+  \item local projection and cross-target generation are not central requirements.
+\end{itemize}
+
+Prefer a hybrid when a small number of native services provide clear value but the broader application still benefits from one tested contract.
+
+\section{Implementation workflow}
+
+\begin{enumerate}
+  \item Read the relevant \product{xt.substrate}, \product{xt.db.node} and \product{postgres.core} source and matching \product{code.test} facts.
+  \item Reproduce one vertical flow using the narrowest test namespace.
+  \item Define the server model and RPC operation.
+  \item Define local views and their remote space mapping.
+  \item Attach Postgres to the server space and SQLite or cache storage to the local space.
+  \item Assert emitted SQL separately from database execution.
+  \item Assert refresh, invalidation and projection behaviour through the node runtime.
+  \item Generate a thin UI adapter and verify it against fixtures and the live backbone.
+  \item Profile before assigning work to Bun or Rust.
+  \item Add contract/conformance tests for every specialised runtime boundary.
+\end{enumerate}
+
+\section{Conclusion}
+
+Foundation offers a semantics-first route to cross-cutting applications. It is strongest where code generation, database-side RPC, portable modules and local/remote state must evolve together. Bun and Rust offer a runtime-first route with excellent target-native characteristics. A disciplined architecture chooses between them per boundary, based on measured constraints, while retaining executable contracts and end-to-end data movement tests as the common quality mechanism.
+
+\end{document}

--- a/docs/application-backbone/senior-developer.tex
+++ b/docs/application-backbone/senior-developer.tex
@@ -1,44 +1,31 @@
-\documentclass[11pt]{article}
+\documentclass[10pt]{article}
 \usepackage{foundation-backbone}
 
 \begin{document}
-\foundationtitle{Foundation as an Executable Application Backbone}{A technical guide for senior developers working across PostgreSQL, JavaScript, mobile, edge and native ecosystems}{Audience: senior developers and architects who may be new to Clojure, Lisp and Foundation}
+\foundationtitle{Foundation as an Executable Application Backbone}{A five-page technical guide for senior developers across PostgreSQL, JavaScript, mobile, edge and native ecosystems}{Audience: senior developers and architects who may be new to Clojure, Lisp and Foundation}
 
-\tableofcontents
-\newpage
+\section{1. Architectural model}
 
-\section{Architectural intent}
+Foundation Base is not primarily a web framework. It is a language and runtime toolkit for describing behaviour, transforming source forms, emitting target-language code, executing that code in target runtimes and testing agreement across those stages.
 
-Foundation Base is not primarily a web framework. It is a language and runtime toolkit for describing behaviour, emitting target-language code, running that code in target runtimes, and testing the agreement between those stages.
-
-For application work, three areas form a useful backbone:
+For application work, three areas form the backbone:
 
 \begin{itemize}
-  \item \product{postgres.core}: PostgreSQL definitions and generated database-side operations;
-  \item \product{xt.substrate}: spaces, request/response transport, eventing and runtime context;
-  \item \product{xt.db.node}: models, named views, local caches, SQL attachments, invalidation and remote refresh.
+  \item \product{postgres.core}: PostgreSQL-oriented definitions and database-side RPC operations;
+  \item \product{xt.substrate}: nodes, spaces, request transport, eventing and runtime context;
+  \item \product{xt.db.node}: models, named views, local stores, invalidation and remote refresh.
 \end{itemize}
 
-The intended outcome is a stable application contract that is executable before a production UI exists.
-
-\section{Mental model for non-Lisp developers}
-
-Lisp syntax makes code structure explicit with lists. A form such as:
-
-\begin{lstlisting}[language=Lisp]
-(model/view-refresh node "room/local" "orders" "list")
-\end{lstlisting}
-
-is equivalent in intent to a conventional function call. The additional value in Foundation is that forms can be inspected and transformed as data before they are emitted to JavaScript, SQL, Python or another target.
+For developers unfamiliar with Lisp, a form is both executable code and inspectable data. That permits Foundation to transform the same logical definition into supported target syntax.
 
 \begin{center}
-\begin{tikzpicture}[node distance=11mm and 16mm]
+\begin{tikzpicture}[node distance=9mm and 12mm,scale=.86,transform shape]
   \node[fbwide] (form) {Source form\\data structure};
-  \node[fbwide,right=of form] (prep) {Preprocessing\\macro expansion};
-  \node[fbwide,right=of prep] (grammar) {Target grammar\\validated constructs};
+  \node[fbwide,right=of form] (prep) {Preprocessing\\and macros};
+  \node[fbwide,right=of prep] (grammar) {Target grammar\\supported forms};
   \node[fbwide,below=of prep] (emit) {Emitter output};
   \node[fbwide,left=of emit] (runtime) {Target runtime};
-  \node[fbwide,right=of emit] (tests) {Emission and runtime tests};
+  \node[fbwide,right=of emit] (tests) {Emitter and\\runtime tests};
   \draw[fbedge] (form) -- (prep);
   \draw[fbedge] (prep) -- (grammar);
   \draw[fbedge] (grammar) -- (emit);
@@ -48,72 +35,42 @@ is equivalent in intent to a conventional function call. The additional value in
 \end{tikzpicture}
 \end{center}
 
-This pipeline is why a portable module is more than a shared package. Its source form, transformations, target grammar, emitted syntax and runtime result are all part of the implementation.
+A portable module is therefore more than a shared library. Its source form, preprocessing, grammar representation, emitted syntax and runtime result all belong to the implementation contract.
 
-\section{Backbone topology}
+\callout{Technical proposition}{Treat the application model and its data movement as executable infrastructure. Generate thin target adapters only after RPC, refresh and projection behaviour are proven.}
 
-\subsection{Spaces and live views}
+\newpage
+\section{2. Spaces, views and PostgreSQL}
 
-A substrate node owns application spaces. A space can represent a local client context, a remote server context, a test peer or another logical boundary. \product{xt.db.node} installs models into spaces. A model groups named views; each view has query input, status, value, dependencies and a query key.
+A substrate node owns application spaces. A space represents an execution context such as \texttt{room/local} or \texttt{room/server}. \product{xt.db.node} installs models into spaces. A model groups named views; a view holds query input, status, value, dependencies and a query key.
 
-\begin{center}
-\begin{tikzpicture}[node distance=10mm and 18mm]
-  \node[fbwide] (node) {substrate node};
-  \node[fbwide,below left=of node] (local) {space: room/local};
-  \node[fbwide,below right=of node] (server) {space: room/server};
-  \node[fbbox,below left=of local] (list) {view: list};
-  \node[fbbox,below right=of local] (detail) {view: detail};
-  \node[fbwide,below=of server] (model) {server model};
-  \draw[fbedge] (node) -- (local);
-  \draw[fbedge] (node) -- (server);
-  \draw[fbedge] (local) -- (list);
-  \draw[fbedge] (local) -- (detail);
-  \draw[fbedge] (server) -- (model);
-\end{tikzpicture}
-\end{center}
-
-The application-facing shape is defined before storage. A view can begin in memory, then be backed by SQLite or delegated to a remote Postgres-backed space without changing the screen-level model.
-
-\subsection{Local SQLite and remote PostgreSQL}
-
-The repository walkthroughs exercise this topology directly:
+The repository walkthroughs exercise an explicit local SQLite and remote PostgreSQL pipeline:
 
 \begin{center}
-\begin{tikzpicture}[node distance=11mm and 20mm]
+\begin{tikzpicture}[node distance=9mm and 14mm,scale=.83,transform shape]
   \node[fbwide] (ui) {UI adapter};
-  \node[fbwide,right=of ui] (lv) {local live view};
-  \node[fbstorage,below=of lv] (sqlite) {SQLite};
-  \node[fbwide,right=of lv] (transport) {substrate transport};
-  \node[fbwide,right=of transport] (sv) {server view / RPC};
-  \node[fbstorage,below=of sv] (pg) {Postgres};
-  \draw[fbedge] (ui) -- node[above,scale=.8]{refresh / read} (lv);
-  \draw[fbedge] (lv) -- (transport);
-  \draw[fbedge] (transport) -- (sv);
-  \draw[fbedge] (sv) -- (pg);
-  \draw[fbedge] (lv) -- (sqlite);
-  \draw[fbdashed,bend right=28] (sv.south) to node[below,scale=.8]{project result} (lv.south);
+  \node[fbwide,right=of ui] (local) {local live view};
+  \node[fbstorage,below=of local] (sqlite) {SQLite};
+  \node[fbwide,right=of local] (transport) {substrate transport};
+  \node[fbwide,right=of transport] (server) {server model / RPC};
+  \node[fbstorage,below=of server] (pg) {Postgres};
+  \draw[fbedge] (ui) -- node[above,scale=.75]{refresh/read} (local);
+  \draw[fbedge] (local) -- (transport);
+  \draw[fbedge] (transport) -- (server);
+  \draw[fbedge] (server) -- (pg);
+  \draw[fbedge] (local) -- (sqlite);
+  \draw[fbdashed,bend right=27] (server.south) to node[below,scale=.75]{project result} (local.south);
 \end{tikzpicture}
 \end{center}
 
-This makes the local store an explicit materialised projection rather than an incidental framework cache.
+The application-facing model is defined before storage. A view may begin in an in-memory cache, move to SQLite or delegate to a remote Postgres-backed space without changing the conceptual screen contract.
 
-\section{Role of \product{postgres.core}}
+\subsection{Role of \product{postgres.core}}
 
-\product{postgres.core} is part of the target-language system rather than an ORM abstraction over SQL. PostgreSQL functions, graph operations and supporting definitions can be expressed in Foundation forms, emitted as SQL/PLpgSQL and executed in a PostgreSQL runtime.
-
-A robust workflow treats database generation as a separate validation stage:
-
-\begin{enumerate}
-  \item inspect the source form and nearby grammar definitions;
-  \item emit SQL and review the exact generated text;
-  \item validate syntax and quoting against PostgreSQL;
-  \item execute against a disposable database where the environment permits;
-  \item invoke the operation through the same RPC path used by the application;
-  \item verify the resulting local projection through \product{xt.db.node}.
-\end{enumerate}
+\product{postgres.core} is part of the target-language system rather than an ORM over SQL. PostgreSQL functions and supporting definitions can be represented in Foundation forms, emitted as SQL/PLpgSQL and executed against PostgreSQL.
 
 \begin{center}
-\begin{tikzpicture}[node distance=9mm]
+\begin{tikzpicture}[node distance=7mm,scale=.86,transform shape]
   \node[fbwide] (src) {Foundation Postgres form};
   \node[fbwide,below=of src] (sql) {Emitted SQL / PLpgSQL};
   \node[fbwide,below=of sql] (db) {Database execution};
@@ -126,62 +83,40 @@ A robust workflow treats database generation as a separate validation stage:
 \end{tikzpicture}
 \end{center}
 
-\section{Testing strategy}
+Validation should separately prove emitted syntax, database execution, RPC behaviour and the resulting local projection. A passing emitter test alone does not establish runtime correctness.
 
-The highest-value tests are not isolated CRUD facts. They prove agreement across layers.
+\newpage
+\section{3. Testing and AI-generated adapters}
 
-\subsection{Test pyramid for generated applications}
+The highest-value tests prove agreement across layers rather than only isolated CRUD functions.
 
 \begin{center}
 \begin{tikzpicture}
-  \filldraw[fill=FoundationLight,draw=FoundationBlue] (0,0) -- (12,0) -- (10.8,1.4) -- (1.2,1.4) -- cycle;
-  \node at (6,.7) {grammar, transformation and emitter facts};
-  \filldraw[fill=FoundationLight,draw=FoundationTeal] (1.2,1.6) -- (10.8,1.6) -- (9.5,3) -- (2.5,3) -- cycle;
-  \node at (6,2.3) {target runtime and database execution};
-  \filldraw[fill=FoundationLight,draw=FoundationGold] (2.5,3.2) -- (9.5,3.2) -- (8.2,4.6) -- (3.8,4.6) -- cycle;
-  \node at (6,3.9) {RPC, sync and projection flows};
-  \filldraw[fill=FoundationLight,draw=FoundationRed] (3.8,4.8) -- (8.2,4.8) -- (7.1,6.2) -- (4.9,6.2) -- cycle;
-  \node[align=center] at (6,5.5) {thin UI\\acceptance};
+  \filldraw[fill=FoundationLight,draw=FoundationBlue] (0,0) -- (12,0) -- (10.8,1.25) -- (1.2,1.25) -- cycle;
+  \node at (6,.62) {grammar, transformation and emitter facts};
+  \filldraw[fill=FoundationLight,draw=FoundationTeal] (1.2,1.45) -- (10.8,1.45) -- (9.5,2.7) -- (2.5,2.7) -- cycle;
+  \node at (6,2.07) {target runtime and database execution};
+  \filldraw[fill=FoundationLight,draw=FoundationGold] (2.5,2.9) -- (9.5,2.9) -- (8.2,4.15) -- (3.8,4.15) -- cycle;
+  \node at (6,3.52) {RPC, sync and projection flows};
+  \filldraw[fill=FoundationLight,draw=FoundationRed] (3.8,4.35) -- (8.2,4.35) -- (7.1,5.6) -- (4.9,5.6) -- cycle;
+  \node[align=center] at (6,4.97) {thin UI acceptance};
 \end{tikzpicture}
 \end{center}
 
-This ordering pushes correctness below the UI. UI tests then verify interaction and accessibility rather than re-proving every database rule.
+A representative flow test should:
 
-\subsection{Representative flow test}
+\begin{enumerate}
+  \item create controlled server and local state;
+  \item invoke an RPC or remote view refresh;
+  \item assert the authoritative PostgreSQL result;
+  \item assert local SQLite projection, status and invalidation;
+  \item repeat for permission and failure paths.
+\end{enumerate}
 
-\begin{center}
-\begin{tikzpicture}[node distance=12mm and 16mm]
-  \node[fbbox] (test) {code.test fact};
-  \node[fbwide,right=of test] (local) {local view refresh};
-  \node[fbwide,right=of local] (remote) {remote dispatch};
-  \node[fbstorage,below=of remote] (pg) {Postgres};
-  \node[fbstorage,below=of local] (sqlite) {SQLite};
-  \node[fbwide,left=of sqlite] (assert) {assert status, value, invalidation};
-  \draw[fbedge] (test) -- (local);
-  \draw[fbedge] (local) -- (remote);
-  \draw[fbedge] (remote) -- (pg);
-  \draw[fbedge] (remote) -- (local);
-  \draw[fbedge] (local) -- (sqlite);
-  \draw[fbedge] (sqlite) -- (assert);
-\end{tikzpicture}
-\end{center}
-
-\section{AI-generated UI as an adapter}
-
-Once the backbone is executable, UI generation can be treated as adapter generation. The AI receives:
-
-\begin{itemize}
-  \item model and view definitions;
-  \item view inputs, statuses and result shapes;
-  \item RPC names, arguments, errors and permissions;
-  \item fixture data and passing flow tests;
-  \item the design system and target framework constraints.
-\end{itemize}
-
-The generated client should not reproduce domain rules. It invokes operations, renders view state and adapts interaction to the target ecosystem.
+Once that backbone is executable, AI-generated UI becomes adapter generation rather than domain invention.
 
 \begin{center}
-\begin{tikzpicture}[node distance=11mm and 15mm]
+\begin{tikzpicture}[node distance=9mm and 14mm,scale=.87,transform shape]
   \node[fbwide] (backbone) {Executable backbone};
   \node[fbwide,below=of backbone] (adapter) {Generated adapter boundary};
   \node[fbbox,below left=of adapter] (next) {Next.js};
@@ -194,129 +129,56 @@ The generated client should not reproduce domain rules. It invokes operations, r
 \end{tikzpicture}
 \end{center}
 
-\section{Comparison with established approaches}
+The AI should receive view definitions, statuses, result shapes, RPC arguments, permission outcomes, fixtures, passing flow tests and target-framework constraints. The generated client renders state and invokes operations; it should not reproduce database rules.
 
-\begin{tabularx}{\textwidth}{P{27mm}YYYY}
+This arrangement keeps UI acceptance tests thin. They verify interaction, accessibility and target integration while emitter, runtime, RPC and sync tests carry most correctness.
+
+\newpage
+\section{4. Ecosystem comparison and rewrite strategy}
+
+\begin{tabularx}{\textwidth}{P{27mm}YYY}
 \toprule
-\textbf{Approach} & \textbf{Contract} & \textbf{Local state} & \textbf{Generation} & \textbf{Main trade-off} \\
+\textbf{Approach} & \textbf{Contract} & \textbf{Local state} & \textbf{Main trade-off} \\
 \midrule
-REST + OpenAPI & HTTP operations and schemas & Client-framework responsibility & Excellent clients and server stubs & Weak model of view lifecycle and sync \\
-GraphQL & Type graph and resolver operations & Normalised client cache, framework-specific & Strong schema tooling & Resolver/cache semantics are distributed \\
-gRPC / Protobuf & Binary service contracts & Application responsibility & Excellent multi-language stubs & RPC-centric, not projection-centric \\
-Prisma / ORM & Database model and generated client & Application responsibility & Strong DB client generation & Domain and sync behaviour remain elsewhere \\
-Supabase/Firebase & Hosted schema, auth, realtime and SDK & Platform-managed or client SDK cache & Fast client delivery & Vendor-specific semantics and boundaries \\
-CQRS/event sourcing & Commands, events and projections & Explicit projections & Often custom generators & Operational cost and eventual consistency complexity \\
-Local-first frameworks & Replicated local model & First-class & Varies & Conflict semantics and backend integration can dominate \\
-Foundation & Forms, grammars, spaces, views, RPC and runtime tests & Explicit local projection attached to a space & Multi-target emitters and portable modules & Requires Foundation literacy and cross-stage discipline \\
+REST/OpenAPI & HTTP operations and schemas & Client responsibility & Strong stubs; weak view lifecycle model \\
+GraphQL & Type graph and resolvers & Framework-specific cache & Flexible queries; distributed mutation semantics \\
+gRPC/Protobuf & Binary service schema & Application responsibility & Excellent stubs; RPC-centric \\
+ORM/Prisma & Database model and client & Application responsibility & Strong DB access; domain and sync remain elsewhere \\
+Supabase/Firebase & Vendor schema, auth and SDK & Platform-dependent & Rapid delivery; vendor semantics dominate \\
+CQRS/event sourcing & Commands, events, projections & Explicit & Strong history; high operational complexity \\
+Foundation & Forms, grammars, spaces, views and RPC & Explicit local projection & Cross-stage discipline and learning curve \\
 \bottomrule
 \end{tabularx}
 
-Foundation's differentiator is not that it alone can generate code or support local state. It is the ability to keep source forms, emitted target code, target runtimes and local/remote projection tests in one repository and one implementation workflow.
+\subsection{Foundation versus a Bun/Rust rewrite}
 
-\section{Comparison with a Bun/Rust rewrite}
+A Bun/Rust rewrite is a runtime-first optimisation. Foundation is a semantics-first optimisation.
 
-A Bun/Rust rewrite should be evaluated as an alternative decomposition, not as an automatic successor architecture.
-
-\subsection{Typical Bun/Rust topology}
-
-\begin{center}
-\begin{tikzpicture}[node distance=11mm and 18mm]
-  \node[fbwide] (client) {TypeScript clients};
-  \node[fbwide,right=of client] (bun) {Bun API / edge layer};
-  \node[fbwide,right=of bun] (rust) {Rust domain services};
-  \node[fbstorage,right=of rust] (pg) {Postgres};
-  \node[fbwide,below=of bun] (schema) {OpenAPI / Protobuf / shared schemas};
-  \draw[fbedge] (client) -- (bun);
-  \draw[fbedge] (bun) -- (rust);
-  \draw[fbedge] (rust) -- (pg);
-  \draw[fbdashed] (schema) -- (client);
-  \draw[fbdashed] (schema) -- (bun);
-  \draw[fbdashed] (schema) -- (rust);
-\end{tikzpicture}
-\end{center}
-
-This architecture can be excellent when the system needs highly tuned native services, predictable memory use, low startup overhead or a TypeScript-native web/edge layer. It also makes the target implementation direct: Rust developers read Rust and Bun developers read TypeScript.
-
-\subsection{Trade-off matrix}
-
-\begin{tabularx}{\textwidth}{P{34mm}YY}
+\begin{tabularx}{\textwidth}{P{31mm}YY}
 \toprule
 \textbf{Dimension} & \textbf{Foundation} & \textbf{Bun/Rust rewrite} \\
 \midrule
-Primary abstraction & Portable source forms and target grammars & Services and packages in their implementation languages \\
-Source of truth & Foundation module plus emitter/runtime tests & Protocol schemas plus Rust/TypeScript implementations \\
-Runtime efficiency & Depends on emitted target and placement of work, especially PostgreSQL & Direct control; Rust is strong for CPU, memory and concurrency hot paths \\
-Developer onboarding & Lisp syntax and Foundation concepts are unfamiliar to many & Bun/TypeScript is accessible; production Rust has a steep ownership/type learning curve \\
-Cross-target consistency & High when portable modules and tests remain supported across targets & Must be enforced through schemas, generated clients and conformance suites \\
-Debugging & Requires tracing source form through emitted code and runtime & Familiar target-native debugging in each service \\
-Change surface & A model change may regenerate several targets & A contract change may require multiple service and client updates \\
-Local/remote sync & Modelled directly through spaces, views and projections & Requires a chosen sync/local-first library or custom protocol \\
-Best optimisation & Reduce semantic duplication and improve generation & Maximise target-native performance and operational isolation \\
-Failure mode & Unsupported grammar constructs or emitter/runtime disagreement & Protocol drift, duplicated domain rules and service integration complexity \\
+Source of truth & Portable forms plus emitter/runtime tests & Protocol schemas plus Rust/TS implementations \\
+Primary benefit & Cross-target consistency and generation & Native performance and direct runtime control \\
+Local/remote sync & Modelled through spaces, views and projections & Requires a selected sync layer or custom protocol \\
+Debugging & Trace source form through emitted target & Target-native debugging per service \\
+Change surface & One model may regenerate several targets & Contract changes span services and SDKs \\
+Best fit & Cross-cutting, sync-heavy applications & Measured CPU, memory, latency or startup constraints \\
 \bottomrule
 \end{tabularx}
 
-\subsection{Hybrid placement}
+A hybrid is often stronger than a repository-wide rewrite: retain Foundation for contract generation and projection tests; use Bun as a TypeScript-native web or edge adapter; use Rust for a narrow, profiled service boundary.
 
-The strongest design may be hybrid:
-
-\begin{center}
-\begin{tikzpicture}[node distance=10mm and 17mm]
-  \node[fbwide] (model) {Foundation contract and sync tests};
-  \node[fbwide,below left=of model] (pg) {Generated Postgres RPC};
-  \node[fbwide,below=of model] (bun) {Bun web / edge adapter};
-  \node[fbwide,below right=of model] (rust) {Rust specialised service};
-  \node[fbwide,below=20mm of model] (clients) {Web and mobile clients};
-  \draw[fbedge] (model) -- (pg);
-  \draw[fbedge] (model) -- (bun);
-  \draw[fbedge] (model) -- (rust);
-  \draw[fbedge] (pg) -- (clients);
-  \draw[fbedge] (bun) -- (clients);
-  \draw[fbedge] (rust) -- (clients);
-\end{tikzpicture}
-\end{center}
-
-Use Rust for a measured hotspot or systems boundary, Bun for a TypeScript-native adapter, and Foundation for contract generation and end-to-end projection tests. This preserves the rewrite's performance benefits without discarding the tested backbone.
-
-\section{Decision framework}
-
-Prefer Foundation when:
+\subsection{Implementation decision rules}
 
 \begin{itemize}
-  \item the same domain behaviour must be projected across several target ecosystems;
-  \item generated SQL and portable modules already express substantial business value;
-  \item local SQLite/remote PostgreSQL behaviour is important;
-  \item consistency and testable code generation are more valuable than target-native familiarity.
+  \item Prefer Foundation when the same behaviour must remain aligned across PostgreSQL, web, mobile and edge targets.
+  \item Prefer direct Bun/Rust when profiling proves that runtime characteristics materially constrain the product.
+  \item Keep native services behind stable RPC boundaries with conformance tests.
+  \item Verify emitted SQL separately from execution and execution separately from sync.
+  \item Follow adjacent Foundation source, grammars and \product{code.test} facts before introducing abstractions.
 \end{itemize}
 
-Prefer a direct Bun/Rust implementation when:
-
-\begin{itemize}
-  \item profiling demonstrates CPU, memory, latency or startup constraints that target-native code materially improves;
-  \item the service boundary is narrow and stable;
-  \item the organisation can sustain Rust and TypeScript implementations plus protocol conformance tests;
-  \item local projection and cross-target generation are not central requirements.
-\end{itemize}
-
-Prefer a hybrid when a small number of native services provide clear value but the broader application still benefits from one tested contract.
-
-\section{Implementation workflow}
-
-\begin{enumerate}
-  \item Read the relevant \product{xt.substrate}, \product{xt.db.node} and \product{postgres.core} source and matching \product{code.test} facts.
-  \item Reproduce one vertical flow using the narrowest test namespace.
-  \item Define the server model and RPC operation.
-  \item Define local views and their remote space mapping.
-  \item Attach Postgres to the server space and SQLite or cache storage to the local space.
-  \item Assert emitted SQL separately from database execution.
-  \item Assert refresh, invalidation and projection behaviour through the node runtime.
-  \item Generate a thin UI adapter and verify it against fixtures and the live backbone.
-  \item Profile before assigning work to Bun or Rust.
-  \item Add contract/conformance tests for every specialised runtime boundary.
-\end{enumerate}
-
-\section{Conclusion}
-
-Foundation offers a semantics-first route to cross-cutting applications. It is strongest where code generation, database-side RPC, portable modules and local/remote state must evolve together. Bun and Rust offer a runtime-first route with excellent target-native characteristics. A disciplined architecture chooses between them per boundary, based on measured constraints, while retaining executable contracts and end-to-end data movement tests as the common quality mechanism.
+\callout{Practical rule}{Optimise semantic duplication first. Optimise runtime hotspots second. Preserve an executable contract across both.}
 
 \end{document}


### PR DESCRIPTION
## Summary

Adds two diagram-rich **five-page LaTeX papers** describing how `xt.substrate`, `xt.db.node` and `postgres.core` can provide a tested data-sync and RPC backbone for AI-assisted web, mobile and edge applications.

### Documents

- **Business analyst paper (5 pages)**: proposition, data/RPC backbone, AI-assisted delivery, programme controls and ecosystem comparisons.
- **Senior developer paper (5 pages)**: Foundation form/grammar/emitter/runtime model, local SQLite/remote PostgreSQL topology, PostgreSQL/RPC validation, testing strategy and rewrite decisions for developers new to Clojure/Lisp.

Each document uses a fixed structure: one title page and four deliberately separated content pages.

Both papers compare Foundation with REST/OpenAPI, GraphQL, gRPC/Protobuf, ORMs, Supabase/Firebase-style backends, CQRS/event sourcing and a direct Bun/Rust rewrite. The Bun/Rust comparison covers target-native performance, protocol drift, local-state semantics, change propagation and a hybrid architecture where specialised Bun/Rust services remain behind a Foundation-tested contract.

## Publishing workflow

Adds `.github/workflows/application-backbone-docs.yml`, which:

1. installs XeLaTeX, `latexmk` and fonts;
2. builds both PDFs;
3. stages a publication directory under `target/documents/application-backbone/`;
4. verifies the expected files;
5. uploads `foundation-application-backbone-pdfs` as a workflow artifact.

Local commands:

```bash
docs/application-backbone/install-deps.sh
make -C docs/application-backbone
make -C docs/application-backbone publish
```

## Files

- `docs/application-backbone/business-analyst.tex`
- `docs/application-backbone/senior-developer.tex`
- `docs/application-backbone/foundation-backbone.sty`
- `docs/application-backbone/Makefile`
- `docs/application-backbone/install-deps.sh`
- `docs/application-backbone/README.md`
- `.github/workflows/application-backbone-docs.yml`

## Validation

The GitHub Actions workflow is the reproducible XeLaTeX validation environment for this PR. No Clojure source or runtime behaviour is changed.