### PR TITLE
Add Foundation runner for code.query conformance parity

### DIFF
--- a/scripts/code_query_conformance.clj
+++ b/scripts/code_query_conformance.clj
@@ -1,0 +1,64 @@
+(ns code-query-conformance
+  (:require [clojure.edn :as edn]))
+
+(defn- function-symbol
+  "Returns the qualified symbol for a function value if it matches a public
+   var in any loaded namespace, otherwise returns the value unchanged."
+  [value]
+  (or (some (fn [ns]
+              (some (fn [[sym var]]
+                      (if (= value (var-get var))
+                        (symbol (str ns) (str sym))))
+                    (ns-publics ns)))
+            (all-ns))
+      value))
+
+(defn- normalize-result
+  "Walks a result value and replaces function objects with their qualified
+   symbols so the output is readable EDN and comparable across runtimes."
+  [value]
+  (cond
+    (fn? value)
+    (function-symbol value)
+
+    (map? value)
+    (into {} (map (fn [[k v]] [k (normalize-result v)]) value))
+
+    (vector? value)
+    (mapv #(normalize-result %) value)
+
+    (seq? value)
+    (doall (map #(normalize-result %) value))
+
+    :else value))
+
+(defn evaluate-fixture
+  [fixture]
+  (let [ns-sym (:ns fixture)
+        expr-str (:expr fixture)]
+    (require ns-sym)
+    (binding [*ns* (find-ns ns-sym)]
+      (normalize-result (eval (read-string expr-str))))))
+
+(defn run
+  [fixture-path]
+  (let [fixtures (edn/read-string (slurp fixture-path))
+        results (mapv (fn [fixture]
+                        (try
+                          {:id (:id fixture)
+                           :actual (evaluate-fixture fixture)}
+                          (catch Throwable error
+                            {:id (:id fixture)
+                             :error (str error)})))
+                      fixtures)]
+    (prn (into {} (map (fn [result]
+                         [(:id result)
+                          (dissoc result :id)]))
+               results))))
+
+(let [args *command-line-args*]
+  (if (empty? args)
+    (do (println "Usage: lein run -m clojure.main/main scripts/code_query_conformance.clj <fixture-path>")
+        (println "Received:" args)
+        (System/exit 1))
+    (run (first args))))


### PR DESCRIPTION
## Summary

Adds a small Clojure runner used by the Hara `code.query.conformance` harness to produce comparable EDN output for shared code.query fixtures.

## Changes

- New `scripts/code_query_conformance.clj` reads a fixture EDN file, evaluates each expression, normalizes function values to qualified symbols, and prints a result map.

## Related work

Used by: https://github.com/hara-lang/hara/pull/988