### PR TITLE
Fix sequential nested let scope validation

### DIFF
--- a/src/tahto/model/spec_postgres/form_let.clj
+++ b/src/tahto/model/spec_postgres/form_let.clj
@@ -114,7 +114,7 @@
                                         inner-body (drop 2 x)
                                         pairs      (partition 2 bindings)
                                         inner-syms (reduce (fn [acc [b v]]
-                                                             (check-fn csyms v)
+                                                             (check-fn acc v)
                                                              (clojure.set/union acc (collect-syms b)))
                                                            csyms
                                                            pairs)]

--- a/test/tahto/model/spec_postgres/form_let_test.clj
+++ b/test/tahto/model/spec_postgres/form_let_test.clj
@@ -39,6 +39,14 @@
   (pg-tf-let-check-body '#{v-a} '[(let [v-b 2] (:= v-b (+ v-a v-b)))])
   => nil
 
+  ;; Later binding values may reference earlier bindings in the same let.
+  (pg-tf-let-check-body
+   '#{v-a}
+   '[(let [(:integer v-b) (+ v-a 1)
+           (:integer v-c) (+ v-b 1)]
+       (:= v-a v-c))])
+  => nil
+
   ;; :for should pass IF the variable is declared (PL/pgSQL semantics)
   (pg-tf-let-check-body '#{v-a i-emails v-email} '[[:for v-email :in :select (elements i-emails)
                                                    (loop [] (:= v-a v-email))]])


### PR DESCRIPTION
## Summary

Fix PostgreSQL DSL scope validation for sequential bindings inside a nested `let`.

`pg-tf-let-check-body` already accumulates each binding symbol, but it validates every binding value against the original outer scope (`csyms`). A later binding that legitimately references an earlier binding is therefore reported as unknown.

The reducer now validates each binding value against the accumulated scope (`acc`) before adding the current binding symbols.

## Regression covered

```clojure
(let [(:integer v-b) (+ v-a 1)
      (:integer v-c) (+ v-b 1)]
  (:= v-a v-c))
```

This is ordinary sequential `let` semantics. Truly forward or undeclared references remain rejected.

## Downstream impact

This unblocks Tahto generation for Ignatius's recursive PostgreSQL runtime, whose nested function-call frame bindings correctly depend on earlier values in the same `let`. No emitted SQL semantics are changed; only static scope checking is corrected.