### PR TITLE
Consume fixed figma-ui package

### DIFF
--- a/.github/workflows/run-pull-request.yml
+++ b/.github/workflows/run-pull-request.yml
@@ -188,6 +188,9 @@ jobs:
       - name: Install root JS dependencies
         run: npm ci --legacy-peer-deps
 
+      - name: Verify figma-ui package consumption
+        run: npm run test:figma-ui-package
+
       - name: Install JS parser dependencies
         if: needs.detect-affected-tests.outputs.needs_js_parser == 'true'
         working-directory: scripts/js_parser

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -225,6 +225,10 @@ jobs:
         if: matrix.lang == 'js'
         run: npm ci --legacy-peer-deps
 
+      - name: Verify figma-ui package consumption
+        if: matrix.lang == 'js'
+        run: npm run test:figma-ui-package
+
       - name: Install JS parser dependencies
         if: matrix.install_js_parser == true
         working-directory: scripts/js_parser

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@supabase/supabase-js": "^2.103.0",
         "@tamagui/get-token": "^2.0.0-rc.40",
         "@tamagui/toast": "^2.0.0-rc.40",
-        "@xtalk/figma-ui": "^0.1.3",
+        "@xtalk/figma-ui": "^0.1.4",
         "bip32": "^5.0.1",
         "bip39": "^3.1.0",
         "bitcoinjs-lib": "^7.0.1",
@@ -3954,9 +3954,9 @@
       }
     },
     "node_modules/@xtalk/figma-ui": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@xtalk/figma-ui/-/figma-ui-0.1.3.tgz",
-      "integrity": "sha512-QVKMCylWlAdkLsxjhzgAicaxOHXiOOhFuzRC9GxDPa5wsoyM0d5cgWRclrP5vIh9g/U5S2aQqrl71l6SitzWjA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@xtalk/figma-ui/-/figma-ui-0.1.4.tgz",
+      "integrity": "sha512-RNTsGYDYmUbHxIOpHQnc/HOo6pFZyhBzfoRutdlf6JawqzTtb9YiaGGndUKbkXhL/9x9Q6hUYo4urLgVHPnfzg==",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.3",
         "@radix-ui/react-alert-dialog": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "code-manage:poll": "node scripts/code_manage_poller/poller.mjs",
     "code-manage:serve": "node scripts/code_manage_poller/poller.mjs --serve",
-    "test:code-manage-poller": "node --test scripts/code_manage_poller/test/*.test.mjs"
+    "test:code-manage-poller": "node --test scripts/code_manage_poller/test/*.test.mjs",
+    "test:figma-ui-package": "node --test scripts/figma_ui_package/test/*.test.mjs"
   },
   "dependencies": {
     "@measured/puck": "^0.20.2",
@@ -19,7 +20,7 @@
     "@supabase/supabase-js": "^2.103.0",
     "@tamagui/get-token": "^2.0.0-rc.40",
     "@tamagui/toast": "^2.0.0-rc.40",
-    "@xtalk/figma-ui": "^0.1.3",
+    "@xtalk/figma-ui": "^0.1.4",
     "bip32": "^5.0.1",
     "bip39": "^3.1.0",
     "bitcoinjs-lib": "^7.0.1",

--- a/scripts/figma_ui_package/test/package-consumption.test.mjs
+++ b/scripts/figma_ui_package/test/package-consumption.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+
+test('the installed figma-ui package loads through CommonJS', () => {
+  const ui = require('@xtalk/figma-ui');
+  assert.equal(typeof ui.Button, 'function');
+});
+
+test('the installed figma-ui package loads through ESM', async () => {
+  const ui = await import('@xtalk/figma-ui');
+  assert.equal(typeof ui.Button, 'function');
+});

--- a/src-build/xtalk/packages.clj
+++ b/src-build/xtalk/packages.clj
@@ -182,7 +182,7 @@
                       "redis" "^4.7.0"))
     (= segment :ui)
     (assoc "peerDependencies"
-           (array-map "@xtalk/figma-ui" "^0.1.3"
+           (array-map "@xtalk/figma-ui" "^0.1.4"
                       "react" ">=18"
                       "react-dom" ">=18")
            "dependencies"

--- a/test/xtalk/packages_test.clj
+++ b/test/xtalk/packages_test.clj
@@ -35,7 +35,10 @@
   => VERSION
 
   (get (js-package :ui) "version")
-  => VERSION)
+  => VERSION
+
+  (get-in (js-package :ui) ["peerDependencies" "@xtalk/figma-ui"])
+  => "^0.1.4")
 
 ^{:refer xtalk.packages/dart-project :added "4.1"}
 (fact "adds application members without changing package workspace entries"


### PR DESCRIPTION
## Summary

- update Foundation metadata to require `@xtalk/figma-ui@^0.1.4`
- lock the verified 0.1.4 package artifact
- add CommonJS and ESM consumption regression tests
- run the package check in pull-request CI and the main JavaScript job

## Root cause

`@xtalk/figma-ui@0.1.3` declared `"type": "module"` while exposing CommonJS from `dist/index.cjs.js`, so Node interpreted that file as ESM and failed on `exports`.

## Dependency

Depends on merged zcaudate-xyz/figma-ui#1 and publication of `@xtalk/figma-ui@0.1.4`.

## Validation

Using the locally packed upstream 0.1.4 artifact:

- `npm run test:figma-ui-package` — 2 passed
- `lein test :only xtalk.packages-test` — 9 passed after rebasing onto current `main`
- `lein test :only js.lib.figma-test` — 2 passed
- `lein test :only js.react.view-test` — 6 passed
- `lein test :only js.react.view-demos-test` — 3 passed

Refs #414.
